### PR TITLE
fix(outbox): bound persistent_outbox_events insert into chunked sub-batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,9 +932,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.26"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bccc4738be139d63a915ab2af1a039c19a714c2bf05ce441f682ca42cdcd7d"
+checksum = "518512c0122e327140301d066e994339ce74cbbff0d33be40d0292d0c1b57d94"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ chrono = { version = "0.4", features = ["clock", "serde"], default-features = fa
 tracing = { version = "0.1" }
 futures = "0.3"
 im = { version = "15.1", features = ["serde"] }
-job = "0.6.26"
+job = "0.6.28"
 thiserror = "2.0"
 async-trait = "0.1"
 derive_builder = "0.20"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
 use derive_builder::Builder;
 use es_entity::clock::{Clock, ClockHandle};
 
+pub const DEFAULT_PERSIST_EVENTS_BATCH_SIZE: usize = 5000;
+
 #[derive(Clone, Builder)]
 pub struct MailboxConfig {
     #[builder(default = "100")]
@@ -9,6 +11,8 @@ pub struct MailboxConfig {
     pub event_cache_size: usize,
     #[builder(default = "10")]
     pub event_cache_trim_percent: u8,
+    #[builder(default = "DEFAULT_PERSIST_EVENTS_BATCH_SIZE")]
+    pub persist_events_batch_size: usize,
     #[builder(default = "Clock::handle().clone()")]
     pub clock: ClockHandle,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod tables;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 
-pub use config::MailboxConfig;
+pub use config::{DEFAULT_PERSIST_EVENTS_BATCH_SIZE, MailboxConfig};
 pub use inbox::{
     Inbox, InboxConfig, InboxError, InboxEvent, InboxEventId, InboxEventStatus, InboxHandler,
     InboxIdempotencyKey, InboxResult,

--- a/src/out/mod.rs
+++ b/src/out/mod.rs
@@ -29,6 +29,7 @@ where
 {
     pool: sqlx::PgPool,
     event_buffer_size: usize,
+    persist_events_batch_size: usize,
     persistent_cache: Arc<PersistentOutboxEventCache<P, Tables>>,
     ephemeral_cache: Arc<EphemeralOutboxEventCache<P, Tables>>,
     _pg_listener_handle: Arc<OwnedTaskHandle>,
@@ -44,6 +45,7 @@ where
         Self {
             pool: self.pool.clone(),
             event_buffer_size: self.event_buffer_size,
+            persist_events_batch_size: self.persist_events_batch_size,
             persistent_cache: self.persistent_cache.clone(),
             ephemeral_cache: self.ephemeral_cache.clone(),
             _pg_listener_handle: self._pg_listener_handle.clone(),
@@ -79,6 +81,7 @@ where
         Ok(Self {
             pool,
             event_buffer_size: config.event_buffer_size,
+            persist_events_batch_size: config.persist_events_batch_size,
             persistent_cache: Arc::new(persistent_cache),
             ephemeral_cache: Arc::new(ephemeral_cache),
             _pg_listener_handle: Arc::new(pg_listener_handle),
@@ -106,6 +109,7 @@ where
         let hook = persist_events_hook::PersistEvents::<P, Tables>::new(
             self.persistent_cache.cache_fill_sender(),
             events,
+            self.persist_events_batch_size,
         );
         if let Err(hook) = op.add_commit_hook(hook) {
             use es_entity::hooks::CommitHook;

--- a/src/out/persist_events_hook.rs
+++ b/src/out/persist_events_hook.rs
@@ -15,6 +15,7 @@ where
     sender: broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
     pre_commit_events: Vec<P>,
     post_commit_events: Vec<PersistentOutboxEvent<P>>,
+    batch_size: usize,
     _phantom: PhantomData<Tables>,
 }
 
@@ -26,11 +27,13 @@ where
     pub fn new(
         sender: broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
         events: impl IntoIterator<Item = impl Into<P>>,
+        batch_size: usize,
     ) -> Self {
         Self {
             sender,
             pre_commit_events: events.into_iter().map(Into::into).collect(),
             post_commit_events: Vec::new(),
+            batch_size,
             _phantom: PhantomData,
         }
     }
@@ -45,7 +48,17 @@ where
         mut self,
         mut op: HookOperation<'_>,
     ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
-        let persisted = Tables::persist_events(&mut op, self.pre_commit_events.drain(..)).await?;
+        let batch_size = self.batch_size.max(1);
+        let events = std::mem::take(&mut self.pre_commit_events);
+        let mut persisted = Vec::with_capacity(events.len());
+        let mut events = events.into_iter();
+        loop {
+            let chunk: Vec<P> = events.by_ref().take(batch_size).collect();
+            if chunk.is_empty() {
+                break;
+            }
+            persisted.extend(Tables::persist_events(&mut op, chunk.into_iter()).await?);
+        }
         self.post_commit_events = persisted;
         PreCommitRet::ok(self, op)
     }

--- a/tests/outbox.rs
+++ b/tests/outbox.rs
@@ -279,6 +279,63 @@ async fn large_payload_via_pg_notify_fetches_from_db() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[file_serial]
+async fn large_batch_persisted_in_bounded_chunks() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let batch_size = 5;
+    let total = 23;
+
+    let outbox = init_outbox::<TestEvent>(
+        &pool,
+        MailboxConfig::builder()
+            .persist_events_batch_size(batch_size)
+            .build()
+            .expect("Couldn't build MailboxConfig"),
+    )
+    .await?;
+
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_all_persisted(&mut op, (0..10).map(TestEvent::Ping))
+        .await?;
+    outbox
+        .publish_all_persisted(&mut op, (10..total).map(TestEvent::Ping))
+        .await?;
+    op.commit().await?;
+
+    let mut listener = outbox.listen_persisted(EventSequence::BEGIN);
+
+    let mut events = Vec::new();
+    for i in 0..total {
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
+            .await
+            .unwrap_or_else(|_| panic!("timeout waiting for event {i}"))
+            .unwrap_or_else(|| panic!("expected event {i} but got None"));
+        events.push(event);
+    }
+
+    assert_eq!(events.len() as u64, total, "all events should be persisted");
+
+    let mut last_sequence: Option<EventSequence> = None;
+    for (i, event) in events.iter().enumerate() {
+        assert!(
+            matches!(event.payload, Some(TestEvent::Ping(n)) if n == i as u64),
+            "event {i} payload should match publish order",
+        );
+        if let Some(prev) = last_sequence {
+            assert!(
+                event.sequence > prev,
+                "sequences must be strictly increasing across chunk boundaries",
+            );
+        }
+        last_sequence = Some(event.sequence);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
 async fn sequence_gap_from_rolled_back_transaction() -> anyhow::Result<()> {
     let pool = init_pool().await?;
 


### PR DESCRIPTION
## Problem

At commit, the `PersistEvents` hook merges **every** `publish_all_persisted` call in a transaction into one `pre_commit_events: Vec<P>` (`PersistEvents::merge`), then writes them all in a **single** `INSERT INTO persistent_outbox_events ... SELECT unnest($1::jsonb[])`.

At scale — e.g. a cala EC deep-recalc emitting **millions** of balance events in one transaction — that is one giant statement that can **OOM a Postgres backend**. Because events are deferred + merged into a single commit-time insert, call-site batching is ineffective (5k-chunked publishes still merge into one `unnest` insert), so the bound must live inside obix.

This is the commit-time counterpart to cala PR #740, which bounds the balance-history insert but not this outbox insert — leaving the OOM to reappear at commit time.

## Fix

Persist the batch in bounded sub-batches of `persist_events_batch_size` (default `5000`) inside the **same** pre-commit transaction (`src/out/persist_events_hook.rs`). Invariants preserved:

- **Atomicity** — all sub-batches share `op`; a failure rolls the whole batch back. No torn/partial outbox.
- **Sequence order** — chunks are drained and inserted in publish order; `unnest` preserves array order and sequences are assigned per row.
- **post_commit broadcast** — `RETURNING` rows are gathered across all chunks before the broadcast.
- **Ephemeral events** — separate single-row upsert path, unaffected.

The bound is surfaced on `MailboxConfig::persist_events_batch_size` (builder-defaulted, non-breaking) so consumers can tune it, and `DEFAULT_PERSIST_EVENTS_BATCH_SIZE` is exported.

## Testing

- `nix flake check` green (fmt, clippy `--deny warnings`, audit, deny).
- New `large_batch_persisted_in_bounded_chunks` publishes 23 events (across two merged `publish_all_persisted` calls) with `persist_events_batch_size = 5`, forcing 5 sub-batch inserts (incl. a partial final chunk), and asserts all rows land in publish order with strictly increasing sequences. Full `tests/outbox.rs` suite passes (11/11).

## Rollout

Behavior-preserving, no schema change — only splits one statement into N. Needs a new obix release → bump in consumers (cala, job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches commit-time persistence for all persistent outbox traffic; behavior should be equivalent but mis-tuned batch sizes or ordering bugs could affect high-volume producers.
> 
> **Overview**
> **Fixes commit-time OOM** when a transaction merges many `publish_all_persisted` events into one giant `INSERT … unnest` by splitting persistence into bounded sub-batches inside the same pre-commit hook.
> 
> `MailboxConfig` gains **`persist_events_batch_size`** (default **5000**, exported as `DEFAULT_PERSIST_EVENTS_BATCH_SIZE`); `Outbox` passes it into `PersistEvents`, which loops `Tables::persist_events` per chunk while keeping atomicity, publish order, and a single post-commit broadcast. Also bumps the **`job`** workspace dependency to **0.6.28**.
> 
> Adds **`large_batch_persisted_in_bounded_chunks`** to verify merged publishes with a small batch size still yield all events in order with strictly increasing sequences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c82cb0538dcd0dadf515d172246951f8333ef530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->