### PR TITLE
fix: update trait to use correct time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ chrono = { version = "0.4", features = ["clock", "serde"], default-features = fa
 tracing = { version = "0.1" }
 futures = "0.3"
 im = { version = "15.1", features = ["serde"] }
-job = "0.6"
+job = { version = "0.6", features = ["es-entity"] }
 thiserror = "2.0"
 async-trait = "0.1"
 derive_builder = "0.20"

--- a/obix-macros/src/tables.rs
+++ b/obix-macros/src/tables.rs
@@ -532,30 +532,6 @@ FROM {}persistent_outbox_events_sequence_seq",
                         Ok(())
                     }
                 }
-
-                fn update_inbox_event_status_in_op(
-                    op: &mut impl #crate_name::prelude::es_entity::AtomicOperation,
-                    id: #crate_name::inbox::InboxEventId,
-                    status: #crate_name::inbox::InboxEventStatus,
-                    error: Option<&str>,
-                ) -> impl std::future::Future<Output = Result<(), #crate_name::prelude::sqlx::Error>> + Send
-                {
-                    use #crate_name::prelude::es_entity::AtomicOperation;
-
-                    let error = error.map(|s| s.to_string());
-
-                    async move {
-                        sqlx::query!(
-                            #update_inbox_event_status_query,
-                            id as #crate_name::inbox::InboxEventId,
-                            status as #crate_name::inbox::InboxEventStatus,
-                            error
-                        )
-                        .execute(op.as_executor())
-                        .await?;
-                        Ok(())
-                    }
-                }
             }
         });
     }

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -34,7 +34,7 @@ pub trait MailboxTables: Send + Sync + 'static {
         P: Serialize + DeserializeOwned + Send;
 
     fn persist_ephemeral_event<P>(
-        pool: &sqlx::PgPool,
+        op: &mut impl es_entity::AtomicOperation,
         event_type: EphemeralEventType,
         payload: P,
     ) -> impl Future<Output = Result<EphemeralOutboxEvent<P>, sqlx::Error>> + Send
@@ -65,13 +65,6 @@ pub trait MailboxTables: Send + Sync + 'static {
         pool: &sqlx::PgPool,
         id: InboxEventId,
     ) -> impl Future<Output = Result<InboxEvent, InboxError>> + Send;
-
-    fn update_inbox_event_status(
-        pool: &sqlx::PgPool,
-        id: InboxEventId,
-        status: InboxEventStatus,
-        error: Option<&str>,
-    ) -> impl Future<Output = Result<(), sqlx::Error>> + Send;
 
     fn update_inbox_event_status_in_op(
         op: &mut impl es_entity::AtomicOperation,


### PR DESCRIPTION
reminder: need to update macros
note: moving forward, using `dbop` (begin and commit) for db mutations will be a requirement to get clock time instead of simple `&self.pool`?