### PR TITLE
chore: use artificial now time

### DIFF
--- a/.sqlx/query-67d00fd58ef8d703d28c8bf569d32e3acdb37ced7c7a2fb9947147747acd723b.json
+++ b/.sqlx/query-67d00fd58ef8d703d28c8bf569d32e3acdb37ced7c7a2fb9947147747acd723b.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "UPDATE inbox_events\n            SET status = $2,\n                error = $3,\n                processed_at = CASE WHEN $2 = 'completed'::InboxEventStatus THEN NOW() ELSE processed_at END\n            WHERE id = $1",
+  "query": "UPDATE inbox_events\n            SET status = $2,\n                error = $3,\n                processed_at = CASE WHEN $2 = 'completed'::InboxEventStatus THEN COALESCE($4::timestamptz, NOW()) ELSE processed_at END\n            WHERE id = $1",
   "describe": {
     "columns": [],
     "parameters": {
@@ -19,10 +19,11 @@
             }
           }
         },
-        "Varchar"
+        "Varchar",
+        "Timestamptz"
       ]
     },
     "nullable": []
   },
-  "hash": "2b3ffb84c64b4b0bd9c288266b84078346370be4958943a8a85534e08831f932"
+  "hash": "67d00fd58ef8d703d28c8bf569d32e3acdb37ced7c7a2fb9947147747acd723b"
 }

--- a/src/inbox/mod.rs
+++ b/src/inbox/mod.rs
@@ -39,6 +39,7 @@ where
             handler,
             config.job_type.clone(),
             config.retry_settings.clone(),
+            config.clock.clone(),
         );
 
         let spawner = jobs.add_initializer(initializer);

--- a/src/out/mod.rs
+++ b/src/out/mod.rs
@@ -116,7 +116,13 @@ where
         event_type: EphemeralEventType,
         event: impl Into<P>,
     ) -> Result<(), sqlx::Error> {
-        let event = Tables::persist_ephemeral_event(&self.pool, event_type, event.into()).await?;
+        let now = if self.clock.is_artificial() {
+            Some(self.clock.now())
+        } else {
+            None
+        };
+        let event =
+            Tables::persist_ephemeral_event(&self.pool, now, event_type, event.into()).await?;
         let _ = self
             .ephemeral_cache
             .cache_fill_sender()

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -35,6 +35,7 @@ pub trait MailboxTables: Send + Sync + 'static {
 
     fn persist_ephemeral_event<P>(
         pool: &sqlx::PgPool,
+        now: Option<chrono::DateTime<chrono::Utc>>,
         event_type: EphemeralEventType,
         payload: P,
     ) -> impl Future<Output = Result<EphemeralOutboxEvent<P>, sqlx::Error>> + Send
@@ -68,6 +69,7 @@ pub trait MailboxTables: Send + Sync + 'static {
 
     fn update_inbox_event_status(
         pool: &sqlx::PgPool,
+        now: Option<chrono::DateTime<chrono::Utc>>,
         id: InboxEventId,
         status: InboxEventStatus,
         error: Option<&str>,


### PR DESCRIPTION
this was the result of the following 2 prompts:
> in obix_setup sql there are some tables with recorded_at that defaults to NOW. Identify all places in the code base where a row is inserted / updated to one of those tables that would cause the implicit NOW
to be written

> I want all places where recorded_at and processed_at are being implicitly set to use the artificial clock that is passed in at configuration (if one is set)