### PR TITLE
chore(deps): bump es-entity to 0.11.2 and job to 0.6.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,13 +446,16 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.10.41"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d52128c990c3d4fa2cb357b4a9dedbd9a18bc6f4b09c04c81874a7e4b85e8a"
+checksum = "2e9202fb16f15dd697e20a31b1b7a38772f6e7926014cacd847cdefe2f2ce214"
 dependencies = [
+ "async-stream",
  "chrono",
  "derive_builder",
  "es-entity-macros",
+ "futures-core",
+ "futures-util",
  "im",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -448,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.10.41"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c9e15612548ff642ede03c81262d541e89392d71d86a6855c2ef2104bcb079"
+checksum = "c0c32fdc62f4087581040d26a88e6708c0c754761b7509709ab13b7f4cff112d"
 dependencies = [
  "convert_case",
  "darling 0.23.0",
@@ -932,9 +957,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.28"
+version = "0.6.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518512c0122e327140301d066e994339ce74cbbff0d33be40d0292d0c1b57d94"
+checksum = "87168d8fdabbc2b5a57d63470040134da6ae9135140af92e03ee494e277475e2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ obix-macros = { path = "obix-macros", version = "0.2.31-dev" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-es-entity = "0.10.41"
+es-entity = "0.11.2"
 anyhow = "1.0"
 tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
@@ -64,7 +64,7 @@ chrono = { version = "0.4", features = ["clock", "serde"], default-features = fa
 tracing = { version = "0.1" }
 futures = "0.3"
 im = { version = "15.1", features = ["serde"] }
-job = "0.6.28"
+job = "0.6.30"
 thiserror = "2.0"
 async-trait = "0.1"
 derive_builder = "0.20"


### PR DESCRIPTION
Unifies es-entity across obix and job (0.11.2) - picks up OTel trace-context SQL annotation. Previously blocked by the dual-version constraint (see #77); job 0.6.30 now ships es-entity 0.11.2.

Release chain: es-entity 0.11.2 -> job 0.6.30 -> obix -> cala -> lana-bank

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> No obix source changes, but upgrades core persistence/job dependencies; es-entity 0.11.x may change SQL/OTel behavior at runtime compared to 0.10.x.
> 
> **Overview**
> Bumps workspace **`es-entity`** from **0.10.41** to **0.11.2** and **`job`** from **0.6.28** to **0.6.30**, with matching **`Cargo.lock`** updates (including new transitive crates such as **`async-stream`** pulled in by es-entity).
> 
> This aligns **obix** and **job** on a single es-entity version so the stack can use **OpenTelemetry trace-context SQL annotation** from 0.11.x; **job** 0.6.30 is the release that depends on es-entity 0.11.2, resolving the prior dual-version constraint noted in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccdaabf545c2b20007cbfa2db24a9cfdaf07d958. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->