### PR TITLE
chore: align dependabot policy with job/es-entity/cala

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,13 @@ updates:
 - package-ecosystem: "cargo"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
+  cooldown:
+    default-days: 7
+  groups:
+    all-dependencies:
+      patterns:
+        - "*"
+  ignore:
+    - dependency-name: "job"
+    - dependency-name: "es-entity*"


### PR DESCRIPTION
## Summary

obix's dependabot.yml is the only one in the release chain still on daily, ungrouped updates. This PR:

- Sets `interval: weekly`
- Adds `cooldown.default-days: 7`
- Adds `groups.all-dependencies.patterns: ["*"]`
- Adds `ignore` entries for the release-chain crates obix depends on (`es-entity*`, `job`) — these are bumped manually via the release crate chain workflow, so dependabot shouldn't open PRs for them.

Matches the cala dependabot policy.

## Test plan

- [ ] Confirm CI passes