### PR TITLE
fix: make inbox status type creation idempotent

### DIFF
--- a/migrations/20251204130225_obix_setup.sql
+++ b/migrations/20251204130225_obix_setup.sql
@@ -69,7 +69,11 @@ CREATE TRIGGER ephemeral_outbox_events_notify
   FOR EACH ROW EXECUTE FUNCTION notify_ephemeral_outbox_events();
 
 -- Inbox events
-CREATE TYPE InboxEventStatus AS ENUM ('pending', 'processing', 'completed', 'failed');
+DO $$ BEGIN
+    CREATE TYPE InboxEventStatus AS ENUM ('pending', 'processing', 'completed', 'failed');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
 
 CREATE TABLE inbox_events (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
inspired from https://stackoverflow.com/questions/7624919/check-if-a-user-defined-type-already-exists-in-postgresql