### PR TITLE
chore(deps): bump es-entity to 0.10.36 and job to 0.6.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,9 +415,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.10.35"
+version = "0.10.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f523e4cd9b354b57b458aee369eadba8da68fbfb2af636c7a429c7942160d3"
+checksum = "bffb4c045095c29c481e97358b072497865b0c45ff5ff23fdf57eaa069e59971"
 dependencies = [
  "chrono",
  "derive_builder",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.10.35"
+version = "0.10.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48186330c95462026a942f3f1d95beb99e95da0bc4fdcae76a6cf55afee9cae"
+checksum = "2c1bb41f0f8f49452fa1ffd0377ddb180df35a8fcee7024a3d2a2974cd6c2d7e"
 dependencies = [
  "convert_case",
  "darling 0.23.0",
@@ -923,9 +923,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.22"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f5984583408d25de1b4a0b4a60d4292bbfc7daf9504ea2b8daad4d266f65400"
+checksum = "ed95a4bbfcfc29d8510c696220a20b5af2fea040c0b9e75ffc2258b32dfa8e09"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ obix-macros = { path = "obix-macros", version = "0.2.27-dev" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-es-entity = "0.10.35"
+es-entity = "0.10.36"
 anyhow = "1.0"
 tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
@@ -64,7 +64,7 @@ chrono = { version = "0.4", features = ["clock", "serde"], default-features = fa
 tracing = { version = "0.1" }
 futures = "0.3"
 im = { version = "15.1", features = ["serde"] }
-job = "0.6.22"
+job = "0.6.25"
 thiserror = "2.0"
 async-trait = "0.1"
 derive_builder = "0.20"


### PR DESCRIPTION
Bump es-entity and job as part of the release crate chain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only update; behavior changes (if any) come from upstream `es-entity`/`job` releases and could subtly affect inbox/job execution at runtime.
> 
> **Overview**
> Updates workspace dependency versions: bumps `es-entity` from `0.10.35` to `0.10.36` and `job` from `0.6.22` to `0.6.25`.
> 
> Regenerates `Cargo.lock` accordingly (including the matching `es-entity-macros` patch bump), with no source-code changes in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af66d957bd3fefd388d0311efe5d250215ef7b5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->