### PR TITLE
fix(outbox): proactively fill sequence gaps in cache broadcast path

### DIFF
--- a/src/out/persistent/cache.rs
+++ b/src/out/persistent/cache.rs
@@ -166,6 +166,19 @@ where
         (cache, last_broadcast_sequence)
     }
 
+    async fn fill_gap(
+        pool: sqlx::PgPool,
+        from_sequence: EventSequence,
+        cache_fill_sender: broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
+        buffer_size: usize,
+    ) {
+        if let Ok(events) = Tables::load_next_page::<P>(&pool, from_sequence, buffer_size).await {
+            for event in events {
+                let _ = cache_fill_sender.send(Arc::new(event));
+            }
+        }
+    }
+
     async fn handle_backfill_request(
         pool: sqlx::PgPool,
         start_after: EventSequence,
@@ -284,6 +297,7 @@ where
             let mut persistent_cache: im::OrdMap<EventSequence, Arc<PersistentOutboxEvent<P>>> =
                 im::OrdMap::new();
             let mut last_broadcast_sequence = initial_sequence;
+            let mut gap_fill_in_progress_for: Option<(EventSequence, std::time::Instant)> = None;
 
             loop {
                 tokio::select! {
@@ -400,6 +414,33 @@ where
                             }
                         }
                     }
+                }
+
+                // Proactive gap fill: if broadcasting is stuck waiting for a missing
+                // sequence, trigger load_next_page which will fill the gap via
+                // fill_gaps_query.
+                let next_needed = last_broadcast_sequence.next();
+                let highest = highest_known_sequence.load(Ordering::Relaxed);
+                if u64::from(next_needed) <= highest && !persistent_cache.contains_key(&next_needed)
+                {
+                    let should_fill = match gap_fill_in_progress_for {
+                        Some((seq, started)) if seq == last_broadcast_sequence => {
+                            started.elapsed() > std::time::Duration::from_secs(1)
+                        }
+                        _ => true,
+                    };
+                    if should_fill {
+                        gap_fill_in_progress_for =
+                            Some((last_broadcast_sequence, std::time::Instant::now()));
+                        tokio::spawn(Self::fill_gap(
+                            pool.clone(),
+                            last_broadcast_sequence,
+                            cache_fill_sender.clone(),
+                            cache_size,
+                        ));
+                    }
+                } else {
+                    gap_fill_in_progress_for = None;
                 }
 
                 if persistent_cache.len() > high_water {

--- a/tests/outbox.rs
+++ b/tests/outbox.rs
@@ -279,6 +279,62 @@ async fn large_payload_via_pg_notify_fetches_from_db() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[file_serial]
+async fn sequence_gap_from_rolled_back_transaction() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let outbox = init_outbox::<TestEvent>(
+        &pool,
+        MailboxConfig::builder()
+            .build()
+            .expect("Couldn't build MailboxConfig"),
+    )
+    .await?;
+
+    let mut listener = outbox.listen_persisted(None);
+
+    // Publish an event (seq N)
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(0))
+        .await?;
+    op.commit().await?;
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
+        .await?
+        .expect("should receive first event");
+    assert!(matches!(event.payload, Some(TestEvent::Ping(0))));
+
+    // Create a gap by consuming a sequence number without inserting a row
+    sqlx::query!("SELECT nextval('persistent_outbox_events_sequence_seq')")
+        .fetch_one(&pool)
+        .await?;
+
+    // Publish another event (seq N+2, skipping the consumed N+1)
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+        .await?;
+    op.commit().await?;
+
+    // Should receive the gap-filled placeholder (None payload) followed by the real event
+    let gap_event = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
+        .await?
+        .expect("should receive gap-filled placeholder");
+    assert!(
+        gap_event.payload.is_none(),
+        "gap-filled event should have None payload"
+    );
+
+    let real_event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
+        .await?
+        .expect("should receive real event after gap");
+    assert!(matches!(real_event.payload, Some(TestEvent::Ping(1))));
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
 async fn ephemeral_events_via_cache() -> anyhow::Result<()> {
     let pool = init_pool().await?;
 


### PR DESCRIPTION
## Summary
- Adds proactive gap detection in the persistent outbox cache loop: after each `tokio::select!` iteration, checks if `last_broadcast_sequence + 1` is missing from the cache but within the known sequence range
- Spawns a background `fill_gap` task that calls existing `Tables::load_next_page()` (generate_series + LEFT JOIN + fill_gaps_query) to insert NULL-payload placeholder rows for gaps caused by rolled-back transactions
- Adds cooldown-based dedup guard (`gap_fill_in_progress_for`) to prevent redundant fill spawns while allowing retry after 1 second
- Adds integration test that creates a sequence gap via `SELECT nextval()` and verifies the listener receives the gap-filled placeholder followed by the real event without blocking

Fixes #43

## Test plan
- [ ] New `sequence_gap_from_rolled_back_transaction` integration test passes
- [ ] Existing outbox tests continue to pass (no regressions)
- [ ] `nix flake check` passes (fmt + clippy + deny + audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)