### PR TITLE
feat(obix): surface silent failures in cache loop, pg-listener, and listeners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ im = { workspace = true }
 job = { workspace = true }
 async-trait = { workspace = true }
 derive_builder = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,3 +1,7 @@
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+
+use futures::FutureExt;
 use tokio::task::JoinHandle;
 
 #[derive(Debug)]
@@ -15,4 +19,41 @@ impl Drop for OwnedTaskHandle {
             handle.abort();
         }
     }
+}
+
+/// Spawn a background task whose exit and panics are loud.
+///
+/// All long-lived obix tasks (cache loop, pg-listener forwarder) must go
+/// through here so that any silent death — normal exit or panic — surfaces
+/// in the logs instead of leaving the outbox half-alive.
+pub(crate) fn spawn_supervised<F>(task_name: &'static str, fut: F) -> JoinHandle<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        match AssertUnwindSafe(fut).catch_unwind().await {
+            Ok(()) => {
+                tracing::error!(
+                    target: "obix::supervisor",
+                    task = task_name,
+                    "obix background task exited — downstream outbox delivery will stall"
+                );
+            }
+            Err(panic) => {
+                let msg = if let Some(s) = panic.downcast_ref::<&str>() {
+                    (*s).to_string()
+                } else if let Some(s) = panic.downcast_ref::<String>() {
+                    s.clone()
+                } else {
+                    "<unknown panic payload>".to_string()
+                };
+                tracing::error!(
+                    target: "obix::supervisor",
+                    task = task_name,
+                    panic = %msg,
+                    "obix background task PANICKED — downstream outbox delivery will stall"
+                );
+            }
+        }
+    })
 }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -21,11 +21,12 @@ impl Drop for OwnedTaskHandle {
     }
 }
 
-/// Spawn a background task whose exit and panics are loud.
+/// Spawn a background task whose exit and panics surface as OTEL spans.
 ///
 /// All long-lived obix tasks (cache loop, pg-listener forwarder) must go
-/// through here so that any silent death — normal exit or panic — surfaces
-/// in the logs instead of leaving the outbox half-alive.
+/// through here so that any silent death — normal exit or panic — emits a
+/// short-lived error span (queryable in Honeycomb) instead of leaving the
+/// outbox half-alive with no signal.
 pub(crate) fn spawn_supervised<F>(task_name: &'static str, fut: F) -> JoinHandle<()>
 where
     F: Future<Output = ()> + Send + 'static,
@@ -33,11 +34,12 @@ where
     tokio::spawn(async move {
         match AssertUnwindSafe(fut).catch_unwind().await {
             Ok(()) => {
-                tracing::error!(
-                    target: "obix::supervisor",
+                tracing::error_span!(
+                    "obix.supervisor.task_exited",
+                    otel.status_code = "ERROR",
                     task = task_name,
-                    "obix background task exited — downstream outbox delivery will stall"
-                );
+                )
+                .in_scope(|| ());
             }
             Err(panic) => {
                 let msg = if let Some(s) = panic.downcast_ref::<&str>() {
@@ -47,12 +49,13 @@ where
                 } else {
                     "<unknown panic payload>".to_string()
                 };
-                tracing::error!(
-                    target: "obix::supervisor",
+                tracing::error_span!(
+                    "obix.supervisor.task_panicked",
+                    otel.status_code = "ERROR",
                     task = task_name,
                     panic = %msg,
-                    "obix background task PANICKED — downstream outbox delivery will stall"
-                );
+                )
+                .in_scope(|| ());
             }
         }
     })

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -33,14 +33,7 @@ where
 {
     tokio::spawn(async move {
         match AssertUnwindSafe(fut).catch_unwind().await {
-            Ok(()) => {
-                tracing::error_span!(
-                    "obix.supervisor.task_exited",
-                    otel.status_code = "ERROR",
-                    task = task_name,
-                )
-                .in_scope(|| ());
-            }
+            Ok(()) => record_task_exited(task_name),
             Err(panic) => {
                 let msg = if let Some(s) = panic.downcast_ref::<&str>() {
                     (*s).to_string()
@@ -49,14 +42,24 @@ where
                 } else {
                     "<unknown panic payload>".to_string()
                 };
-                tracing::error_span!(
-                    "obix.supervisor.task_panicked",
-                    otel.status_code = "ERROR",
-                    task = task_name,
-                    panic = %msg,
-                )
-                .in_scope(|| ());
+                record_task_panicked(task_name, &msg);
             }
         }
     })
 }
+
+#[tracing::instrument(
+    name = "obix.supervisor.task_exited",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", task = %task),
+)]
+fn record_task_exited(task: &'static str) {}
+
+#[tracing::instrument(
+    name = "obix.supervisor.task_panicked",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", task = %task, panic = %panic),
+)]
+fn record_task_panicked(task: &'static str, panic: &str) {}

--- a/src/out/ephemeral/cache.rs
+++ b/src/out/ephemeral/cache.rs
@@ -4,7 +4,10 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 use std::sync::Arc;
 
 use crate::out::event::*;
-use crate::{config::*, handle::OwnedTaskHandle};
+use crate::{
+    config::*,
+    handle::{OwnedTaskHandle, spawn_supervised},
+};
 
 pub struct CacheHandle<P>
 where
@@ -181,7 +184,7 @@ where
     ) -> Result<OwnedTaskHandle, sqlx::Error> {
         let pool = pool.clone();
 
-        let handle = tokio::spawn(async move {
+        let handle = spawn_supervised("obix::ephemeral_cache_loop", async move {
             let mut ephemeral_cache: im::HashMap<EphemeralEventType, Arc<EphemeralOutboxEvent<P>>> =
                 im::HashMap::new();
 
@@ -195,6 +198,10 @@ where
                                 let _ = sender.send(ephemeral_cache.clone());
                             }
                             None => {
+                                tracing::error!(
+                                    target: "obix::ephemeral_cache",
+                                    "backfill_request channel closed; ephemeral cache loop shutting down"
+                                );
                                 break;
                             }
                         }
@@ -218,10 +225,19 @@ where
                                     );
                                 }
                             }
-                            Err(broadcast::error::RecvError::Lagged(_)) => {
+                            Err(broadcast::error::RecvError::Lagged(n)) => {
+                                tracing::error!(
+                                    target: "obix::ephemeral_cache",
+                                    dropped = n,
+                                    "ephemeral cache_fill_receiver lagged — events silently dropped"
+                                );
                                 continue;
                             }
                             Err(broadcast::error::RecvError::Closed) => {
+                                tracing::error!(
+                                    target: "obix::ephemeral_cache",
+                                    "ephemeral cache_fill broadcast closed; cache loop shutting down"
+                                );
                                 break;
                             }
                         }
@@ -260,6 +276,10 @@ where
                                 }
                             }
                             None => {
+                                tracing::error!(
+                                    target: "obix::ephemeral_cache",
+                                    "ephemeral notification_receiver channel closed; cache loop shutting down"
+                                );
                                 break;
                             }
                         }

--- a/src/out/ephemeral/cache.rs
+++ b/src/out/ephemeral/cache.rs
@@ -198,11 +198,7 @@ where
                                 let _ = sender.send(ephemeral_cache.clone());
                             }
                             None => {
-                                tracing::error_span!(
-                                    "obix.ephemeral_cache.backfill_channel_closed",
-                                    otel.status_code = "ERROR",
-                                )
-                                .in_scope(|| ());
+                                record_backfill_channel_closed();
                                 break;
                             }
                         }
@@ -227,20 +223,11 @@ where
                                 }
                             }
                             Err(broadcast::error::RecvError::Lagged(n)) => {
-                                tracing::error_span!(
-                                    "obix.ephemeral_cache.cache_fill_lagged",
-                                    otel.status_code = "ERROR",
-                                    dropped = n,
-                                )
-                                .in_scope(|| ());
+                                record_cache_fill_lagged(n);
                                 continue;
                             }
                             Err(broadcast::error::RecvError::Closed) => {
-                                tracing::error_span!(
-                                    "obix.ephemeral_cache.cache_fill_closed",
-                                    otel.status_code = "ERROR",
-                                )
-                                .in_scope(|| ());
+                                record_cache_fill_closed();
                                 break;
                             }
                         }
@@ -279,11 +266,7 @@ where
                                 }
                             }
                             None => {
-                                tracing::error_span!(
-                                    "obix.ephemeral_cache.notification_channel_closed",
-                                    otel.status_code = "ERROR",
-                                )
-                                .in_scope(|| ());
+                                record_notification_channel_closed();
                                 break;
                             }
                         }
@@ -294,3 +277,31 @@ where
         Ok(OwnedTaskHandle::new(handle))
     }
 }
+
+#[tracing::instrument(
+    name = "obix.ephemeral_cache.backfill_channel_closed",
+    level = "error",
+    fields(otel.status_code = "ERROR"),
+)]
+fn record_backfill_channel_closed() {}
+
+#[tracing::instrument(
+    name = "obix.ephemeral_cache.cache_fill_lagged",
+    level = "error",
+    fields(otel.status_code = "ERROR"),
+)]
+fn record_cache_fill_lagged(dropped: u64) {}
+
+#[tracing::instrument(
+    name = "obix.ephemeral_cache.cache_fill_closed",
+    level = "error",
+    fields(otel.status_code = "ERROR"),
+)]
+fn record_cache_fill_closed() {}
+
+#[tracing::instrument(
+    name = "obix.ephemeral_cache.notification_channel_closed",
+    level = "error",
+    fields(otel.status_code = "ERROR"),
+)]
+fn record_notification_channel_closed() {}

--- a/src/out/ephemeral/cache.rs
+++ b/src/out/ephemeral/cache.rs
@@ -198,10 +198,11 @@ where
                                 let _ = sender.send(ephemeral_cache.clone());
                             }
                             None => {
-                                tracing::error!(
-                                    target: "obix::ephemeral_cache",
-                                    "backfill_request channel closed; ephemeral cache loop shutting down"
-                                );
+                                tracing::error_span!(
+                                    "obix.ephemeral_cache.backfill_channel_closed",
+                                    otel.status_code = "ERROR",
+                                )
+                                .in_scope(|| ());
                                 break;
                             }
                         }
@@ -226,18 +227,20 @@ where
                                 }
                             }
                             Err(broadcast::error::RecvError::Lagged(n)) => {
-                                tracing::error!(
-                                    target: "obix::ephemeral_cache",
+                                tracing::error_span!(
+                                    "obix.ephemeral_cache.cache_fill_lagged",
+                                    otel.status_code = "ERROR",
                                     dropped = n,
-                                    "ephemeral cache_fill_receiver lagged — events silently dropped"
-                                );
+                                )
+                                .in_scope(|| ());
                                 continue;
                             }
                             Err(broadcast::error::RecvError::Closed) => {
-                                tracing::error!(
-                                    target: "obix::ephemeral_cache",
-                                    "ephemeral cache_fill broadcast closed; cache loop shutting down"
-                                );
+                                tracing::error_span!(
+                                    "obix.ephemeral_cache.cache_fill_closed",
+                                    otel.status_code = "ERROR",
+                                )
+                                .in_scope(|| ());
                                 break;
                             }
                         }
@@ -276,10 +279,11 @@ where
                                 }
                             }
                             None => {
-                                tracing::error!(
-                                    target: "obix::ephemeral_cache",
-                                    "ephemeral notification_receiver channel closed; cache loop shutting down"
-                                );
+                                tracing::error_span!(
+                                    "obix.ephemeral_cache.notification_channel_closed",
+                                    otel.status_code = "ERROR",
+                                )
+                                .in_scope(|| ());
                                 break;
                             }
                         }

--- a/src/out/ephemeral/listener.rs
+++ b/src/out/ephemeral/listener.rs
@@ -93,11 +93,8 @@ where
             match Pin::new(&mut this.event_receiver).poll_next(cx) {
                 Poll::Ready(Some(Ok(event))) => return Poll::Ready(Some(event)),
                 Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n)))) => {
-                    tracing::warn!(
-                        target: "obix::ephemeral_listener",
-                        dropped = n,
-                        "ephemeral broadcast receiver lagged — listener dropped events"
-                    );
+                    tracing::warn_span!("obix.ephemeral_listener.lagged", dropped = n,)
+                        .in_scope(|| ());
                     continue;
                 }
                 Poll::Ready(None) => return Poll::Ready(None),

--- a/src/out/ephemeral/listener.rs
+++ b/src/out/ephemeral/listener.rs
@@ -93,8 +93,7 @@ where
             match Pin::new(&mut this.event_receiver).poll_next(cx) {
                 Poll::Ready(Some(Ok(event))) => return Poll::Ready(Some(event)),
                 Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n)))) => {
-                    tracing::warn_span!("obix.ephemeral_listener.lagged", dropped = n,)
-                        .in_scope(|| ());
+                    record_lagged(n);
                     continue;
                 }
                 Poll::Ready(None) => return Poll::Ready(None),
@@ -103,3 +102,6 @@ where
         }
     }
 }
+
+#[tracing::instrument(name = "obix.ephemeral_listener.lagged", level = "warn")]
+fn record_lagged(dropped: u64) {}

--- a/src/out/ephemeral/listener.rs
+++ b/src/out/ephemeral/listener.rs
@@ -2,7 +2,7 @@ use futures::Stream;
 use serde::{Serialize, de::DeserializeOwned};
 use std::{pin::Pin, sync::Arc, task::Poll};
 use tokio::sync::oneshot;
-use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 
 use super::cache::CacheHandle;
 use crate::out::event::{EphemeralEventType, EphemeralOutboxEvent};
@@ -92,7 +92,14 @@ where
         loop {
             match Pin::new(&mut this.event_receiver).poll_next(cx) {
                 Poll::Ready(Some(Ok(event))) => return Poll::Ready(Some(event)),
-                Poll::Ready(Some(Err(_))) => continue, // Skip lagged, try next
+                Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n)))) => {
+                    tracing::warn!(
+                        target: "obix::ephemeral_listener",
+                        dropped = n,
+                        "ephemeral broadcast receiver lagged — listener dropped events"
+                    );
+                    continue;
+                }
                 Poll::Ready(None) => return Poll::Ready(None),
                 Poll::Pending => return Poll::Pending,
             }

--- a/src/out/persistent/cache.rs
+++ b/src/out/persistent/cache.rs
@@ -149,21 +149,21 @@ where
         for (seq, evt) in cache.range((Bound::Excluded(last_broadcast_sequence), Bound::Unbounded))
         {
             if *seq != last_broadcast_sequence.next() {
-                tracing::warn!(
-                    target: "obix::persistent_cache",
+                tracing::warn_span!(
+                    "obix.persistent_cache.sequence_gap",
                     last_broadcast_sequence = u64::from(last_broadcast_sequence),
                     next_in_cache = u64::from(*seq),
                     highest_known = highest_known_sequence.load(Ordering::Relaxed),
-                    "persistent cache has sequence gap; broadcast halted until gap is filled"
-                );
+                )
+                .in_scope(|| ());
                 break;
             }
             if persistent_event_sender.send(evt.clone()).is_err() {
-                tracing::warn!(
-                    target: "obix::persistent_cache",
+                tracing::warn_span!(
+                    "obix.persistent_cache.no_receivers",
                     sequence = u64::from(*seq),
-                    "persistent_event_sender has no active receivers; broadcast halted"
-                );
+                )
+                .in_scope(|| ());
                 break;
             }
             last_broadcast_sequence = *seq;
@@ -205,12 +205,12 @@ where
                     }
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        target: "obix::persistent_cache",
+                    tracing::warn_span!(
+                        "obix.persistent_cache.backfill_failed",
                         error = %e,
                         current_sequence = u64::from(current_sequence),
-                        "backfill load_next_page failed; aborting backfill for this listener"
-                    );
+                    )
+                    .in_scope(|| ());
                     break;
                 }
             }
@@ -319,10 +319,11 @@ where
                                 ));
                             }
                             None => {
-                                tracing::error!(
-                                    target: "obix::persistent_cache",
-                                    "backfill_request channel closed; cache loop shutting down"
-                                );
+                                tracing::error_span!(
+                                    "obix.persistent_cache.backfill_channel_closed",
+                                    otel.status_code = "ERROR",
+                                )
+                                .in_scope(|| ());
                                 break;
                             }
                         }
@@ -355,20 +356,22 @@ where
                                 }
                             }
                             Err(broadcast::error::RecvError::Lagged(n)) => {
-                                tracing::error!(
-                                    target: "obix::persistent_cache",
+                                tracing::error_span!(
+                                    "obix.persistent_cache.cache_fill_lagged",
+                                    otel.status_code = "ERROR",
                                     dropped = n,
                                     last_broadcast_sequence = u64::from(last_broadcast_sequence),
                                     highest_known = highest_known_sequence.load(Ordering::Relaxed),
-                                    "cache_fill_receiver lagged — events silently dropped"
-                                );
+                                )
+                                .in_scope(|| ());
                                 continue;
                             }
                             Err(broadcast::error::RecvError::Closed) => {
-                                tracing::error!(
-                                    target: "obix::persistent_cache",
-                                    "cache_fill broadcast channel closed; cache loop shutting down"
-                                );
+                                tracing::error_span!(
+                                    "obix.persistent_cache.cache_fill_closed",
+                                    otel.status_code = "ERROR",
+                                )
+                                .in_scope(|| ());
                                 break;
                             }
                         }
@@ -414,10 +417,11 @@ where
                                 }
                             }
                             None => {
-                                tracing::error!(
-                                    target: "obix::persistent_cache",
-                                    "notification_receiver channel closed; cache loop shutting down"
-                                );
+                                tracing::error_span!(
+                                    "obix.persistent_cache.notification_channel_closed",
+                                    otel.status_code = "ERROR",
+                                )
+                                .in_scope(|| ());
                                 break;
                             }
                         }

--- a/src/out/persistent/cache.rs
+++ b/src/out/persistent/cache.rs
@@ -8,7 +8,11 @@ use std::sync::{
 };
 
 use crate::out::event::*;
-use crate::{config::*, handle::OwnedTaskHandle, sequence::EventSequence};
+use crate::{
+    config::*,
+    handle::{OwnedTaskHandle, spawn_supervised},
+    sequence::EventSequence,
+};
 
 pub struct CacheHandle<P>
 where
@@ -145,9 +149,21 @@ where
         for (seq, evt) in cache.range((Bound::Excluded(last_broadcast_sequence), Bound::Unbounded))
         {
             if *seq != last_broadcast_sequence.next() {
+                tracing::warn!(
+                    target: "obix::persistent_cache",
+                    last_broadcast_sequence = u64::from(last_broadcast_sequence),
+                    next_in_cache = u64::from(*seq),
+                    highest_known = highest_known_sequence.load(Ordering::Relaxed),
+                    "persistent cache has sequence gap; broadcast halted until gap is filled"
+                );
                 break;
             }
             if persistent_event_sender.send(evt.clone()).is_err() {
+                tracing::warn!(
+                    target: "obix::persistent_cache",
+                    sequence = u64::from(*seq),
+                    "persistent_event_sender has no active receivers; broadcast halted"
+                );
                 break;
             }
             last_broadcast_sequence = *seq;
@@ -188,7 +204,15 @@ where
                         current_sequence = seq;
                     }
                 }
-                Err(_) => break,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "obix::persistent_cache",
+                        error = %e,
+                        current_sequence = u64::from(current_sequence),
+                        "backfill load_next_page failed; aborting backfill for this listener"
+                    );
+                    break;
+                }
             }
         }
 
@@ -267,7 +291,7 @@ where
 
         let initial_sequence = EventSequence::from(highest_known_sequence.load(Ordering::Relaxed));
 
-        let handle = tokio::spawn(async move {
+        let handle = spawn_supervised("obix::persistent_cache_loop", async move {
             let mut persistent_cache: im::OrdMap<EventSequence, Arc<PersistentOutboxEvent<P>>> =
                 im::OrdMap::new();
             let mut last_broadcast_sequence = initial_sequence;
@@ -295,6 +319,10 @@ where
                                 ));
                             }
                             None => {
+                                tracing::error!(
+                                    target: "obix::persistent_cache",
+                                    "backfill_request channel closed; cache loop shutting down"
+                                );
                                 break;
                             }
                         }
@@ -326,10 +354,21 @@ where
                                         );
                                 }
                             }
-                            Err(broadcast::error::RecvError::Lagged(_)) => {
+                            Err(broadcast::error::RecvError::Lagged(n)) => {
+                                tracing::error!(
+                                    target: "obix::persistent_cache",
+                                    dropped = n,
+                                    last_broadcast_sequence = u64::from(last_broadcast_sequence),
+                                    highest_known = highest_known_sequence.load(Ordering::Relaxed),
+                                    "cache_fill_receiver lagged — events silently dropped"
+                                );
                                 continue;
                             }
                             Err(broadcast::error::RecvError::Closed) => {
+                                tracing::error!(
+                                    target: "obix::persistent_cache",
+                                    "cache_fill broadcast channel closed; cache loop shutting down"
+                                );
                                 break;
                             }
                         }
@@ -375,6 +414,10 @@ where
                                 }
                             }
                             None => {
+                                tracing::error!(
+                                    target: "obix::persistent_cache",
+                                    "notification_receiver channel closed; cache loop shutting down"
+                                );
                                 break;
                             }
                         }

--- a/src/out/persistent/cache.rs
+++ b/src/out/persistent/cache.rs
@@ -149,21 +149,15 @@ where
         for (seq, evt) in cache.range((Bound::Excluded(last_broadcast_sequence), Bound::Unbounded))
         {
             if *seq != last_broadcast_sequence.next() {
-                tracing::warn_span!(
-                    "obix.persistent_cache.sequence_gap",
-                    last_broadcast_sequence = u64::from(last_broadcast_sequence),
-                    next_in_cache = u64::from(*seq),
-                    highest_known = highest_known_sequence.load(Ordering::Relaxed),
-                )
-                .in_scope(|| ());
+                record_sequence_gap(
+                    u64::from(last_broadcast_sequence),
+                    u64::from(*seq),
+                    highest_known_sequence.load(Ordering::Relaxed),
+                );
                 break;
             }
             if persistent_event_sender.send(evt.clone()).is_err() {
-                tracing::warn_span!(
-                    "obix.persistent_cache.no_receivers",
-                    sequence = u64::from(*seq),
-                )
-                .in_scope(|| ());
+                record_no_receivers(u64::from(*seq));
                 break;
             }
             last_broadcast_sequence = *seq;
@@ -205,12 +199,7 @@ where
                     }
                 }
                 Err(e) => {
-                    tracing::warn_span!(
-                        "obix.persistent_cache.backfill_failed",
-                        error = %e,
-                        current_sequence = u64::from(current_sequence),
-                    )
-                    .in_scope(|| ());
+                    record_backfill_failed(&e, u64::from(current_sequence));
                     break;
                 }
             }
@@ -319,11 +308,7 @@ where
                                 ));
                             }
                             None => {
-                                tracing::error_span!(
-                                    "obix.persistent_cache.backfill_channel_closed",
-                                    otel.status_code = "ERROR",
-                                )
-                                .in_scope(|| ());
+                                record_backfill_channel_closed();
                                 break;
                             }
                         }
@@ -356,22 +341,15 @@ where
                                 }
                             }
                             Err(broadcast::error::RecvError::Lagged(n)) => {
-                                tracing::error_span!(
-                                    "obix.persistent_cache.cache_fill_lagged",
-                                    otel.status_code = "ERROR",
-                                    dropped = n,
-                                    last_broadcast_sequence = u64::from(last_broadcast_sequence),
-                                    highest_known = highest_known_sequence.load(Ordering::Relaxed),
-                                )
-                                .in_scope(|| ());
+                                record_cache_fill_lagged(
+                                    n,
+                                    u64::from(last_broadcast_sequence),
+                                    highest_known_sequence.load(Ordering::Relaxed),
+                                );
                                 continue;
                             }
                             Err(broadcast::error::RecvError::Closed) => {
-                                tracing::error_span!(
-                                    "obix.persistent_cache.cache_fill_closed",
-                                    otel.status_code = "ERROR",
-                                )
-                                .in_scope(|| ());
+                                record_cache_fill_closed();
                                 break;
                             }
                         }
@@ -417,11 +395,7 @@ where
                                 }
                             }
                             None => {
-                                tracing::error_span!(
-                                    "obix.persistent_cache.notification_channel_closed",
-                                    otel.status_code = "ERROR",
-                                )
-                                .in_scope(|| ());
+                                record_notification_channel_closed();
                                 break;
                             }
                         }
@@ -440,3 +414,45 @@ where
         Ok(OwnedTaskHandle::new(handle))
     }
 }
+
+#[tracing::instrument(name = "obix.persistent_cache.sequence_gap", level = "warn")]
+fn record_sequence_gap(last_broadcast_sequence: u64, next_in_cache: u64, highest_known: u64) {}
+
+#[tracing::instrument(name = "obix.persistent_cache.no_receivers", level = "warn")]
+fn record_no_receivers(sequence: u64) {}
+
+#[tracing::instrument(
+    name = "obix.persistent_cache.backfill_failed",
+    level = "warn",
+    skip_all,
+    fields(error = %error, current_sequence = current_sequence),
+)]
+fn record_backfill_failed(error: &sqlx::Error, current_sequence: u64) {}
+
+#[tracing::instrument(
+    name = "obix.persistent_cache.backfill_channel_closed",
+    level = "error",
+    fields(otel.status_code = "ERROR"),
+)]
+fn record_backfill_channel_closed() {}
+
+#[tracing::instrument(
+    name = "obix.persistent_cache.cache_fill_lagged",
+    level = "error",
+    fields(otel.status_code = "ERROR"),
+)]
+fn record_cache_fill_lagged(dropped: u64, last_broadcast_sequence: u64, highest_known: u64) {}
+
+#[tracing::instrument(
+    name = "obix.persistent_cache.cache_fill_closed",
+    level = "error",
+    fields(otel.status_code = "ERROR"),
+)]
+fn record_cache_fill_closed() {}
+
+#[tracing::instrument(
+    name = "obix.persistent_cache.notification_channel_closed",
+    level = "error",
+    fields(otel.status_code = "ERROR"),
+)]
+fn record_notification_channel_closed() {}

--- a/src/out/persistent/listener.rs
+++ b/src/out/persistent/listener.rs
@@ -81,13 +81,13 @@ where
                     this.maybe_add_to_cache(event);
                 }
                 Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n)))) => {
-                    tracing::warn!(
-                        target: "obix::persistent_listener",
+                    tracing::warn_span!(
+                        "obix.persistent_listener.lagged",
                         dropped = n,
                         last_returned_sequence = u64::from(this.last_returned_sequence),
                         latest_known = u64::from(this.latest_known),
-                        "broadcast receiver lagged — listener dropped events (will recover via backfill if latest_known advances)"
-                    );
+                    )
+                    .in_scope(|| ());
                 }
                 Poll::Pending => break,
             }

--- a/src/out/persistent/listener.rs
+++ b/src/out/persistent/listener.rs
@@ -81,13 +81,11 @@ where
                     this.maybe_add_to_cache(event);
                 }
                 Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n)))) => {
-                    tracing::warn_span!(
-                        "obix.persistent_listener.lagged",
-                        dropped = n,
-                        last_returned_sequence = u64::from(this.last_returned_sequence),
-                        latest_known = u64::from(this.latest_known),
-                    )
-                    .in_scope(|| ());
+                    record_lagged(
+                        n,
+                        u64::from(this.last_returned_sequence),
+                        u64::from(this.latest_known),
+                    );
                 }
                 Poll::Pending => break,
             }
@@ -136,3 +134,6 @@ where
         Poll::Pending
     }
 }
+
+#[tracing::instrument(name = "obix.persistent_listener.lagged", level = "warn")]
+fn record_lagged(dropped: u64, last_returned_sequence: u64, latest_known: u64) {}

--- a/src/out/persistent/listener.rs
+++ b/src/out/persistent/listener.rs
@@ -80,7 +80,15 @@ where
                 Poll::Ready(Some(Ok(event))) => {
                     this.maybe_add_to_cache(event);
                 }
-                Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(_)))) => (),
+                Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n)))) => {
+                    tracing::warn!(
+                        target: "obix::persistent_listener",
+                        dropped = n,
+                        last_returned_sequence = u64::from(this.last_returned_sequence),
+                        latest_known = u64::from(this.latest_known),
+                        "broadcast receiver lagged — listener dropped events (will recover via backfill if latest_known advances)"
+                    );
+                }
                 Poll::Pending => break,
             }
         }

--- a/src/out/pg_notify.rs
+++ b/src/out/pg_notify.rs
@@ -27,12 +27,7 @@ where
             let notification = match listener.recv().await {
                 Ok(notification) => notification,
                 Err(e) => {
-                    tracing::error_span!(
-                        "obix.pg_listener.recv_error",
-                        otel.status_code = "ERROR",
-                        error = %e,
-                    )
-                    .in_scope(|| ());
+                    record_recv_error(&e);
                     break;
                 }
             };
@@ -49,12 +44,7 @@ where
 
             // If send fails, receiver is dropped, so break
             if let Err(e) = result {
-                tracing::error_span!(
-                    "obix.pg_listener.forward_failed",
-                    otel.status_code = "ERROR",
-                    error = %e,
-                )
-                .in_scope(|| ());
+                record_forward_failed(&e);
                 break;
             }
         }
@@ -62,3 +52,19 @@ where
 
     Ok(OwnedTaskHandle::new(handle))
 }
+
+#[tracing::instrument(
+    name = "obix.pg_listener.recv_error",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", error = %error),
+)]
+fn record_recv_error(error: &sqlx::Error) {}
+
+#[tracing::instrument(
+    name = "obix.pg_listener.forward_failed",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", error = %error),
+)]
+fn record_forward_failed<T>(error: &tokio::sync::mpsc::error::SendError<T>) {}

--- a/src/out/pg_notify.rs
+++ b/src/out/pg_notify.rs
@@ -27,11 +27,12 @@ where
             let notification = match listener.recv().await {
                 Ok(notification) => notification,
                 Err(e) => {
-                    tracing::error!(
-                        target: "obix::pg_listener",
+                    tracing::error_span!(
+                        "obix.pg_listener.recv_error",
+                        otel.status_code = "ERROR",
                         error = %e,
-                        "PgListener.recv() returned error; pg-listener forwarder halting"
-                    );
+                    )
+                    .in_scope(|| ());
                     break;
                 }
             };
@@ -48,11 +49,12 @@ where
 
             // If send fails, receiver is dropped, so break
             if let Err(e) = result {
-                tracing::error!(
-                    target: "obix::pg_listener",
+                tracing::error_span!(
+                    "obix.pg_listener.forward_failed",
+                    otel.status_code = "ERROR",
                     error = %e,
-                    "notification forward failed — cache loop receiver dropped; pg-listener forwarder halting"
-                );
+                )
+                .in_scope(|| ());
                 break;
             }
         }

--- a/src/out/pg_notify.rs
+++ b/src/out/pg_notify.rs
@@ -1,6 +1,9 @@
 use tokio::sync::mpsc;
 
-use crate::{handle::OwnedTaskHandle, tables::MailboxTables};
+use crate::{
+    handle::{OwnedTaskHandle, spawn_supervised},
+    tables::MailboxTables,
+};
 
 pub async fn spawn_pg_listener<Tables>(
     pool: &sqlx::PgPool,
@@ -19,8 +22,20 @@ where
         ])
         .await?;
 
-    let handle = tokio::spawn(async move {
-        while let Ok(notification) = listener.recv().await {
+    let handle = spawn_supervised("obix::pg_listener", async move {
+        loop {
+            let notification = match listener.recv().await {
+                Ok(notification) => notification,
+                Err(e) => {
+                    tracing::error!(
+                        target: "obix::pg_listener",
+                        error = %e,
+                        "PgListener.recv() returned error; pg-listener forwarder halting"
+                    );
+                    break;
+                }
+            };
+
             // Route notification to appropriate channel with backpressure
             let result = if notification.channel() == Tables::persistent_outbox_events_channel() {
                 persistent_notification_tx.send(notification).await
@@ -32,7 +47,12 @@ where
             };
 
             // If send fails, receiver is dropped, so break
-            if result.is_err() {
+            if let Err(e) = result {
+                tracing::error!(
+                    target: "obix::pg_listener",
+                    error = %e,
+                    "notification forward failed — cache loop receiver dropped; pg-listener forwarder halting"
+                );
                 break;
             }
         }


### PR DESCRIPTION
## Summary

Observability-only change to make the stall described in [GaloyMoney/lana-bank#5035](https://github.com/GaloyMoney/lana-bank/issues/5035) self-diagnosing. No behavior is modified — every previously-silent drop or task exit in the outbox path now emits a short-lived OTEL span that is queryable in Honeycomb.

Context: the same stall signature reproduced on staging today (`0.53.0-rc.5`, job 0.6.18, obix 0.2.21) even though PR #87 in `job` (lost-handler self-steal fix) is live. 25 outbox handlers frozen at the exact same sequence; 7 events sitting unprocessed in `persistent_outbox_events`; zero log output from the server pod for 30+ minutes. The job poller is demonstrably alive (the two `task.*` crons keep dispatching every ~15s in Honeycomb) — so the stall is inside the obix subscription layer, and today there is no way to tell which silent-drop site is firing.

## What this PR changes

Every previously-silent failure site now emits a trace-visible signal:

- **`persistent/cache.rs`** — `cache_fill_receiver` `Lagged` / `Closed`, notification / backfill channel closure, broadcast-loop halt on sequence gap, broadcast-loop halt on `persistent_event_sender` having no active receivers, and `load_next_page` failure in `handle_backfill_request`.
- **`persistent/listener.rs`** — `BroadcastStreamRecvError::Lagged` drops (previously `()`-swallowed).
- **`ephemeral/cache.rs`** + **`ephemeral/listener.rs`** — symmetric signals for the ephemeral path.
- **`out/pg_notify.rs`** — `PgListener.recv()` errors and forward-send failures.
- **New `handle::spawn_supervised`** wraps the three long-lived background tasks (`persistent_cache_loop`, `ephemeral_cache_loop`, `pg_listener`) in `AssertUnwindSafe::catch_unwind` and records both normal-exit and panic termination. A silent cache-loop death is no longer silent.

## Why spans instead of `tracing::error!`

All these failure sites live inside `tokio::spawn`'d long-lived `select!` loops with no surrounding span. `lana-bank`'s `tracing-opentelemetry` layer only exports spans via OTLP — bare `tracing::error!` events without a parent span land in stdout but never reach Honeycomb. To make these stall signals queryable, each one has to open (and close) its own short-lived span.

## The `record_*` helper pattern

Each failure site calls a small `#[tracing::instrument]`-decorated no-op helper function at the bottom of the module:

```rust
#[tracing::instrument(
    name = "obix.persistent_cache.cache_fill_lagged",
    level = "error",
    fields(otel.status_code = "ERROR"),
)]
fn record_cache_fill_lagged(dropped: u64, last_broadcast_sequence: u64, highest_known: u64) {}
```

The empty body is intentional. `#[instrument]` creates a span on entry, records the function's arguments as span fields, and closes the span on return — so an empty function produces a single short-lived trace-visible signal with structured attributes, and the whole exporter pipeline (otel layer → OTLP → Honeycomb) fires as usual.

This pattern is **not used elsewhere** in `lana-bank`, `es-entity`, `job`, or obix `main` — it was introduced in this PR. The alternatives we considered:

1. Refactor each `select!` arm body into its own `#[instrument]`ed async method — matches lana-bank's usual convention, but requires threading `persistent_cache` / `last_broadcast_sequence` / cache refs through method signatures for what is essentially an error log. Invasive for an observability-only PR.
2. Bare `tracing::error!` without a span — aesthetically matches lana-bank, but the signal is invisible in Honeycomb. Defeats the purpose of the PR.
3. Inline `error_span!(...).in_scope(|| ())` at each site — same mechanics as the helper pattern, but 14× the ceremony.

The empty-body `#[instrument]` helper keeps every call site a plain, type-checked function call and declares the span name / level / `otel.status_code` once per signal. Localised to this subsystem; not being introduced as a project-wide convention.

Signal names follow the shape `obix.<subsystem>.<condition>`, e.g. `obix.persistent_cache.sequence_gap`, `obix.supervisor.task_panicked` — stable, queryable, dot-hierarchical so Honeycomb can filter by prefix.

## Deliberately out of scope

Actual behavioral fixes to the stall (e.g., the listener re-reading `latest_known_persisted()` so `latest_known` self-corrects after a dropped broadcast event; periodic gap-fill sweeper; the `c9868b2` gap-fix branch decision). Those should be driven by what the traces in this PR surface on the next reproduction, not by guessing.

## Test plan

- [x] `cargo build` (SQLX_OFFLINE)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo nextest run` — all 17 tests pass
- [ ] Deploy to staging, run simulation, observe next stall, query `name = "obix.*"` in Honeycomb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)