### PR TITLE
fix(persistent/cache): clamp skip_too_old threshold to last_broadcast_sequence

### DIFF
--- a/src/out/persistent/cache.rs
+++ b/src/out/persistent/cache.rs
@@ -133,8 +133,16 @@ where
         let sequence = event.sequence;
         let highest_known = highest_known_sequence.load(Ordering::Relaxed);
 
-        // Skip events that are too old to be useful
-        let threshold = highest_known.saturating_sub(cache_size as u64);
+        // Skip events that are too old to be useful, but never let the
+        // threshold move past the broadcast cursor — events still required
+        // for the contiguity loop to advance (sequence > last_broadcast_sequence)
+        // must always reach the cache. Without this clamp, a burst that
+        // advances `highest_known` ahead of `last_broadcast_sequence`
+        // silently drops the events between them and permanently breaks
+        // broadcast (see lana-bank#5035).
+        let threshold = highest_known
+            .saturating_sub(cache_size as u64)
+            .min(u64::from(last_broadcast_sequence));
         if u64::from(sequence) <= threshold {
             return (cache, last_broadcast_sequence);
         }


### PR DESCRIPTION
The `skip_too_old` check in `obix/src/out/persistent/cache.rs` drops events whose sequence is `<= highest_known - cache_size`. Under a burst, `highest_known` can run ahead of `last_broadcast_sequence`, so that threshold can exceed the broadcast cursor. Events in `(last_broadcast_sequence, highest_known - cache_size]` are then silently discarded even though they are still required for the contiguity loop to advance. Once contiguity breaks, broadcast stops; the listener's `latest_known` only advances via broadcast, so it freezes; `request_backfill()` never fires; handlers park indefinitely.

On staging, the trigger was [lana-bank#4972](https://github.com/GaloyMoney/lana-bank/pull/4972) (merged April 10, 2026), which wired chart-of-accounts node events into the outbox. `initialize_chart_of_accounts()` now commits about 1858 events in one op, which is large enough to trip the latent obix bug with the default `event_cache_size=1000`.

The job#87 explanation does not fit this incident. That bug mutates job rows `running -> pending`; on staging the 25 outbox rows remained `state='running'`, `attempt_index=1`, with no sign of reset. The failure reproduces locally inside obix without needing the job bug.

Minimal fix:

```rust
let threshold = highest_known
    .saturating_sub(cache_size as u64)
    .min(u64::from(last_broadcast_sequence));
```

This prevents dropping any event that is still ahead of the broadcast cursor.

Refs: GaloyMoney/lana-bank#5035
