### PR TITLE
fix(outbox): survive LISTEN connection loss with reconnect + cache resync

### DIFF
--- a/src/out/ephemeral/cache.rs
+++ b/src/out/ephemeral/cache.rs
@@ -122,17 +122,6 @@ where
         }
     }
 
-    async fn fetch_all_events(
-        pool: sqlx::PgPool,
-        cache_fill_sender: broadcast::Sender<Arc<EphemeralOutboxEvent<P>>>,
-    ) {
-        if let Ok(events) = Tables::load_ephemeral_events::<P>(&pool, None).await {
-            for event in events {
-                let _ = cache_fill_sender.send(Arc::new(event));
-            }
-        }
-    }
-
     fn handle_ephemeral_notification(
         pool: &sqlx::PgPool,
         payload: &str,
@@ -280,11 +269,36 @@ where
                                     // The LISTEN connection dropped and any
                                     // notifications sent meanwhile are gone —
                                     // reload the current per-type state from
-                                    // the table.
-                                    tokio::spawn(Self::fetch_all_events(
-                                        pool.clone(),
-                                        cache_fill_sender.clone(),
-                                    ));
+                                    // the table. Applied inline (not via
+                                    // cache_fill, which also carries live
+                                    // short-circuit events) and guarded by
+                                    // recency: the reload races live
+                                    // deliveries, and a row read before a
+                                    // newer event was applied must not
+                                    // overwrite or re-broadcast over it.
+                                    // recorded_at is the only ordering the
+                                    // table carries, so equal-timestamp rows
+                                    // are treated as already known.
+                                    match Tables::load_ephemeral_events::<P>(&pool, None).await {
+                                        Ok(events) => {
+                                            for event in events {
+                                                let stale = ephemeral_cache
+                                                    .get(&event.event_type)
+                                                    .is_some_and(|cached| {
+                                                        cached.recorded_at >= event.recorded_at
+                                                    });
+                                                if !stale {
+                                                    ephemeral_cache =
+                                                        Self::insert_into_cache_and_broadcast(
+                                                            ephemeral_cache,
+                                                            Arc::new(event),
+                                                            &ephemeral_event_sender,
+                                                        );
+                                                }
+                                            }
+                                        }
+                                        Err(e) => record_resync_failed(&e),
+                                    }
                                 }
                             }
                             None => {
@@ -327,3 +341,11 @@ fn record_cache_fill_closed() {}
     fields(otel.status_code = "ERROR"),
 )]
 fn record_notification_channel_closed() {}
+
+#[tracing::instrument(
+    name = "obix.ephemeral_cache.resync_failed",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", error = %error),
+)]
+fn record_resync_failed(error: &sqlx::Error) {}

--- a/src/out/ephemeral/cache.rs
+++ b/src/out/ephemeral/cache.rs
@@ -3,11 +3,10 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 
 use std::sync::Arc;
 
-use crate::out::event::*;
-use crate::out::pg_notify::NotifyMessage;
 use crate::{
     config::*,
     handle::{OwnedTaskHandle, spawn_supervised},
+    out::{event::*, pg_notify::NotifyMessage},
 };
 
 pub struct CacheHandle<P>
@@ -266,19 +265,6 @@ where
                                 }
 
                                 if resync_needed {
-                                    // The LISTEN connection dropped and any
-                                    // notifications sent meanwhile are gone —
-                                    // reload the current per-type state from
-                                    // the table. Applied inline (not via
-                                    // cache_fill, which also carries live
-                                    // short-circuit events) and guarded by
-                                    // recency: the reload races live
-                                    // deliveries, and a row read before a
-                                    // newer event was applied must not
-                                    // overwrite or re-broadcast over it.
-                                    // recorded_at is the only ordering the
-                                    // table carries, so equal-timestamp rows
-                                    // are treated as already known.
                                     match Tables::load_ephemeral_events::<P>(&pool, None).await {
                                         Ok(events) => {
                                             for event in events {

--- a/src/out/ephemeral/cache.rs
+++ b/src/out/ephemeral/cache.rs
@@ -4,6 +4,7 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 use std::sync::Arc;
 
 use crate::out::event::*;
+use crate::out::pg_notify::NotifyMessage;
 use crate::{
     config::*,
     handle::{OwnedTaskHandle, spawn_supervised},
@@ -71,7 +72,7 @@ where
     pub async fn init(
         pool: &sqlx::PgPool,
         config: &MailboxConfig,
-        ephemeral_notification_rx: mpsc::Receiver<sqlx::postgres::PgNotification>,
+        ephemeral_notification_rx: mpsc::Receiver<NotifyMessage>,
     ) -> Result<Self, sqlx::Error> {
         let (backfill_send, backfill_recv) = mpsc::unbounded_channel();
         let (cache_fill_send, cache_fill_recv) = broadcast::channel(config.event_buffer_size);
@@ -115,6 +116,17 @@ where
         cache_fill_sender: broadcast::Sender<Arc<EphemeralOutboxEvent<P>>>,
     ) {
         if let Ok(events) = Tables::load_ephemeral_events::<P>(&pool, Some(event_type)).await {
+            for event in events {
+                let _ = cache_fill_sender.send(Arc::new(event));
+            }
+        }
+    }
+
+    async fn fetch_all_events(
+        pool: sqlx::PgPool,
+        cache_fill_sender: broadcast::Sender<Arc<EphemeralOutboxEvent<P>>>,
+    ) {
+        if let Ok(events) = Tables::load_ephemeral_events::<P>(&pool, None).await {
             for event in events {
                 let _ = cache_fill_sender.send(Arc::new(event));
             }
@@ -180,7 +192,7 @@ where
         >,
         mut cache_fill_receiver: broadcast::Receiver<Arc<EphemeralOutboxEvent<P>>>,
         cache_fill_sender: broadcast::Sender<Arc<EphemeralOutboxEvent<P>>>,
-        mut ephemeral_notification_rx: mpsc::Receiver<sqlx::postgres::PgNotification>,
+        mut ephemeral_notification_rx: mpsc::Receiver<NotifyMessage>,
     ) -> Result<OwnedTaskHandle, sqlx::Error> {
         let pool = pool.clone();
 
@@ -235,34 +247,44 @@ where
 
                     result = ephemeral_notification_rx.recv() => {
                         match result {
-                            Some(notification) => {
-                                if let Some(event) = Self::process_notification(
-                                    notification,
-                                    &pool,
-                                    &ephemeral_cache,
-                                    &cache_fill_sender,
-                                ) {
-                                    ephemeral_cache = Self::insert_into_cache_and_broadcast(
-                                        ephemeral_cache,
-                                        Arc::new(event),
-                                        &ephemeral_event_sender,
-                                    );
+                            Some(message) => {
+                                let mut resync_needed = false;
+                                let mut messages = vec![message];
+                                // Process any additional buffered notifications
+                                while let Ok(message) = ephemeral_notification_rx.try_recv() {
+                                    messages.push(message);
+                                }
+                                for message in messages {
+                                    match message {
+                                        NotifyMessage::Notification(notification) => {
+                                            if let Some(event) = Self::process_notification(
+                                                notification,
+                                                &pool,
+                                                &ephemeral_cache,
+                                                &cache_fill_sender,
+                                            ) {
+                                                ephemeral_cache = Self::insert_into_cache_and_broadcast(
+                                                    ephemeral_cache,
+                                                    Arc::new(event),
+                                                    &ephemeral_event_sender,
+                                                );
+                                            }
+                                        }
+                                        NotifyMessage::Resync => {
+                                            resync_needed = true;
+                                        }
+                                    }
                                 }
 
-                                // Process any additional buffered notifications
-                                while let Ok(notification) = ephemeral_notification_rx.try_recv() {
-                                    if let Some(event) = Self::process_notification(
-                                        notification,
-                                        &pool,
-                                        &ephemeral_cache,
-                                        &cache_fill_sender,
-                                    ) {
-                                        ephemeral_cache = Self::insert_into_cache_and_broadcast(
-                                            ephemeral_cache,
-                                            Arc::new(event),
-                                            &ephemeral_event_sender,
-                                        );
-                                    }
+                                if resync_needed {
+                                    // The LISTEN connection dropped and any
+                                    // notifications sent meanwhile are gone —
+                                    // reload the current per-type state from
+                                    // the table.
+                                    tokio::spawn(Self::fetch_all_events(
+                                        pool.clone(),
+                                        cache_fill_sender.clone(),
+                                    ));
                                 }
                             }
                             None => {

--- a/src/out/persistent/cache.rs
+++ b/src/out/persistent/cache.rs
@@ -8,6 +8,7 @@ use std::sync::{
 };
 
 use crate::out::event::*;
+use crate::out::pg_notify::NotifyMessage;
 use crate::{
     config::*,
     handle::{OwnedTaskHandle, spawn_supervised},
@@ -87,7 +88,7 @@ where
     pub async fn init(
         pool: &sqlx::PgPool,
         config: &MailboxConfig,
-        persistent_notification_rx: mpsc::Receiver<sqlx::postgres::PgNotification>,
+        persistent_notification_rx: mpsc::Receiver<NotifyMessage>,
     ) -> Result<Self, sqlx::Error> {
         let (backfill_send, backfill_recv) = mpsc::unbounded_channel();
         let (cache_fill_send, cache_fill_recv) = broadcast::channel(config.event_buffer_size);
@@ -291,7 +292,7 @@ where
         )>,
         mut cache_fill_receiver: broadcast::Receiver<Arc<PersistentOutboxEvent<P>>>,
         cache_fill_sender: broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
-        mut notification_receiver: mpsc::Receiver<sqlx::postgres::PgNotification>,
+        mut notification_receiver: mpsc::Receiver<NotifyMessage>,
     ) -> Result<OwnedTaskHandle, sqlx::Error> {
         let pool = pool.clone();
 
@@ -379,40 +380,52 @@ where
 
                     result = notification_receiver.recv() => {
                         match result {
-                            Some(notification) => {
-                                if let Some(event) = Self::handle_notification(
-                                    &pool,
-                                    notification.payload(),
-                                    &persistent_cache,
-                                    &cache_fill_sender,
-                                ) {
-                                    (persistent_cache, last_broadcast_sequence) =
-                                        Self::insert_into_cache_and_maybe_broadcast(
-                                            persistent_cache,
-                                            Arc::new(event),
-                                            &highest_known_sequence,
-                                            &persistent_event_sender,
-                                            last_broadcast_sequence,
-                                            cache_size,
-                                        );
+                            Some(message) => {
+                                let mut resync_needed = false;
+                                let mut messages = vec![message];
+                                while let Ok(message) = notification_receiver.try_recv() {
+                                    messages.push(message);
+                                }
+                                for message in messages {
+                                    match message {
+                                        NotifyMessage::Notification(notification) => {
+                                            if let Some(event) = Self::handle_notification(
+                                                &pool,
+                                                notification.payload(),
+                                                &persistent_cache,
+                                                &cache_fill_sender,
+                                            ) {
+                                                (persistent_cache, last_broadcast_sequence) =
+                                                    Self::insert_into_cache_and_maybe_broadcast(
+                                                        persistent_cache,
+                                                        Arc::new(event),
+                                                        &highest_known_sequence,
+                                                        &persistent_event_sender,
+                                                        last_broadcast_sequence,
+                                                        cache_size,
+                                                    );
+                                            }
+                                        }
+                                        NotifyMessage::Resync => {
+                                            resync_needed = true;
+                                        }
+                                    }
                                 }
 
-                                while let Ok(notification) = notification_receiver.try_recv() {
-                                    if let Some(event) = Self::handle_notification(
-                                        &pool,
-                                        notification.payload(),
-                                        &persistent_cache,
-                                        &cache_fill_sender,
-                                    ) {
-                                        (persistent_cache, last_broadcast_sequence) =
-                                            Self::insert_into_cache_and_maybe_broadcast(
-                                                persistent_cache,
-                                                Arc::new(event),
-                                                &highest_known_sequence,
-                                                &persistent_event_sender,
-                                                last_broadcast_sequence,
-                                                cache_size,
+                                if resync_needed {
+                                    // The LISTEN connection dropped and any
+                                    // notifications sent meanwhile are gone.
+                                    // Re-read the head from the table; the
+                                    // proactive gap fill below then pages the
+                                    // missed range into the cache.
+                                    match Tables::highest_known_persistent_sequence(&pool).await {
+                                        Ok(head) => {
+                                            highest_known_sequence.fetch_max(
+                                                u64::from(head),
+                                                Ordering::AcqRel,
                                             );
+                                        }
+                                        Err(e) => record_resync_failed(&e),
                                     }
                                 }
                             }
@@ -505,3 +518,11 @@ fn record_cache_fill_closed() {}
     fields(otel.status_code = "ERROR"),
 )]
 fn record_notification_channel_closed() {}
+
+#[tracing::instrument(
+    name = "obix.persistent_cache.resync_failed",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", error = %error),
+)]
+fn record_resync_failed(error: &sqlx::Error) {}

--- a/src/out/persistent/cache.rs
+++ b/src/out/persistent/cache.rs
@@ -7,11 +7,10 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
 };
 
-use crate::out::event::*;
-use crate::out::pg_notify::NotifyMessage;
 use crate::{
     config::*,
     handle::{OwnedTaskHandle, spawn_supervised},
+    out::{event::*, pg_notify::NotifyMessage},
     sequence::EventSequence,
 };
 
@@ -413,11 +412,6 @@ where
                                 }
 
                                 if resync_needed {
-                                    // The LISTEN connection dropped and any
-                                    // notifications sent meanwhile are gone.
-                                    // Re-read the head from the table; the
-                                    // proactive gap fill below then pages the
-                                    // missed range into the cache.
                                     match Tables::highest_known_persistent_sequence(&pool).await {
                                         Ok(head) => {
                                             highest_known_sequence.fetch_max(

--- a/src/out/pg_notify.rs
+++ b/src/out/pg_notify.rs
@@ -39,8 +39,8 @@ where
     let handle = spawn_supervised("obix::pg_listener", async move {
         loop {
             // `try_recv` (unlike `recv`) surfaces connection loss as
-            // `Ok(None)` after sqlx has already reconnected and re-LISTENed.
-            // `recv` would swallow that marker — and any notifications sent
+            // `Ok(None)` after sqlx has already reconnected and re-issued
+            // LISTEN. `recv` would swallow that marker — and any notifications sent
             // while the connection was down would be silently lost with no
             // resync, stalling every consumer until the next notification.
             match listener.try_recv().await {
@@ -67,8 +67,8 @@ where
                 }
                 Ok(None) => {
                     // Connection was lost; sqlx already reconnected and
-                    // re-LISTENed. Tell both caches to resync for whatever
-                    // was notified during the gap.
+                    // re-issued LISTEN. Tell both caches to resync for
+                    // whatever was notified during the gap.
                     record_connection_lost();
                     if send_resync(&persistent_notification_tx, &ephemeral_notification_tx)
                         .await

--- a/src/out/pg_notify.rs
+++ b/src/out/pg_notify.rs
@@ -1,56 +1,145 @@
 use tokio::sync::mpsc;
 
+use std::time::Duration;
+
 use crate::{
     handle::{OwnedTaskHandle, spawn_supervised},
     tables::MailboxTables,
 };
 
+/// A message from the pg LISTEN pump to a cache loop.
+pub(crate) enum NotifyMessage {
+    /// A notification arrived on one of the subscribed channels.
+    Notification(sqlx::postgres::PgNotification),
+    /// The LISTEN connection was lost and has been re-established.
+    /// Notifications sent while it was down are gone — the cache must
+    /// resync against the tables instead of trusting the notify stream.
+    Resync,
+}
+
+const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_millis(50);
+const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
+
 pub async fn spawn_pg_listener<Tables>(
     pool: &sqlx::PgPool,
-    persistent_notification_tx: mpsc::Sender<sqlx::postgres::PgNotification>,
-    ephemeral_notification_tx: mpsc::Sender<sqlx::postgres::PgNotification>,
+    persistent_notification_tx: mpsc::Sender<NotifyMessage>,
+    ephemeral_notification_tx: mpsc::Sender<NotifyMessage>,
 ) -> Result<OwnedTaskHandle, sqlx::Error>
 where
     Tables: MailboxTables,
 {
     let pool = pool.clone();
-    let mut listener = sqlx::postgres::PgListener::connect_with(&pool).await?;
-    listener
-        .listen_all([
-            Tables::persistent_outbox_events_channel(),
-            Tables::ephemeral_outbox_events_channel(),
-        ])
-        .await?;
+    let persistent_channel = Tables::persistent_outbox_events_channel();
+    let ephemeral_channel = Tables::ephemeral_outbox_events_channel();
+
+    // The initial connection stays fail-fast: a broken setup should surface
+    // at init, not as an endlessly-retrying background task.
+    let mut listener = connect_and_listen(&pool, persistent_channel, ephemeral_channel).await?;
 
     let handle = spawn_supervised("obix::pg_listener", async move {
         loop {
-            let notification = match listener.recv().await {
-                Ok(notification) => notification,
-                Err(e) => {
-                    record_recv_error(&e);
-                    break;
+            // `try_recv` (unlike `recv`) surfaces connection loss as
+            // `Ok(None)` after sqlx has already reconnected and re-LISTENed.
+            // `recv` would swallow that marker — and any notifications sent
+            // while the connection was down would be silently lost with no
+            // resync, stalling every consumer until the next notification.
+            match listener.try_recv().await {
+                Ok(Some(notification)) => {
+                    // Route notification to appropriate channel with backpressure
+                    let result = if notification.channel() == persistent_channel {
+                        persistent_notification_tx
+                            .send(NotifyMessage::Notification(notification))
+                            .await
+                    } else if notification.channel() == ephemeral_channel {
+                        ephemeral_notification_tx
+                            .send(NotifyMessage::Notification(notification))
+                            .await
+                    } else {
+                        // Unknown channel, skip
+                        continue;
+                    };
+
+                    // If send fails, receiver is dropped, so break
+                    if let Err(e) = result {
+                        record_forward_failed(&e);
+                        break;
+                    }
                 }
-            };
-
-            // Route notification to appropriate channel with backpressure
-            let result = if notification.channel() == Tables::persistent_outbox_events_channel() {
-                persistent_notification_tx.send(notification).await
-            } else if notification.channel() == Tables::ephemeral_outbox_events_channel() {
-                ephemeral_notification_tx.send(notification).await
-            } else {
-                // Unknown channel, skip
-                continue;
-            };
-
-            // If send fails, receiver is dropped, so break
-            if let Err(e) = result {
-                record_forward_failed(&e);
-                break;
+                Ok(None) => {
+                    // Connection was lost; sqlx already reconnected and
+                    // re-LISTENed. Tell both caches to resync for whatever
+                    // was notified during the gap.
+                    record_connection_lost();
+                    if send_resync(&persistent_notification_tx, &ephemeral_notification_tx)
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    // Reconnecting inside `try_recv` failed (e.g. the pool
+                    // was saturated at that moment). This pump must outlive
+                    // transient failures: exiting here drops the notification
+                    // senders, which kills the cache loops and leaves the
+                    // outbox permanently deaf while every consumer still
+                    // looks healthy. Rebuild the listener with capped
+                    // backoff, then resync.
+                    record_recv_error(&error);
+                    let mut backoff = INITIAL_RECONNECT_BACKOFF;
+                    listener = loop {
+                        tokio::time::sleep(backoff).await;
+                        match connect_and_listen(&pool, persistent_channel, ephemeral_channel).await
+                        {
+                            Ok(listener) => break listener,
+                            Err(error) => {
+                                record_reconnect_failed(&error);
+                                backoff = (backoff * 2).min(MAX_RECONNECT_BACKOFF);
+                            }
+                        }
+                    };
+                    record_reconnected();
+                    // Resync only after LISTEN is active again: anything
+                    // published before this point is covered by the resync
+                    // (the head re-read happens after), anything after by
+                    // regular notifications.
+                    if send_resync(&persistent_notification_tx, &ephemeral_notification_tx)
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
             }
         }
     });
 
     Ok(OwnedTaskHandle::new(handle))
+}
+
+async fn connect_and_listen(
+    pool: &sqlx::PgPool,
+    persistent_channel: &'static str,
+    ephemeral_channel: &'static str,
+) -> Result<sqlx::postgres::PgListener, sqlx::Error> {
+    let mut listener = sqlx::postgres::PgListener::connect_with(pool).await?;
+    listener
+        .listen_all([persistent_channel, ephemeral_channel])
+        .await?;
+    Ok(listener)
+}
+
+async fn send_resync(
+    persistent_notification_tx: &mpsc::Sender<NotifyMessage>,
+    ephemeral_notification_tx: &mpsc::Sender<NotifyMessage>,
+) -> Result<(), ()> {
+    for tx in [persistent_notification_tx, ephemeral_notification_tx] {
+        if let Err(e) = tx.send(NotifyMessage::Resync).await {
+            record_forward_failed(&e);
+            return Err(());
+        }
+    }
+    Ok(())
 }
 
 #[tracing::instrument(
@@ -60,6 +149,24 @@ where
     fields(otel.status_code = "ERROR", error = %error),
 )]
 fn record_recv_error(error: &sqlx::Error) {}
+
+#[tracing::instrument(
+    name = "obix.pg_listener.connection_lost",
+    level = "error",
+    fields(otel.status_code = "ERROR"),
+)]
+fn record_connection_lost() {}
+
+#[tracing::instrument(
+    name = "obix.pg_listener.reconnect_failed",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", error = %error),
+)]
+fn record_reconnect_failed(error: &sqlx::Error) {}
+
+#[tracing::instrument(name = "obix.pg_listener.reconnected", level = "warn")]
+fn record_reconnected() {}
 
 #[tracing::instrument(
     name = "obix.pg_listener.forward_failed",

--- a/tests/outbox.rs
+++ b/tests/outbox.rs
@@ -521,3 +521,85 @@ async fn ephemeral_events_replace_same_type() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Regression: an event whose NOTIFY fires while the LISTEN connection is
+/// down must still reach consumers.
+///
+/// Publishing through a plain transaction delivers exclusively via pg_notify
+/// (no same-process short-circuit hook), so the event below travels the wire
+/// path or not at all. The LISTEN backends are terminated *inside* the
+/// publishing transaction: they die at statement time and the NOTIFY fires at
+/// COMMIT moments later, guaranteeing it is sent while no listener connection
+/// exists — that notification is unrecoverably lost.
+///
+/// Before the fix the pump ran on `PgListener::recv()`, which silently
+/// swallows the reconnect marker, so a notification lost in the gap was never
+/// resynced and the consumer stalled forever (and when the internal reconnect
+/// itself failed, the pump task exited, dropping the notification senders and
+/// killing the cache loops outright — the sb-realtime staging wedge, where
+/// every outbox consumer froze mid-sequence while its listener job kept
+/// heartbeating). With the fix the pump surfaces the gap (`try_recv` +
+/// `NotifyMessage::Resync`) and the caches re-read the tables.
+#[tokio::test]
+#[file_serial]
+async fn delivers_events_notified_while_listen_connection_down() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let outbox = init_outbox::<TestEvent>(
+        &pool,
+        MailboxConfig::builder()
+            .build()
+            .expect("Couldn't build MailboxConfig"),
+    )
+    .await?;
+
+    let mut listener = outbox.listen_persisted(None);
+
+    // Baseline: the pg_notify path works.
+    let mut op = pool.begin().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+        .await?;
+    op.commit().await?;
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(10), listener.next())
+        .await
+        .map_err(|_| anyhow::anyhow!("baseline pg_notify delivery timed out"))?
+        .ok_or_else(|| anyhow::anyhow!("listener stream ended"))?;
+    assert!(matches!(event.payload, Some(TestEvent::Ping(1))));
+
+    // Terminate every LISTEN backend and insert the event in ONE autocommit
+    // statement: the backends die mid-statement and the insert trigger's
+    // NOTIFY fires at that same statement's commit, before any client-side
+    // reconnect round trip can complete — so the notification is
+    // deterministically sent while no LISTEN connection exists. (Publishing
+    // in a separate statement is racy: sqlx's eager reconnect re-LISTENs off
+    // a warm pool connection faster than a second round trip.)
+    sqlx::query(
+        r#"
+        WITH kill AS (
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE pid <> pg_backend_pid() AND query LIKE 'LISTEN%'
+        )
+        INSERT INTO persistent_outbox_events (payload)
+        SELECT $1::jsonb FROM (SELECT count(*) FROM kill) _forced
+        "#,
+    )
+    .bind(r#"{"Ping": 2}"#)
+    .execute(&pool)
+    .await?;
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(10), listener.next())
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "event published while the LISTEN connection was down was never delivered \
+                 (missed notification not resynced)"
+            )
+        })?
+        .ok_or_else(|| anyhow::anyhow!("listener stream ended"))?;
+    assert!(matches!(event.payload, Some(TestEvent::Ping(2))));
+
+    Ok(())
+}

--- a/tests/outbox.rs
+++ b/tests/outbox.rs
@@ -573,7 +573,7 @@ async fn delivers_events_notified_while_listen_connection_down() -> anyhow::Resu
     // NOTIFY fires at that same statement's commit, before any client-side
     // reconnect round trip can complete — so the notification is
     // deterministically sent while no LISTEN connection exists. (Publishing
-    // in a separate statement is racy: sqlx's eager reconnect re-LISTENs off
+    // in a separate statement is racy: sqlx's eager reconnect re-subscribes off
     // a warm pool connection faster than a second round trip.)
     sqlx::query(
         r#"


### PR DESCRIPTION
## Problem

The pg-notify pump has two ways to permanently detach the outbox from its notification stream:

1. **Silent gap** — it consumes via `PgListener::recv()`, which internally reconnects on connection loss and swallows the `Ok(None)` marker that `try_recv()` surfaces. Any notification sent while the connection was down is lost with no resync; consumers stall until the next unrelated notification happens to advance the head.
2. **Hard death** — when the internal reconnect itself fails (e.g. the pool is saturated at that moment), `recv()` returns `Err` and the pump `break`s. `spawn_supervised` only *logs* task exit, so the pump dies for good — and dropping its notification senders makes **both cache loops** observe a closed channel and exit too. From then on even same-process publishes (which short-circuit into `cache_fill`) have no loop left to broadcast them: every consumer stream parks forever while its listener job keeps heartbeating.

**Observed in production shape** (lana-bank staging `sb-realtime`, 2026-07-14): one network blip EOF'd the pod's DB connections. The sqlx pool healed; the outbox never did — every consumer cursor froze at sequence 10869 while producers advanced the head to 10922, killing prospect→customer conversion and all other event-driven flows, with nothing unhealthy visible in job state ('running' listeners, fresh heartbeats). Breadcrumbs in Honeycomb: `obix.pg_listener.recv_error` → `obix.supervisor.task_exited` → `obix.persistent_cache.notification_channel_closed`.

## Fix

**Pump (`pg_notify.rs`)** — never exits while the caches live:
- consume via `try_recv()` so connection loss is visible;
- `Ok(None)` (sqlx already reconnected + re-LISTENed): emit `NotifyMessage::Resync` to both caches;
- `Err`: rebuild the listener with capped backoff (50ms→5s) instead of exiting, then emit `Resync`;
- `Resync` is only sent once LISTEN is active again — anything published before it is covered by the resync head re-read, anything after by regular notifications, so there is no window.

**Caches** — notification channels now carry `NotifyMessage {Notification, Resync}`:
- persistent: on `Resync`, re-read the head sequence from the table (`highest_known_persistent_sequence`); the existing proactive gap fill then pages the missed range in and broadcasting resumes contiguously;
- ephemeral: on `Resync`, reload current per-type state from the table.

New OTEL breadcrumbs: `obix.pg_listener.connection_lost`, `.reconnect_failed`, `.reconnected`, `obix.persistent_cache.resync_failed`.

## Testing

- New integration test `delivers_events_notified_while_listen_connection_down`: terminates every LISTEN backend **and inserts an event in the same autocommit statement**, so the insert trigger's NOTIFY fires deterministically while no listener connection exists (publishing in a separate statement is racy — sqlx's eager reconnect re-LISTENs off a warm pool connection faster than a second round trip). **Fails on `main`** (consumer stalls, 10s timeout) and passes with this change.
- Full suite green (4 inbox + 12 outbox + 4 outbox_event_handler); `cargo clippy --all-features --all-targets` clean; `SQLX_OFFLINE=true cargo check --all-features` (lib, as CI builds it) green; no `.sqlx` changes (no new checked queries).

## Notes

- The retry-black-hole companion issue in the job crate (errored listener-job retries stranded under a frozen manual clock) is separate — this PR removes the failure mode that persists even on realtime clocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core outbox notification and cache recovery paths; a bug could still stall consumers or duplicate/miss events, though behavior is covered by a targeted regression test.
> 
> **Overview**
> Fixes outbox consumers **stalling or dying permanently** when the Postgres `LISTEN` connection drops: notifications sent during the gap were lost and the pump could exit on reconnect failure, killing both cache loops.
> 
> The **pg listener** now uses `try_recv()` so connection loss surfaces as `Ok(None)`, forwards **`NotifyMessage::Resync`** to persistent and ephemeral caches after reconnect, and on hard errors **rebuilds the listener with capped backoff** (50ms→5s) instead of breaking the loop. Initial connect still fails fast at init.
> 
> **Persistent** and **ephemeral** cache loops consume `NotifyMessage` (`Notification` | `Resync`) instead of raw `PgNotification`. On `Resync`, persistent cache refreshes **`highest_known_persistent_sequence`** (existing gap fill catches up); ephemeral cache **reloads events from the table**, skipping stale entries by `recorded_at`. New OTEL hooks cover connection loss, reconnect, and resync failures.
> 
> Adds integration test **`delivers_events_notified_while_listen_connection_down`** that kills LISTEN backends and inserts in one statement so NOTIFY fires with no listener.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec0a1a5f3fd43a5b74873e0b7aa24b4b6de701ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->