### PR TITLE
chore(deps): bump job from 0.6.25 to 0.6.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,9 +424,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.10.36"
+version = "0.10.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb4c045095c29c481e97358b072497865b0c45ff5ff23fdf57eaa069e59971"
+checksum = "edd151ac4deea5d758e89ebcb33243f852c8175544f1912602cdf4dff19e15ec"
 dependencies = [
  "chrono",
  "derive_builder",
@@ -439,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.10.36"
+version = "0.10.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1bb41f0f8f49452fa1ffd0377ddb180df35a8fcee7024a3d2a2974cd6c2d7e"
+checksum = "313bc1f90897a0b4e098cf0c61e5f1cf16d940488574d4917161503c9d0785b5"
 dependencies = [
  "convert_case",
  "darling 0.23.0",
@@ -923,9 +932,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed95a4bbfcfc29d8510c696220a20b5af2fea040c0b9e75ffc2258b32dfa8e09"
+checksum = "e0bccc4738be139d63a915ab2af1a039c19a714c2bf05ce441f682ca42cdcd7d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1142,9 +1151,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1156,15 +1165,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.2",
  "thiserror",
  "tokio",
@@ -1277,6 +1287,12 @@ dependencies = [
  "once_cell",
  "regex",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1676,11 +1692,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -1695,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2253,9 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ chrono = { version = "0.4", features = ["clock", "serde"], default-features = fa
 tracing = { version = "0.1" }
 futures = "0.3"
 im = { version = "15.1", features = ["serde"] }
-job = "0.6.25"
+job = "0.6.26"
 thiserror = "2.0"
 async-trait = "0.1"
 derive_builder = "0.20"


### PR DESCRIPTION
## Summary

Picks up [GaloyMoney/job#117](https://github.com/GaloyMoney/job/pull/117), which downgrades the graceful-shutdown force-reschedule log from ERROR to WARN at `poller.rs:857`. That single line was producing every false Zenduty page from the `volcano-qa-main-lana-errors` trigger on pod restart bursts — 10 pages in 6 weeks, 4 of them in 24h.

Lock-file refresh also pulls in opentelemetry + serde_with transitive bumps that `job 0.6.26` inherits from its OTel updates (job#108).

Part of the propagation chain after job#117 merged: cala ([cala#732](https://github.com/GaloyMoney/cala/pull/732)) → obix (this PR) → lana-bank. drua uses caret `"0.6"` so picks up automatically.

## Test plan

- [ ] CI green on this PR
- [ ] After release, lana-bank picks up via its own dependency bump; volcano-qa stops paging on the documented signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no obix code changes; main effect is log level on an expected shutdown path, though transitive OTel/serde_with updates slightly widen the dependency surface.
> 
> **Overview**
> Bumps the workspace **`job`** dependency from **0.6.25** to **0.6.26** in `Cargo.toml`, with **`Cargo.lock`** refreshed for that crate and its transitive updates (**`es-entity`**, **`opentelemetry`**, **`opentelemetry_sdk`**, **`serde_with`**, **`tracing-opentelemetry`**, plus new **`bs58`** / **`portable-atomic`** entries).
> 
> The intended runtime effect comes from upstream **`job`**: graceful-shutdown force-reschedule logging is downgraded from **ERROR** to **WARN**, which should stop false **`volcano-qa-main-lana-errors`** pages on pod restart bursts. No application Rust sources change in this repo—only dependency versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c9919c4fde9a3094203e33a5d0a0efbfeffbf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->