### PR TITLE
feat: adopt es-entity per-operation error types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,9 +450,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.10.19"
+version = "0.10.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7551e7682060b591efa40091d18e12935b596346049e8303def7d96af39da85b"
+checksum = "607c24be4bb7c66fedf170c5295706602fa0fb08732aca00004778e2a4a18520"
 dependencies = [
  "chrono",
  "derive_builder",
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.10.19"
+version = "0.10.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc138e9403ec813dd2bef9f2b411cb4afabd892f18be6bb577cf0461cfd6849"
+checksum = "49da0c534f576919b41757bfb4a35d76b2c66fd228925e11f0ba37a26dd6cb9b"
 dependencies = [
  "convert_case",
  "darling 0.23.0",
@@ -958,9 +958,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a337d17ebba2c96268cf0e51bc6f495282c7c63ee3b8e7a23a166b38801938"
+checksum = "8fc00c6da5bbd66ac5e0d3e8d00cb0cf868f2dc69f21cd9d2ffc6434754e72e7"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ obix-macros = { path = "obix-macros", version = "0.2.15-dev" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-es-entity = "0.10"
+es-entity = "0.10.21"
 anyhow = "1.0"
 tokio = { version = "1.48", features = ["rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
@@ -63,7 +63,7 @@ chrono = { version = "0.4", features = ["clock", "serde"], default-features = fa
 tracing = { version = "0.1" }
 futures = "0.3"
 im = { version = "15.1", features = ["serde"] }
-job = "0.6"
+job = "0.6.7"
 thiserror = "2.0"
 async-trait = "0.1"
 derive_builder = "0.20"

--- a/src/inbox/error.rs
+++ b/src/inbox/error.rs
@@ -4,8 +4,6 @@ use thiserror::Error;
 pub enum InboxError {
     #[error("InboxError - Sqlx: {0}")]
     Sqlx(#[from] sqlx::Error),
-    #[error("InboxError - EsEntity: {0}")]
-    EsEntity(#[from] es_entity::EsEntityError),
     #[error("InboxError - Job: {0}")]
     Job(#[from] job::error::JobError),
     #[error("InboxError - NotFound: {0}")]


### PR DESCRIPTION
Point es-entity to refactor-errors branch and job to es-entity-errors branch to integrate the new per-operation typed error handling. Update EsEntityError to EntityHydrationError following the upstream rename.