### PR TITLE
chore(deps): bump job to 0.6.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,9 +923,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764fd71da384151e105d0c93c85478327e034f512e4836700b04413f5bc580c9"
+checksum = "1f5984583408d25de1b4a0b4a60d4292bbfc7daf9504ea2b8daad4d266f65400"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ chrono = { version = "0.4", features = ["clock", "serde"], default-features = fa
 tracing = { version = "0.1" }
 futures = "0.3"
 im = { version = "15.1", features = ["serde"] }
-job = "0.6.21"
+job = "0.6.22"
 thiserror = "2.0"
 async-trait = "0.1"
 derive_builder = "0.20"


### PR DESCRIPTION
Bumps the `job` workspace dependency from 0.6.21 to 0.6.22, picking up the latest release of the crate. Part of the rollout chain (job → obix → cala → lana-bank) for the new `job` release.