### PR TITLE
chore(deps): bump es-entity to 0.10.32 and job to 0.6.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,9 +415,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.10.30"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa815a1b5e711330415883ee1f0646189ef9d461a58d0333cbe60c6a13faae2b"
+checksum = "c4d3abcd7ae89ef1bebe59d927639baea3ac18d2f49697d452e058d9d853ec7f"
 dependencies = [
  "chrono",
  "derive_builder",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.10.30"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1f6383e8ee2f7fe5d49f7808221521984534beb08015fe50163f5d21c132d6"
+checksum = "f21f3a1133b72c6b18039ef807b4f5af9b70da7fea3265c1d69f06994fd7b68b"
 dependencies = [
  "convert_case",
  "darling 0.23.0",
@@ -923,9 +923,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b128c0bc6a52df4287b3f25960c967891b82548921885eefd6756f9cbe8fead"
+checksum = "9b9048fa5e52aa2e0ddd460eeaf9facc1dc00ddd28160610aa3aa7a290f658ec"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ obix-macros = { path = "obix-macros", version = "0.2.19-dev" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-es-entity = "0.10.30"
+es-entity = "0.10.32"
 anyhow = "1.0"
 tokio = { version = "1.48", features = ["rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
@@ -63,7 +63,7 @@ chrono = { version = "0.4", features = ["clock", "serde"], default-features = fa
 tracing = { version = "0.1" }
 futures = "0.3"
 im = { version = "15.1", features = ["serde"] }
-job = "0.6.11"
+job = "0.6.13"
 thiserror = "2.0"
 async-trait = "0.1"
 derive_builder = "0.20"


### PR DESCRIPTION
## Summary

- Bumps es-entity 0.10.30 → 0.10.32 and job 0.6.11 → 0.6.13
- Picks up singular naming for `SortBy`/`Filters` types (GaloyMoney/es-entity#115)

🤖 Generated with [Claude Code](https://claude.com/claude-code)