### PR TITLE
feat(outbox): batch listener checkpoints in event-handler jobs

### DIFF
--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::sync::Arc;
 
@@ -34,10 +34,15 @@ where
     }
 }
 
+const DEFAULT_BATCH_SIZE: usize = 100;
+const DEFAULT_BATCH_FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
+
 #[derive(Clone)]
 pub struct OutboxEventJobConfig {
     pub job_type: JobType,
     pub retry_settings: RetrySettings,
+    pub batch_size: usize,
+    pub batch_flush_timeout: std::time::Duration,
 }
 
 impl OutboxEventJobConfig {
@@ -45,11 +50,28 @@ impl OutboxEventJobConfig {
         Self {
             job_type,
             retry_settings: RetrySettings::repeat_indefinitely(),
+            batch_size: DEFAULT_BATCH_SIZE,
+            batch_flush_timeout: DEFAULT_BATCH_FLUSH_TIMEOUT,
         }
     }
 
     pub fn with_retry_settings(mut self, settings: RetrySettings) -> Self {
         self.retry_settings = settings;
+        self
+    }
+
+    /// Maximum number of persistent events handled per transaction /
+    /// checkpoint. `1` preserves the legacy one-transaction-per-event
+    /// behavior.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size.max(1);
+        self
+    }
+
+    /// Upper bound on how long a partially filled batch stays open before
+    /// being committed.
+    pub fn with_batch_flush_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.batch_flush_timeout = timeout;
         self
     }
 }
@@ -72,6 +94,8 @@ where
     handler: Arc<H>,
     job_type: JobType,
     retry_settings: RetrySettings,
+    batch_size: usize,
+    batch_flush_timeout: std::time::Duration,
 }
 
 impl<H, P, Tables> OutboxEventJobInitializer<H, P, Tables>
@@ -86,6 +110,8 @@ where
             handler: Arc::new(handler),
             job_type: config.job_type.clone(),
             retry_settings: config.retry_settings.clone(),
+            batch_size: config.batch_size,
+            batch_flush_timeout: config.batch_flush_timeout,
         }
     }
 }
@@ -114,6 +140,8 @@ where
         Ok(Box::new(OutboxEventJobRunner::<H, P, Tables> {
             outbox: self.outbox.clone(),
             handler: self.handler.clone(),
+            batch_size: self.batch_size,
+            batch_flush_timeout: self.batch_flush_timeout,
         }))
     }
 }
@@ -126,6 +154,8 @@ where
 {
     outbox: Outbox<P, Tables>,
     handler: Arc<H>,
+    batch_size: usize,
+    batch_flush_timeout: std::time::Duration,
 }
 
 #[async_trait]
@@ -144,34 +174,111 @@ where
             .unwrap_or_default();
 
         let mut stream = self.outbox.listen_all(Some(state.sequence));
+        let mut batch: Vec<Arc<PersistentOutboxEvent<P>>> = Vec::with_capacity(self.batch_size);
 
         loop {
-            tokio::select! {
+            let first = tokio::select! {
                 biased;
                 _ = current_job.shutdown_requested() => {
                     return Ok(JobCompletion::RescheduleNow);
                 }
-                event = stream.next() => {
-                    match event {
-                        Some(OutboxEvent::Persistent(e)) => {
-                            let mut op = es_entity::DbOp::init_with_clock(
-                                current_job.pool(),
-                                current_job.clock(),
-                            ).await?;
-                            self.handler.handle_persistent(&mut op, &e).await
-                                .map_err(|e| e as Box<dyn std::error::Error>)?;
-                            state.sequence = e.sequence;
-                            current_job.update_execution_state_in_op(&mut op, &state).await?;
-                            op.commit().await?;
-                        }
-                        Some(OutboxEvent::Ephemeral(e)) => {
-                            self.handler.handle_ephemeral(&e).await
-                                .map_err(|e| e as Box<dyn std::error::Error>)?;
-                        }
-                        None => return Ok(JobCompletion::RescheduleNow),
+                event = stream.next() => event,
+            };
+
+            match first {
+                Some(OutboxEvent::Persistent(e)) => batch.push(e),
+                Some(OutboxEvent::Ephemeral(e)) => {
+                    self.handler
+                        .handle_ephemeral(&e)
+                        .await
+                        .map_err(|e| e as Box<dyn std::error::Error>)?;
+                    continue;
+                }
+                None => return Ok(JobCompletion::RescheduleNow),
+            }
+
+            // Drain ready events into the batch without blocking. Flush when
+            // the batch is full, the stream goes pending (idle streams never
+            // wait for a full batch), or the flush timeout caps the batch
+            // lifetime under a continuous feed.
+            let batch_start = tokio::time::Instant::now();
+            let mut flush_reason = "batch_full";
+            let mut stream_closed = false;
+            while batch.len() < self.batch_size {
+                if batch_start.elapsed() >= self.batch_flush_timeout {
+                    flush_reason = "flush_timeout";
+                    break;
+                }
+                match stream.next().now_or_never() {
+                    Some(Some(OutboxEvent::Persistent(e))) => batch.push(e),
+                    Some(Some(OutboxEvent::Ephemeral(e))) => {
+                        self.handler
+                            .handle_ephemeral(&e)
+                            .await
+                            .map_err(|e| e as Box<dyn std::error::Error>)?;
+                    }
+                    Some(None) => {
+                        flush_reason = "stream_closed";
+                        stream_closed = true;
+                        break;
+                    }
+                    None => {
+                        flush_reason = "stream_pending";
+                        break;
                     }
                 }
             }
+
+            self.process_batch(&mut current_job, &mut state, &mut batch, flush_reason)
+                .await?;
+
+            if stream_closed {
+                return Ok(JobCompletion::RescheduleNow);
+            }
         }
+    }
+}
+
+impl<H, P, Tables> OutboxEventJobRunner<H, P, Tables>
+where
+    H: OutboxEventHandler<P>,
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+    Tables: MailboxTables,
+{
+    /// Handle all buffered events and checkpoint once, in a single op. On
+    /// handler error the op is dropped (rolled back); the job retry replays
+    /// the whole batch from the last committed checkpoint.
+    #[tracing::instrument(
+        name = "outbox.process_batch",
+        skip(self, current_job, state, batch),
+        fields(
+            batch_size = batch.len() as u64,
+            first_seq = batch.first().map(|e| u64::from(e.sequence)),
+            last_seq = batch.last().map(|e| u64::from(e.sequence)),
+            flush_reason = flush_reason,
+        ),
+        err
+    )]
+    async fn process_batch(
+        &self,
+        current_job: &mut CurrentJob,
+        state: &mut OutboxEventJobState,
+        batch: &mut Vec<Arc<PersistentOutboxEvent<P>>>,
+        flush_reason: &'static str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut op =
+            es_entity::DbOp::init_with_clock(current_job.pool(), current_job.clock()).await?;
+        for event in batch.drain(..) {
+            self.handler
+                .handle_persistent(&mut op, &event)
+                .await
+                .map_err(|e| e as Box<dyn std::error::Error>)?;
+            state.sequence = event.sequence;
+        }
+        current_job
+            .update_execution_state_in_op(&mut op, state)
+            .await?;
+        op.commit().await?;
+        Ok(())
     }
 }

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -211,13 +211,8 @@ where
             let mut shutdown = false;
             let mut pending_ephemeral = None;
             while batch.len() < self.batch_size {
-                let remaining = self
-                    .batch_flush_timeout
-                    .saturating_sub(batch_start.elapsed());
-                if remaining.is_zero() {
-                    flush_reason = "flush_timeout";
-                    break;
-                }
+                // Drain immediately ready events first so a zero flush
+                // timeout still coalesces everything already buffered.
                 match stream.next().now_or_never() {
                     Some(Some(OutboxEvent::Persistent(e))) => {
                         batch.push(e);
@@ -234,6 +229,13 @@ where
                         break;
                     }
                     None => {}
+                }
+                let remaining = self
+                    .batch_flush_timeout
+                    .saturating_sub(batch_start.elapsed());
+                if remaining.is_zero() {
+                    flush_reason = "flush_timeout";
+                    break;
                 }
                 tokio::select! {
                     biased;
@@ -264,15 +266,23 @@ where
                 }
             }
 
-            self.process_batch(&mut current_job, &mut state, &mut batch, flush_reason)
-                .await?;
+            let batch_result = self
+                .process_batch(&mut current_job, &mut state, &mut batch, flush_reason)
+                .await;
 
+            // Handle the interleaved ephemeral even if the batch failed:
+            // ephemerals are a best-effort broadcast with no replay of their
+            // own, so dropping it behind a batch error could lose it. On
+            // batch failure it is handled ahead of the replayed persistents
+            // — acceptable, since ephemerals carry no durable ordering.
             if let Some(e) = pending_ephemeral {
                 self.handler
                     .handle_ephemeral(&e)
                     .await
                     .map_err(|e| e as Box<dyn std::error::Error>)?;
             }
+
+            batch_result.map_err(|e| -> Box<dyn std::error::Error> { e })?;
 
             if stream_closed || shutdown {
                 return Ok(JobCompletion::RescheduleNow);
@@ -307,14 +317,11 @@ where
         state: &mut OutboxEventJobState,
         batch: &mut Vec<Arc<PersistentOutboxEvent<P>>>,
         flush_reason: &'static str,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let mut op =
             es_entity::DbOp::init_with_clock(current_job.pool(), current_job.clock()).await?;
         for event in batch.drain(..) {
-            self.handler
-                .handle_persistent(&mut op, &event)
-                .await
-                .map_err(|e| e as Box<dyn std::error::Error>)?;
+            self.handler.handle_persistent(&mut op, &event).await?;
             state.sequence = event.sequence;
         }
         current_job

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -62,14 +62,16 @@ impl OutboxEventJobConfig {
 
     /// Maximum number of persistent events handled per transaction /
     /// checkpoint. `1` preserves the legacy one-transaction-per-event
-    /// behavior.
+    /// behavior (and never waits to fill a batch).
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size.max(1);
         self
     }
 
-    /// Upper bound on how long a partially filled batch stays open before
-    /// being committed.
+    /// How long a partially filled batch stays open collecting events
+    /// before being committed. Bounds the added processing latency of a
+    /// single event on an idle stream. `Duration::ZERO` restores
+    /// flush-on-pending behavior (no coalescing wait).
     pub fn with_batch_flush_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.batch_flush_timeout = timeout;
         self
@@ -197,34 +199,67 @@ where
                 None => return Ok(JobCompletion::RescheduleNow),
             }
 
-            // Drain ready events into the batch without blocking. Flush when
-            // the batch is full, the stream goes pending (idle streams never
-            // wait for a full batch), or the flush timeout caps the batch
-            // lifetime under a continuous feed.
+            // Fill the batch: drain ready events, then keep the batch open
+            // for the remainder of batch_flush_timeout to coalesce a
+            // continuous feed. Flush when the batch is full, the timeout
+            // expires, an ephemeral arrives (handled after the commit so
+            // stream order is preserved), the stream closes, or shutdown is
+            // requested.
             let batch_start = tokio::time::Instant::now();
             let mut flush_reason = "batch_full";
             let mut stream_closed = false;
+            let mut shutdown = false;
+            let mut pending_ephemeral = None;
             while batch.len() < self.batch_size {
-                if batch_start.elapsed() >= self.batch_flush_timeout {
+                let remaining = self
+                    .batch_flush_timeout
+                    .saturating_sub(batch_start.elapsed());
+                if remaining.is_zero() {
                     flush_reason = "flush_timeout";
                     break;
                 }
                 match stream.next().now_or_never() {
-                    Some(Some(OutboxEvent::Persistent(e))) => batch.push(e),
+                    Some(Some(OutboxEvent::Persistent(e))) => {
+                        batch.push(e);
+                        continue;
+                    }
                     Some(Some(OutboxEvent::Ephemeral(e))) => {
-                        self.handler
-                            .handle_ephemeral(&e)
-                            .await
-                            .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        flush_reason = "ephemeral";
+                        pending_ephemeral = Some(e);
+                        break;
                     }
                     Some(None) => {
                         flush_reason = "stream_closed";
                         stream_closed = true;
                         break;
                     }
-                    None => {
-                        flush_reason = "stream_pending";
+                    None => {}
+                }
+                tokio::select! {
+                    biased;
+                    _ = current_job.shutdown_requested() => {
+                        flush_reason = "shutdown";
+                        shutdown = true;
                         break;
+                    }
+                    _ = tokio::time::sleep(remaining) => {
+                        flush_reason = "flush_timeout";
+                        break;
+                    }
+                    event = stream.next() => {
+                        match event {
+                            Some(OutboxEvent::Persistent(e)) => batch.push(e),
+                            Some(OutboxEvent::Ephemeral(e)) => {
+                                flush_reason = "ephemeral";
+                                pending_ephemeral = Some(e);
+                                break;
+                            }
+                            None => {
+                                flush_reason = "stream_closed";
+                                stream_closed = true;
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -232,7 +267,14 @@ where
             self.process_batch(&mut current_job, &mut state, &mut batch, flush_reason)
                 .await?;
 
-            if stream_closed {
+            if let Some(e) = pending_ephemeral {
+                self.handler
+                    .handle_ephemeral(&e)
+                    .await
+                    .map_err(|e| e as Box<dyn std::error::Error>)?;
+            }
+
+            if stream_closed || shutdown {
                 return Ok(JobCompletion::RescheduleNow);
             }
         }

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -637,14 +637,116 @@ async fn single_event_flushed_promptly_at_low_traffic() -> anyhow::Result<()> {
         .await?;
     op.commit().await?;
 
-    // An idle listener must not wait for a full batch: the event is flushed
-    // as soon as the stream goes pending (well under any batch-size wait).
+    // An idle listener must not wait for a full batch: the event is
+    // handled within ~batch_flush_timeout (default 100ms).
     wait_for_n_deliveries(&received, 1, std::time::Duration::from_secs(2)).await?;
     let latency = published_at.elapsed();
     assert!(
         latency < std::time::Duration::from_secs(2),
         "single event took {latency:?} to be handled"
     );
+
+    Ok(())
+}
+
+#[derive(Debug, PartialEq)]
+enum Handled {
+    Persistent(u64),
+    Ephemeral(u64),
+}
+
+struct OrderRecordingHandler {
+    log: Arc<Mutex<Vec<Handled>>>,
+}
+
+impl OutboxEventHandler<TestEvent> for OrderRecordingHandler {
+    async fn handle_persistent(
+        &self,
+        _op: &mut es_entity::DbOp<'_>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(TestEvent::Ping(n)) = &event.payload {
+            self.log.lock().await.push(Handled::Persistent(*n));
+        }
+        Ok(())
+    }
+
+    async fn handle_ephemeral(
+        &self,
+        event: &obix::out::EphemeralOutboxEvent<TestEvent>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let TestEvent::Ping(n) = &event.payload;
+        self.log.lock().await.push(Handled::Ephemeral(*n));
+        Ok(())
+    }
+}
+
+#[tokio::test]
+#[file_serial]
+async fn ephemeral_arriving_mid_batch_is_handled_after_buffered_persistents() -> anyhow::Result<()>
+{
+    let pool = init_pool().await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let outbox =
+        init_outbox_with_handler(&pool, &mut jobs, OrderRecordingHandler { log: log.clone() })
+            .await?;
+
+    jobs.start_poll().await?;
+
+    // Let the job start and go idle.
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    // Publish persistent, then ephemeral, then persistent in quick
+    // succession so the ephemeral arrives while the first persistent's
+    // batch is still open.
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+        .await?;
+    op.commit().await?;
+
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    outbox
+        .publish_ephemeral(
+            obix::out::EphemeralEventType::new("ordering_test"),
+            TestEvent::Ping(9),
+        )
+        .await?;
+
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(2))
+        .await?;
+    op.commit().await?;
+
+    // Ephemeral delivery is at-least-once; wait until the second
+    // persistent has been handled.
+    let start = std::time::Instant::now();
+    loop {
+        if log.lock().await.contains(&Handled::Persistent(2)) {
+            break;
+        }
+        if start.elapsed() > std::time::Duration::from_secs(5) {
+            anyhow::bail!("Timeout waiting for all events");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    // Stream order is preserved: the first delivery of the ephemeral
+    // happens only after the persistent buffered ahead of it has been
+    // handled, and before the persistent published after it.
+    let log = log.lock().await;
+    let pos = |h: &Handled| log.iter().position(|e| e == h).unwrap();
+    assert!(pos(&Handled::Persistent(1)) < pos(&Handled::Ephemeral(9)));
+    assert!(pos(&Handled::Ephemeral(9)) < pos(&Handled::Persistent(2)));
 
     Ok(())
 }

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -813,3 +813,139 @@ async fn batch_size_one_preserves_legacy_per_event_semantics() -> anyhow::Result
 
     Ok(())
 }
+
+#[tokio::test]
+#[file_serial]
+async fn zero_flush_timeout_still_batches_ready_events() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let deliveries = Arc::new(Mutex::new(Vec::new()));
+    let config = OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE))
+        .with_retry_settings(fast_retry_settings())
+        .with_batch_flush_timeout(std::time::Duration::ZERO);
+    let outbox = init_outbox_with_handler_config(
+        &pool,
+        &mut jobs,
+        config,
+        BatchEffectHandler {
+            deliveries: deliveries.clone(),
+            fail_on_first: Some(2),
+            failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        },
+    )
+    .await?;
+
+    // Publish before the job starts so all events are buffered and must be
+    // drained into one batch without any coalescing wait.
+    const N: u64 = 5;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    let start = std::time::Instant::now();
+    loop {
+        if batch_effect_rows(&pool).await?.len() == N as usize {
+            break;
+        }
+        if start.elapsed() > std::time::Duration::from_secs(10) {
+            anyhow::bail!("Timeout waiting for all batch effects to commit");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    // Event 1 replayed => the zero-timeout drain still formed a multi-event
+    // batch (single-event batches would never redeliver event 1).
+    let deliveries = deliveries.lock().await;
+    let event_1_deliveries = deliveries.iter().filter(|&&n| n == 1).count();
+    assert!(
+        event_1_deliveries >= 2,
+        "expected ready events to be coalesced with zero timeout, deliveries: {deliveries:?}"
+    );
+    assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3, 4, 5]);
+
+    Ok(())
+}
+
+struct AlwaysFailPersistentWithEphemeralHandler {
+    ephemeral_received: Arc<Mutex<Vec<u64>>>,
+}
+
+impl OutboxEventHandler<TestEvent> for AlwaysFailPersistentWithEphemeralHandler {
+    async fn handle_persistent(
+        &self,
+        _op: &mut es_entity::DbOp<'_>,
+        _event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Err("persistent always fails".into())
+    }
+
+    async fn handle_ephemeral(
+        &self,
+        event: &obix::out::EphemeralOutboxEvent<TestEvent>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let TestEvent::Ping(n) = &event.payload;
+        self.ephemeral_received.lock().await.push(*n);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+#[file_serial]
+async fn ephemeral_is_handled_even_when_batch_fails() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let ephemeral_received = Arc::new(Mutex::new(Vec::new()));
+    let config = OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE))
+        .with_retry_settings(fast_retry_settings());
+    let outbox = init_outbox_with_handler_config(
+        &pool,
+        &mut jobs,
+        config,
+        AlwaysFailPersistentWithEphemeralHandler {
+            ephemeral_received: ephemeral_received.clone(),
+        },
+    )
+    .await?;
+
+    // Both buffered before the job starts: the ephemeral is drained into
+    // pending_ephemeral while the persistent batch is open, and the batch
+    // then fails.
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+        .await?;
+    op.commit().await?;
+    outbox
+        .publish_ephemeral(
+            obix::out::EphemeralEventType::new("batch_failure_test"),
+            TestEvent::Ping(9),
+        )
+        .await?;
+
+    jobs.start_poll().await?;
+
+    // The ephemeral must be handled even though the persistent batch never
+    // commits.
+    wait_for_n_deliveries(&ephemeral_received, 1, std::time::Duration::from_secs(5)).await?;
+
+    Ok(())
+}

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -80,6 +80,21 @@ async fn init_outbox_with_handler<H: OutboxEventHandler<TestEvent>>(
     jobs: &mut job::Jobs,
     handler: H,
 ) -> anyhow::Result<Outbox<TestEvent, TestTables>> {
+    init_outbox_with_handler_config(
+        pool,
+        jobs,
+        OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE)),
+        handler,
+    )
+    .await
+}
+
+async fn init_outbox_with_handler_config<H: OutboxEventHandler<TestEvent>>(
+    pool: &sqlx::PgPool,
+    jobs: &mut job::Jobs,
+    config: OutboxEventJobConfig,
+    handler: H,
+) -> anyhow::Result<Outbox<TestEvent, TestTables>> {
     wipeout_outbox_tables(pool).await?;
     wipeout_outbox_job_tables(pool, JOB_TYPE).await?;
 
@@ -92,15 +107,93 @@ async fn init_outbox_with_handler<H: OutboxEventHandler<TestEvent>>(
     .await?;
 
     outbox
-        .register_event_handler(
-            jobs,
-            OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE)),
-            handler,
-        )
+        .register_event_handler(jobs, config, handler)
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     Ok(outbox)
+}
+
+fn fast_retry_settings() -> job::RetrySettings {
+    let mut settings = job::RetrySettings::repeat_indefinitely();
+    settings.min_backoff = std::time::Duration::from_millis(50);
+    settings.max_backoff = std::time::Duration::from_millis(100);
+    settings.backoff_jitter_pct = 0;
+    settings
+}
+
+async fn wait_for_n_deliveries(
+    received: &Mutex<Vec<u64>>,
+    n: usize,
+    timeout: std::time::Duration,
+) -> anyhow::Result<()> {
+    let start = std::time::Instant::now();
+    loop {
+        if received.lock().await.len() >= n {
+            return Ok(());
+        }
+        if start.elapsed() > timeout {
+            anyhow::bail!("Timeout waiting for {n} deliveries");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+}
+
+async fn checkpoint_sequence(pool: &sqlx::PgPool) -> anyhow::Result<Option<i64>> {
+    let row: Option<(serde_json::Value,)> = sqlx::query_as(
+        "SELECT je.execution_state_json FROM job_executions je \
+         JOIN jobs j ON j.id = je.id WHERE j.job_type = $1",
+    )
+    .bind(JOB_TYPE)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.and_then(|(json,)| json.get("sequence").and_then(|s| s.as_i64())))
+}
+
+struct BatchEffectHandler {
+    deliveries: Arc<Mutex<Vec<u64>>>,
+    fail_on_first: Option<u64>,
+    failed: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl OutboxEventHandler<TestEvent> for BatchEffectHandler {
+    async fn handle_persistent(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use es_entity::AtomicOperation;
+        if let Some(TestEvent::Ping(n)) = &event.payload {
+            self.deliveries.lock().await.push(*n);
+            if self.fail_on_first == Some(*n)
+                && !self.failed.swap(true, std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err("injected mid-batch failure".into());
+            }
+            sqlx::query("INSERT INTO test_batch_effects (n) VALUES ($1)")
+                .bind(*n as i64)
+                .execute(op.as_executor())
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+async fn reset_batch_effects_table(pool: &sqlx::PgPool) -> anyhow::Result<()> {
+    sqlx::query("DROP TABLE IF EXISTS test_batch_effects")
+        .execute(pool)
+        .await?;
+    sqlx::query("CREATE TABLE test_batch_effects (n BIGINT PRIMARY KEY)")
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+async fn batch_effect_rows(pool: &sqlx::PgPool) -> anyhow::Result<Vec<i64>> {
+    let rows: Vec<(i64,)> = sqlx::query_as("SELECT n FROM test_batch_effects ORDER BY n")
+        .fetch_all(pool)
+        .await?;
+    Ok(rows.into_iter().map(|(n,)| n).collect())
 }
 
 #[tokio::test]
@@ -372,6 +465,249 @@ async fn handler_receives_both_persistent_and_ephemeral() -> anyhow::Result<()> 
         }
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn batched_handler_processes_all_events_and_checkpoints_last_sequence() -> anyhow::Result<()>
+{
+    let pool = init_pool().await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let outbox = init_outbox_with_handler(
+        &pool,
+        &mut jobs,
+        TestPersistentHandler {
+            received: received.clone(),
+        },
+    )
+    .await?;
+
+    // Publish all events before the job starts so they are buffered and
+    // drained into batches.
+    const N: u64 = 50;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    wait_for_n_deliveries(&received, N as usize, std::time::Duration::from_secs(10)).await?;
+
+    let events = received.lock().await;
+    assert_eq!(*events, (1..=N).collect::<Vec<_>>());
+    drop(events);
+
+    // The checkpoint eventually reflects the last event's sequence.
+    let last_sequence: i64 =
+        sqlx::query_scalar("SELECT MAX(sequence) FROM persistent_outbox_events")
+            .fetch_one(&pool)
+            .await?;
+    wait_for_checkpoint(&pool, last_sequence).await?;
+
+    Ok(())
+}
+
+async fn wait_for_checkpoint(pool: &sqlx::PgPool, expected: i64) -> anyhow::Result<()> {
+    let start = std::time::Instant::now();
+    loop {
+        if checkpoint_sequence(pool).await? == Some(expected) {
+            return Ok(());
+        }
+        if start.elapsed() > std::time::Duration::from_secs(5) {
+            anyhow::bail!(
+                "Timeout waiting for checkpoint to reach {expected}, at {:?}",
+                checkpoint_sequence(pool).await?
+            );
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test]
+#[file_serial]
+async fn mid_batch_handler_error_replays_batch_exactly_once() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let deliveries = Arc::new(Mutex::new(Vec::new()));
+    let config = OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE))
+        .with_retry_settings(fast_retry_settings());
+    let outbox = init_outbox_with_handler_config(
+        &pool,
+        &mut jobs,
+        config,
+        BatchEffectHandler {
+            deliveries: deliveries.clone(),
+            fail_on_first: Some(2),
+            failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        },
+    )
+    .await?;
+
+    // Publish before the job starts so events land in a single batch.
+    const N: u64 = 5;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    // First batch attempt: event 1 handled, event 2 fails -> whole batch
+    // rolls back. Retry replays the entire batch; this time it succeeds.
+    let start = std::time::Instant::now();
+    loop {
+        if batch_effect_rows(&pool).await?.len() == N as usize {
+            break;
+        }
+        if start.elapsed() > std::time::Duration::from_secs(10) {
+            anyhow::bail!("Timeout waiting for all batch effects to commit");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    // Exactly-once DB effects despite the replay.
+    assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3, 4, 5]);
+
+    // Event 1 was delivered again on replay — proof the checkpoint is
+    // per-batch, not per-event (legacy per-event checkpointing would never
+    // redeliver event 1).
+    let deliveries = deliveries.lock().await;
+    let event_1_deliveries = deliveries.iter().filter(|&&n| n == 1).count();
+    assert!(
+        event_1_deliveries >= 2,
+        "expected event 1 to be replayed with the batch, deliveries: {deliveries:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn single_event_flushed_promptly_at_low_traffic() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let outbox = init_outbox_with_handler(
+        &pool,
+        &mut jobs,
+        TestPersistentHandler {
+            received: received.clone(),
+        },
+    )
+    .await?;
+
+    jobs.start_poll().await?;
+
+    // Let the job start and go idle.
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let published_at = std::time::Instant::now();
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+        .await?;
+    op.commit().await?;
+
+    // An idle listener must not wait for a full batch: the event is flushed
+    // as soon as the stream goes pending (well under any batch-size wait).
+    wait_for_n_deliveries(&received, 1, std::time::Duration::from_secs(2)).await?;
+    let latency = published_at.elapsed();
+    assert!(
+        latency < std::time::Duration::from_secs(2),
+        "single event took {latency:?} to be handled"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn batch_size_one_preserves_legacy_per_event_semantics() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let deliveries = Arc::new(Mutex::new(Vec::new()));
+    let config = OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE))
+        .with_retry_settings(fast_retry_settings())
+        .with_batch_size(1);
+    let outbox = init_outbox_with_handler_config(
+        &pool,
+        &mut jobs,
+        config,
+        BatchEffectHandler {
+            deliveries: deliveries.clone(),
+            fail_on_first: Some(2),
+            failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        },
+    )
+    .await?;
+
+    const N: u64 = 3;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    let start = std::time::Instant::now();
+    loop {
+        if batch_effect_rows(&pool).await?.len() == N as usize {
+            break;
+        }
+        if start.elapsed() > std::time::Duration::from_secs(10) {
+            anyhow::bail!("Timeout waiting for all effects to commit");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    // Legacy semantics: event 1 committed in its own transaction before the
+    // failure on event 2, so it is never redelivered.
+    let deliveries = deliveries.lock().await;
+    let event_1_deliveries = deliveries.iter().filter(|&&n| n == 1).count();
+    assert_eq!(
+        event_1_deliveries, 1,
+        "with batch_size(1) event 1 must not be replayed, deliveries: {deliveries:?}"
+    );
+    assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3]);
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

Under a 1 loan/sec stress-test sandbox, `UPDATE job_executions SET execution_state_json` was the #1 steady-state DB statement: **~250 calls/sec** (195k calls / 13 min), ~22% of all DB time, accompanied by ~300 BEGIN/sec and ~267 COMMIT/sec. Source: 32 concurrently running `outbox.*` listener jobs, each checkpointing **once per persistent event** — one `DbOp` (BEGIN → handler → checkpoint UPDATE → COMMIT) per event.

## Change

`OutboxEventJobRunner` now accumulates up to `batch_size` (default **100**) ready persistent events, runs all handlers in sequence order inside a **single `DbOp`**, checkpoints once at the batch's highest sequence, and commits once:

- **Flush triggers**: batch full, stream goes pending (idle listeners never wait for a full batch — no added low-traffic latency), or `batch_flush_timeout` (default **100ms**) capping batch lifetime under a continuous feed.
- **Ephemeral events** are still handled inline as they arrive, never buffered behind a persistent batch.
- **Error semantics**: a mid-batch handler error rolls back the whole op; the job retry replays the batch from the last committed checkpoint. In-op DB effects stay exactly-once at batch granularity.
- **Config**: `OutboxEventJobConfig::with_batch_size` / `with_batch_flush_timeout`. `batch_size(1)` restores exact legacy per-event semantics. Existing `register_event_handler` callers need no changes.
- **Observability**: `outbox.process_batch` tracing span with `batch_size`, `first_seq`, `last_seq`, `flush_reason`.

## Tests

- `batched_handler_processes_all_events_and_checkpoints_last_sequence` — 50 events drained in batches, checkpoint lands on the last sequence.
- `mid_batch_handler_error_replays_batch_exactly_once` — injected failure on event 2 of 5: whole batch rolls back, replay redelivers event 1 (proves per-batch checkpointing), DB effects land exactly once.
- `single_event_flushed_promptly_at_low_traffic` — idle-stream flush bound.
- `batch_size_one_preserves_legacy_per_event_semantics` — with `batch_size(1)`, event 1 commits before a failure on event 2 and is never redelivered.

Full suite: 30/30 green (`cargo nextest run`), clippy clean.

## Consumer audit (lana-bank)

Audited all 32 `register_event_handler` call sites (17 files) at lana-bank `main`: every handler is batch-safe — external side effects (keycloak, sumsub, SMTP, webhooks) all go through jobs spawned **in-op**; remaining handlers do in-op DB writes, read-only lookups, or idempotent entity commands (`idempotency_guard!`) that tolerate mid-batch replay. Notable: `core/deposit` settlement handler's `confirm/cancel/revert_withdrawal` commit in their own transactions but are idempotent-guarded.

## Follow-ups (not in this PR)

- Release obix, then bump the pin in lana-bank (`Cargo.toml` workspace dep + `Cargo.lock`).
- Verify under stress-test: checkpoint statement should drop ≥50× and fall out of the pg_stat_statements top-10.

Ref: task brief `handoffs/2026-07-22-obix-checkpoint-batching.md` (throughput limiter #2 from the `sb-strtest3` stress-test investigation).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes durable processing semantics to per-batch checkpointing (handlers may see replay of an entire batch on failure); default behavior shifts without caller changes, though consumers must be batch-safe for in-op side effects.
> 
> **Overview**
> **Outbox event-handler jobs** no longer open one DB transaction per persistent event. They buffer up to **100** events (configurable), run handlers in order inside a **single `DbOp`**, and advance the job checkpoint **once** per batch—aimed at cutting steady-state `job_executions` checkpoint traffic.
> 
> **`OutboxEventJobConfig`** gains `with_batch_size` and `with_batch_flush_timeout` (defaults 100 / 100ms). `batch_size(1)` keeps legacy per-event commits; zero flush timeout still coalesces already-buffered ready events without a timed wait.
> 
> The runner flushes on batch full, flush timeout, shutdown, stream close, or an **ephemeral** interrupting an open batch (ephemeral handled after the batch commit, or even when the batch fails, so it is not dropped). Mid-batch handler errors roll back the whole batch; retries replay from the last committed sequence. **`outbox.process_batch`** tracing records batch size, sequence range, and flush reason.
> 
> Integration tests cover large batches, mid-batch failure/replay, low-traffic latency, ephemeral ordering, `batch_size(1)` legacy behavior, zero-timeout coalescing, and ephemerals when persistents fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60215084a2c0aae741694c777f803b0a51fdc54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->