### PR TITLE
build: bump es-entity 0.10.22 -> 0.10.28 and job 0.6.8 -> 0.6.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,16 +254,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -277,20 +267,6 @@ name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
@@ -320,17 +296,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
  "quote",
  "syn",
 ]
@@ -450,9 +415,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.10.22"
+version = "0.10.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662f37372230d7e9dc6d06781d59d32013bb2f8e6727a50e1a6b213c74704b35"
+checksum = "51de953f5d065af7e4c47414f66c9638acfab53b8f6a9d5c56305f892cdd895d"
 dependencies = [
  "chrono",
  "derive_builder",
@@ -474,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.10.22"
+version = "0.10.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8814800d5ca5aff1d5486445e9b586848f7b35753203d92e10dc8fa4d3b85db8"
+checksum = "bfd932759b01ef59116a1228a15bf575e75083a87da71d0dc1c73a1c1dcc58bd"
 dependencies = [
  "convert_case",
  "darling 0.23.0",
@@ -958,9 +923,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a0ec0ddbae968f7bf56f6e8bdc48b6d5fe8344ad1873dde45dda78919e3bf"
+checksum = "b8a47c870b0a298b0823bebec9a5de8db6a87a6cddbb297069c5cd8b79583c39"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1710,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64",
  "chrono",
@@ -1729,11 +1694,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2203,9 +2168,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2381,9 +2346,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ obix-macros = { path = "obix-macros", version = "0.2.16-dev" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-es-entity = "0.10.22"
+es-entity = "0.10.28"
 anyhow = "1.0"
 tokio = { version = "1.48", features = ["rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
@@ -63,7 +63,7 @@ chrono = { version = "0.4", features = ["clock", "serde"], default-features = fa
 tracing = { version = "0.1" }
 futures = "0.3"
 im = { version = "15.1", features = ["serde"] }
-job = "0.6.8"
+job = "0.6.9"
 thiserror = "2.0"
 async-trait = "0.1"
 derive_builder = "0.20"

--- a/migrations/20250904065521_job_setup.sql
+++ b/migrations/20250904065521_job_setup.sql
@@ -51,42 +51,33 @@ CREATE INDEX idx_job_executions_running_queue_id
   ON job_executions(queue_id)
   WHERE state = 'running' AND queue_id IS NOT NULL;
 
-CREATE OR REPLACE FUNCTION notify_job_execution_insert() RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION notify_job_event() RETURNS TRIGGER AS $$
 BEGIN
-  PERFORM pg_notify('job_execution', NEW.job_type);
-  RETURN NULL;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION notify_job_execution_update() RETURNS TRIGGER AS $$
-BEGIN
-  IF NEW.execute_at IS DISTINCT FROM OLD.execute_at THEN
-    PERFORM pg_notify('job_execution', NEW.job_type);
+  IF TG_OP = 'INSERT' THEN
+    PERFORM pg_notify('job_events', json_build_object('type', 'execution_ready', 'job_type', NEW.job_type)::text);
+    RETURN NULL;
   END IF;
-  RETURN NULL;
-END;
-$$ LANGUAGE plpgsql;
 
-CREATE TRIGGER job_executions_notify_insert_trigger
-AFTER INSERT ON job_executions
-FOR EACH ROW
-EXECUTE FUNCTION notify_job_execution_insert();
-
-CREATE TRIGGER job_executions_notify_update_trigger
-AFTER UPDATE ON job_executions
-FOR EACH ROW
-EXECUTE FUNCTION notify_job_execution_update();
-
-CREATE OR REPLACE FUNCTION notify_job_execution_delete() RETURNS TRIGGER AS $$
-BEGIN
-  IF OLD.queue_id IS NOT NULL THEN
-    PERFORM pg_notify('job_execution', OLD.job_type);
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.execute_at IS DISTINCT FROM OLD.execute_at THEN
+      PERFORM pg_notify('job_events', json_build_object('type', 'execution_ready', 'job_type', NEW.job_type)::text);
+    END IF;
+    RETURN NULL;
   END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    PERFORM pg_notify('job_events', json_build_object('type', 'job_terminal', 'job_id', OLD.id::text)::text);
+    IF OLD.queue_id IS NOT NULL THEN
+      PERFORM pg_notify('job_events', json_build_object('type', 'execution_ready', 'job_type', OLD.job_type)::text);
+    END IF;
+    RETURN NULL;
+  END IF;
+
   RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER job_executions_notify_delete_trigger
-AFTER DELETE ON job_executions
+CREATE TRIGGER job_executions_notify_event_trigger
+AFTER INSERT OR UPDATE OR DELETE ON job_executions
 FOR EACH ROW
-EXECUTE FUNCTION notify_job_execution_delete();
+EXECUTE FUNCTION notify_job_event();

--- a/src/inbox/job.rs
+++ b/src/inbox/job.rs
@@ -127,7 +127,7 @@ where
             return Ok(JobCompletion::RescheduleNow);
         }
 
-        let now = self.clock.artificial_now();
+        let now = self.clock.manual_now();
 
         Tables::update_inbox_event_status(
             &self.pool,

--- a/src/out/mod.rs
+++ b/src/out/mod.rs
@@ -119,7 +119,7 @@ where
         event_type: EphemeralEventType,
         event: impl Into<P>,
     ) -> Result<(), sqlx::Error> {
-        let now = self.clock.artificial_now();
+        let now = self.clock.manual_now();
         let event =
             Tables::persist_ephemeral_event(&self.pool, now, event_type, event.into()).await?;
         let _ = self

--- a/tests/inbox.rs
+++ b/tests/inbox.rs
@@ -1,6 +1,6 @@
 mod helpers;
 
-use es_entity::clock::{ArtificialClockConfig, ClockHandle};
+use es_entity::clock::ClockHandle;
 use serde::{Deserialize, Serialize};
 use serial_test::file_serial;
 use tokio::sync::Mutex;
@@ -219,7 +219,7 @@ async fn inbox_multiple_events() -> anyhow::Result<()> {
 async fn inbox_reprocess_in_with_artificial_clock() -> anyhow::Result<()> {
     let pool = init_pool().await?;
 
-    let (clock, controller) = ClockHandle::artificial(ArtificialClockConfig::manual());
+    let (clock, controller) = ClockHandle::manual();
     let initial_time = clock.now();
 
     let job_config = job::JobSvcConfig::builder()


### PR DESCRIPTION
## Summary
- Bump `es-entity` from 0.10.22 to 0.10.28
- Bump `job` from 0.6.8 to 0.6.9
- Adapt to breaking API changes: `artificial_now()` → `manual_now()`, `ClockHandle::artificial(ArtificialClockConfig::manual())` → `ClockHandle::manual()`
- Update job migration triggers to unified `notify_job_event()` function (required by job 0.6.9's new notification router)

## Test plan
- [ ] CI check-code passes (clippy, fmt, audit, deny)
- [ ] CI integration tests pass with updated migration and deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)