### PR TITLE
feat(outbox)!: handler-controlled transaction scoping for event-handler jobs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ pub use inbox::{
     InboxIdempotencyKey, InboxResult,
 };
 pub use obix_macros::{MailboxTables, OutboxEvent};
-pub use out::{CursorError, OpCursor, Outbox, OutboxEventHandler, OutboxEventJobConfig};
+pub use out::{
+    BatchOp, CursorError, EventCtx, Handled, IsolatedOp, OpCursor, Outbox, OutboxEventHandler,
+    OutboxEventJobConfig,
+};
 pub use sequence::EventSequence;
 pub use tables::MailboxTables;

--- a/src/out/ctx.rs
+++ b/src/out/ctx.rs
@@ -1,0 +1,297 @@
+//! Handler-controlled transaction scoping for outbox event-handler jobs.
+//!
+//! Every persistent event delivered to an
+//! [`OutboxEventHandler`](super::OutboxEventHandler) comes with an
+//! [`EventCtx`] that the handler must resolve into a [`Handled`] token by
+//! choosing exactly one of three entry verbs:
+//!
+//! | verb | meaning | cost |
+//! |------|---------|------|
+//! | [`EventCtx::skip`] | not my event | zero — no transaction is opened |
+//! | [`EventCtx::consume_in_batch`] | do work joined to the pending batch op | shares one transaction (and one checkpoint) with neighboring events |
+//! | [`EventCtx::consume_isolated`] | land the pending batch first, then do my work in a fresh op | my event is its own atomic unit, fenced from history |
+//!
+//! and — when work was done — one of two exit verbs:
+//!
+//! | verb | meaning |
+//! |------|---------|
+//! | [`BatchOp::commit`] / [`IsolatedOp::commit`] | land the op (work + checkpoint, atomically) when the invocation returns |
+//! | [`BatchOp::defer`] | leave the op open so subsequent events can coalesce into it |
+//!
+//! A deferred op is only ever open while there is ready backlog: the runner
+//! never awaits the stream while a transaction is open, so a pending stream
+//! is itself a flush trigger. Batching therefore rides bursts that already
+//! happened and adds no latency at low traffic.
+//!
+//! Every flush — whichever of the triggers fires — runs
+//! [`on_flush`](super::OutboxEventHandler::on_flush), then persists the
+//! checkpoint at the last *fully handled* sequence (skips included), then
+//! commits: work and pointer are inseparable.
+
+use serde::{Deserialize, Serialize};
+
+use job::CurrentJob;
+
+use crate::sequence::EventSequence;
+
+/// Error type shared with the handler trait methods.
+pub(crate) type HandlerError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Type-erased [`on_flush`](super::OutboxEventHandler::on_flush) callback so
+/// that [`EventCtx::consume_isolated`] can flush the pending batch from
+/// within a handler invocation.
+pub(crate) type FlushHook = Box<
+    dyn for<'a> Fn(
+            &'a mut es_entity::DbOp<'static>,
+        ) -> futures::future::BoxFuture<'a, Result<(), HandlerError>>
+        + Send
+        + Sync,
+>;
+
+/// Persisted execution state of an outbox event-handler job: the sequence of
+/// the last fully handled persistent event.
+#[derive(Default, Clone, Copy, Serialize, Deserialize)]
+pub(crate) struct OutboxEventJobState {
+    pub(crate) sequence: EventSequence,
+}
+
+/// Book-keeping the runner shares with [`EventCtx`].
+pub(crate) struct BatchTracker {
+    /// Number of events whose work is in the currently open op.
+    pub(crate) events_in_op: usize,
+    /// Highest sequence whose checkpoint has been persisted to the database.
+    pub(crate) persisted_seq: EventSequence,
+    /// When the checkpoint was last persisted (any flush or standalone write).
+    pub(crate) last_persist: tokio::time::Instant,
+    /// Whether the current invocation consumed the event (used to reject
+    /// tokens smuggled across invocations).
+    pub(crate) invocation_consumed: bool,
+}
+
+pub(crate) struct CtxParts<'inv> {
+    pub(crate) op_slot: &'inv mut Option<es_entity::DbOp<'static>>,
+    pub(crate) current_job: &'inv mut CurrentJob,
+    pub(crate) state: &'inv OutboxEventJobState,
+    pub(crate) tracker: &'inv mut BatchTracker,
+    pub(crate) on_flush: &'inv FlushHook,
+}
+
+/// Proof that a persistent event was resolved in one of the legal ways.
+///
+/// Only obtainable from [`EventCtx::skip`], [`BatchOp::commit`],
+/// [`BatchOp::defer`] or [`IsolatedOp::commit`] — the type system forces
+/// every [`handle_persistent`](super::OutboxEventHandler::handle_persistent)
+/// invocation to decide the transactional fate of its event.
+#[must_use = "return the Handled token from handle_persistent"]
+pub struct Handled {
+    pub(crate) outcome: Outcome,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Outcome {
+    Skip,
+    Commit,
+    Defer,
+}
+
+/// Per-event decision point handed to
+/// [`handle_persistent`](super::OutboxEventHandler::handle_persistent).
+///
+/// See the [module docs](self) for the semantics of the three entry verbs.
+#[must_use = "resolve the EventCtx via skip / consume_in_batch / consume_isolated"]
+pub struct EventCtx<'inv> {
+    pub(crate) parts: CtxParts<'inv>,
+}
+
+impl<'inv> EventCtx<'inv> {
+    /// This event is not for me — no transaction is opened, an open batch op
+    /// is left untouched, and the checkpoint advances lazily (piggybacked on
+    /// the next flush, or persisted on the configured checkpoint interval).
+    pub fn skip(self) -> Handled {
+        Handled {
+            outcome: Outcome::Skip,
+        }
+    }
+
+    /// Do transactional work joined to the pending batch op (opening a fresh
+    /// one if none is pending).
+    ///
+    /// Work in a batch shares fate with its neighbors: a failure anywhere in
+    /// the batch rolls back and replays the whole batch from the last
+    /// committed checkpoint. Only choose this when the handler's work is
+    /// idempotent under such replay (pure in-op DB writes and in-op job
+    /// spawns are — they roll back with the op).
+    pub async fn consume_in_batch(self) -> Result<BatchOp<'inv>, HandlerError> {
+        let parts = self.parts;
+        if parts.op_slot.is_none() {
+            *parts.op_slot = Some(
+                es_entity::DbOp::init_with_clock(
+                    parts.current_job.pool(),
+                    parts.current_job.clock(),
+                )
+                .await?,
+            );
+        }
+        parts.tracker.events_in_op += 1;
+        parts.tracker.invocation_consumed = true;
+        Ok(BatchOp { parts })
+    }
+
+    /// Land the pending batch first (its work and its checkpoint, at the
+    /// last fully handled sequence), then hand back a fresh op: this event
+    /// is its own atomic unit, sharing no fate with history — and none with
+    /// the future either, since [`IsolatedOp`] only offers
+    /// [`commit`](IsolatedOp::commit).
+    ///
+    /// This is the failure-isolation fence: if this event's work fails, only
+    /// this event replays; and it is the exact legacy per-event semantics
+    /// when no batch is pending.
+    pub async fn consume_isolated(self) -> Result<IsolatedOp<'inv>, HandlerError> {
+        let mut parts = self.parts;
+        flush_batch(&mut parts, "isolated_entry").await?;
+        *parts.op_slot = Some(
+            es_entity::DbOp::init_with_clock(parts.current_job.pool(), parts.current_job.clock())
+                .await?,
+        );
+        parts.tracker.events_in_op = 1;
+        parts.tracker.invocation_consumed = true;
+        Ok(IsolatedOp { parts })
+    }
+}
+
+/// An op joined to the pending batch. Derefs to [`es_entity::DbOp`] — use it
+/// exactly like any atomic operation, then exit with [`commit`](Self::commit)
+/// or [`defer`](Self::defer).
+#[must_use = "exit with .commit() or .defer() to produce the Handled token"]
+pub struct BatchOp<'inv> {
+    parts: CtxParts<'inv>,
+}
+
+impl BatchOp<'_> {
+    /// Land the whole batch (my work included) when the invocation returns:
+    /// `on_flush` → checkpoint at my sequence → commit.
+    pub fn commit(self) -> Handled {
+        Handled {
+            outcome: Outcome::Commit,
+        }
+    }
+
+    /// Leave the op open so subsequent events can coalesce into it. The
+    /// runner lands it when the ready backlog is drained, when the
+    /// configured max batch size is reached, when a later event commits or
+    /// isolates, or on shutdown.
+    pub fn defer(self) -> Handled {
+        Handled {
+            outcome: Outcome::Defer,
+        }
+    }
+}
+
+impl std::ops::Deref for BatchOp<'_> {
+    type Target = es_entity::DbOp<'static>;
+
+    fn deref(&self) -> &Self::Target {
+        self.parts
+            .op_slot
+            .as_ref()
+            .expect("BatchOp always holds a materialized op")
+    }
+}
+
+impl std::ops::DerefMut for BatchOp<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.parts
+            .op_slot
+            .as_mut()
+            .expect("BatchOp always holds a materialized op")
+    }
+}
+
+/// An op holding exactly this event's work, fenced from the batch history.
+/// Derefs to [`es_entity::DbOp`]. The only exit is [`commit`](Self::commit) —
+/// isolation from future events is guaranteed by construction.
+#[must_use = "exit with .commit() to produce the Handled token"]
+pub struct IsolatedOp<'inv> {
+    parts: CtxParts<'inv>,
+}
+
+impl IsolatedOp<'_> {
+    /// Land my work and my checkpoint, atomically, when the invocation
+    /// returns.
+    pub fn commit(self) -> Handled {
+        Handled {
+            outcome: Outcome::Commit,
+        }
+    }
+}
+
+impl std::ops::Deref for IsolatedOp<'_> {
+    type Target = es_entity::DbOp<'static>;
+
+    fn deref(&self) -> &Self::Target {
+        self.parts
+            .op_slot
+            .as_ref()
+            .expect("IsolatedOp always holds a materialized op")
+    }
+}
+
+impl std::ops::DerefMut for IsolatedOp<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.parts
+            .op_slot
+            .as_mut()
+            .expect("IsolatedOp always holds a materialized op")
+    }
+}
+
+/// Land the pending batch op, if any: `on_flush` → checkpoint at the last
+/// fully handled sequence → commit. No-op when no op is open.
+#[tracing::instrument(
+    name = "outbox.flush_batch",
+    skip_all,
+    fields(
+        reason = reason,
+        batch_size = parts.tracker.events_in_op,
+        checkpoint_seq = u64::from(parts.state.sequence),
+    ),
+    err
+)]
+pub(crate) async fn flush_batch(
+    parts: &mut CtxParts<'_>,
+    reason: &'static str,
+) -> Result<(), HandlerError> {
+    let Some(mut op) = parts.op_slot.take() else {
+        return Ok(());
+    };
+    (parts.on_flush)(&mut op).await?;
+    parts
+        .current_job
+        .update_execution_state_in_op(&mut op, parts.state)
+        .await?;
+    op.commit().await?;
+    parts.tracker.persisted_seq = parts.state.sequence;
+    parts.tracker.last_persist = tokio::time::Instant::now();
+    parts.tracker.events_in_op = 0;
+    Ok(())
+}
+
+/// Persist the checkpoint on its own — used for skip-only stretches where no
+/// work op ever materialized, bounded by the configured checkpoint interval.
+#[tracing::instrument(
+    name = "outbox.persist_checkpoint",
+    skip_all,
+    fields(checkpoint_seq = u64::from(state.sequence)),
+    err
+)]
+pub(crate) async fn persist_checkpoint(
+    current_job: &mut CurrentJob,
+    state: &OutboxEventJobState,
+) -> Result<(), HandlerError> {
+    let mut op = es_entity::DbOp::init_with_clock(current_job.pool(), current_job.clock()).await?;
+    current_job
+        .update_execution_state_in_op(&mut op, state)
+        .await?;
+    op.commit().await?;
+    Ok(())
+}

--- a/src/out/ctx.rs
+++ b/src/out/ctx.rs
@@ -20,8 +20,10 @@
 //!
 //! A deferred op is only ever open while there is ready backlog: the runner
 //! never awaits the stream while a transaction is open, so a pending stream
-//! is itself a flush trigger. Batching therefore rides bursts that already
-//! happened and adds no latency at low traffic.
+//! is itself a flush trigger — as is an interleaved ephemeral event (the op
+//! never spans the foreign `handle_ephemeral` await either). Batching
+//! therefore rides bursts that already happened and adds no latency at low
+//! traffic.
 //!
 //! Every flush — whichever of the triggers fires — runs
 //! [`on_flush`](super::OutboxEventHandler::on_flush), then persists the
@@ -179,7 +181,8 @@ impl BatchOp<'_> {
     /// Leave the op open so subsequent events can coalesce into it. The
     /// runner lands it when the ready backlog is drained, when the
     /// configured max batch size is reached, when a later event commits or
-    /// isolates, or on shutdown.
+    /// isolates, when an ephemeral event arrives (the op never spans the
+    /// foreign `handle_ephemeral` await), or on shutdown.
     pub fn defer(self) -> Handled {
         Handled {
             outcome: Outcome::Defer,

--- a/src/out/ctx.rs
+++ b/src/out/ctx.rs
@@ -32,6 +32,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use std::marker::PhantomData;
+
 use job::CurrentJob;
 
 use crate::sequence::EventSequence;
@@ -65,9 +67,6 @@ pub(crate) struct BatchTracker {
     pub(crate) persisted_seq: EventSequence,
     /// When the checkpoint was last persisted (any flush or standalone write).
     pub(crate) last_persist: tokio::time::Instant,
-    /// Whether the current invocation consumed the event (used to reject
-    /// tokens smuggled across invocations).
-    pub(crate) invocation_consumed: bool,
 }
 
 pub(crate) struct CtxParts<'inv> {
@@ -84,9 +83,31 @@ pub(crate) struct CtxParts<'inv> {
 /// [`BatchOp::defer`] or [`IsolatedOp::commit`] — the type system forces
 /// every [`handle_persistent`](super::OutboxEventHandler::handle_persistent)
 /// invocation to decide the transactional fate of its event.
+///
+/// The token is branded with the invocation's lifetime, so it cannot leave
+/// the invocation that minted it: handlers are `'static`, so stashing a
+/// token for a later invocation does not compile —
+///
+/// ```compile_fail
+/// use obix::{EventCtx, Handled};
+///
+/// struct Evil {
+///     stash: std::sync::Mutex<Option<Handled<'static>>>,
+/// }
+///
+/// fn stash_it(ctx: EventCtx<'_>, evil: &Evil) {
+///     // error[E0521]: borrowed data escapes outside of function
+///     *evil.stash.lock().unwrap() = Some(ctx.skip());
+/// }
+/// ```
+///
+/// Combined with the entry verbs consuming the [`EventCtx`] (each invocation
+/// can mint exactly one token), the returned token is always *the* token of
+/// the current invocation, of the kind that actually happened.
 #[must_use = "return the Handled token from handle_persistent"]
-pub struct Handled {
+pub struct Handled<'inv> {
     pub(crate) outcome: Outcome,
+    pub(crate) _invocation: PhantomData<&'inv ()>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -109,9 +130,10 @@ impl<'inv> EventCtx<'inv> {
     /// This event is not for me — no transaction is opened, an open batch op
     /// is left untouched, and the checkpoint advances lazily (piggybacked on
     /// the next flush, or persisted on the configured checkpoint interval).
-    pub fn skip(self) -> Handled {
+    pub fn skip(self) -> Handled<'inv> {
         Handled {
             outcome: Outcome::Skip,
+            _invocation: PhantomData,
         }
     }
 
@@ -135,7 +157,6 @@ impl<'inv> EventCtx<'inv> {
             );
         }
         parts.tracker.events_in_op += 1;
-        parts.tracker.invocation_consumed = true;
         Ok(BatchOp { parts })
     }
 
@@ -156,7 +177,6 @@ impl<'inv> EventCtx<'inv> {
                 .await?,
         );
         parts.tracker.events_in_op = 1;
-        parts.tracker.invocation_consumed = true;
         Ok(IsolatedOp { parts })
     }
 }
@@ -169,12 +189,13 @@ pub struct BatchOp<'inv> {
     parts: CtxParts<'inv>,
 }
 
-impl BatchOp<'_> {
+impl<'inv> BatchOp<'inv> {
     /// Land the whole batch (my work included) when the invocation returns:
     /// `on_flush` → checkpoint at my sequence → commit.
-    pub fn commit(self) -> Handled {
+    pub fn commit(self) -> Handled<'inv> {
         Handled {
             outcome: Outcome::Commit,
+            _invocation: PhantomData,
         }
     }
 
@@ -183,9 +204,10 @@ impl BatchOp<'_> {
     /// configured max batch size is reached, when a later event commits or
     /// isolates, when an ephemeral event arrives (the op never spans the
     /// foreign `handle_ephemeral` await), or on shutdown.
-    pub fn defer(self) -> Handled {
+    pub fn defer(self) -> Handled<'inv> {
         Handled {
             outcome: Outcome::Defer,
+            _invocation: PhantomData,
         }
     }
 }
@@ -218,12 +240,13 @@ pub struct IsolatedOp<'inv> {
     parts: CtxParts<'inv>,
 }
 
-impl IsolatedOp<'_> {
+impl<'inv> IsolatedOp<'inv> {
     /// Land my work and my checkpoint, atomically, when the invocation
     /// returns.
-    pub fn commit(self) -> Handled {
+    pub fn commit(self) -> Handled<'inv> {
         Handled {
             outcome: Outcome::Commit,
+            _invocation: PhantomData,
         }
     }
 }

--- a/src/out/ctx.rs
+++ b/src/out/ctx.rs
@@ -25,10 +25,9 @@
 //! therefore rides bursts that already happened and adds no latency at low
 //! traffic.
 //!
-//! Every flush — whichever of the triggers fires — runs
-//! [`on_flush`](super::OutboxEventHandler::on_flush), then persists the
-//! checkpoint at the last *fully handled* sequence (skips included), then
-//! commits: work and pointer are inseparable.
+//! Every flush — whichever of the triggers fires — persists the checkpoint
+//! at the last *fully handled* sequence (skips included), then commits:
+//! work and pointer are inseparable.
 
 use serde::{Deserialize, Serialize};
 
@@ -40,17 +39,6 @@ use crate::sequence::EventSequence;
 
 /// Error type shared with the handler trait methods.
 pub(crate) type HandlerError = Box<dyn std::error::Error + Send + Sync>;
-
-/// Type-erased [`on_flush`](super::OutboxEventHandler::on_flush) callback so
-/// that [`EventCtx::consume_isolated`] can flush the pending batch from
-/// within a handler invocation.
-pub(crate) type FlushHook = Box<
-    dyn for<'a> Fn(
-            &'a mut es_entity::DbOp<'static>,
-        ) -> futures::future::BoxFuture<'a, Result<(), HandlerError>>
-        + Send
-        + Sync,
->;
 
 /// Persisted execution state of an outbox event-handler job: the sequence of
 /// the last fully handled persistent event.
@@ -74,7 +62,6 @@ pub(crate) struct CtxParts<'inv> {
     pub(crate) current_job: &'inv mut CurrentJob,
     pub(crate) state: &'inv OutboxEventJobState,
     pub(crate) tracker: &'inv mut BatchTracker,
-    pub(crate) on_flush: &'inv FlushHook,
 }
 
 /// Proof that a persistent event was resolved in one of the legal ways.
@@ -191,7 +178,7 @@ pub struct BatchOp<'inv> {
 
 impl<'inv> BatchOp<'inv> {
     /// Land the whole batch (my work included) when the invocation returns:
-    /// `on_flush` → checkpoint at my sequence → commit.
+    /// checkpoint at my sequence → commit.
     pub fn commit(self) -> Handled<'inv> {
         Handled {
             outcome: Outcome::Commit,
@@ -271,8 +258,8 @@ impl std::ops::DerefMut for IsolatedOp<'_> {
     }
 }
 
-/// Land the pending batch op, if any: `on_flush` → checkpoint at the last
-/// fully handled sequence → commit. No-op when no op is open.
+/// Land the pending batch op, if any: checkpoint at the last fully handled
+/// sequence → commit. No-op when no op is open.
 #[tracing::instrument(
     name = "outbox.flush_batch",
     skip_all,
@@ -290,7 +277,6 @@ pub(crate) async fn flush_batch(
     let Some(mut op) = parts.op_slot.take() else {
         return Ok(());
     };
-    (parts.on_flush)(&mut op).await?;
     parts
         .current_job
         .update_execution_state_in_op(&mut op, parts.state)

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -42,12 +42,13 @@ pub trait OutboxEventHandler<P>: Send + Sync + 'static
 where
     P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
 {
-    fn handle_persistent(
+    fn handle_persistent<'inv>(
         &self,
-        ctx: EventCtx<'_>,
+        ctx: EventCtx<'inv>,
         event: &PersistentOutboxEvent<P>,
-    ) -> impl std::future::Future<Output = Result<Handled, Box<dyn std::error::Error + Send + Sync>>>
-    + Send {
+    ) -> impl std::future::Future<
+        Output = Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>>,
+    > + Send {
         let _ = event;
         async move { Ok(ctx.skip()) }
     }
@@ -221,7 +222,6 @@ where
             events_in_op: 0,
             persisted_seq: state.sequence,
             last_persist: tokio::time::Instant::now(),
-            invocation_consumed: false,
         };
 
         let on_flush: FlushHook = {
@@ -325,7 +325,6 @@ where
                         .map_err(|e| e as Box<dyn std::error::Error>)?;
                 }
                 OutboxEvent::Persistent(event) => {
-                    tracker.invocation_consumed = false;
                     let ctx = EventCtx {
                         parts: CtxParts {
                             op_slot: &mut op_slot,
@@ -335,22 +334,21 @@ where
                             on_flush: &on_flush,
                         },
                     };
-                    let handled = self
+                    // The Handled token is branded with the invocation
+                    // lifetime (it cannot leave this call) and every path
+                    // that mints one consumes the ctx — so the outcome is
+                    // authentic by construction. Extract it in the same
+                    // statement so the token (and with it the ctx borrows)
+                    // ends before the state advance below.
+                    let outcome = self
                         .handler
                         .handle_persistent(ctx, &event)
                         .await
-                        .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        .map_err(|e| e as Box<dyn std::error::Error>)?
+                        .outcome;
                     state.sequence = event.sequence;
-                    match handled.outcome {
-                        Outcome::Skip => {
-                            if tracker.invocation_consumed {
-                                return Err(
-                                    "handler consumed the event but returned a token from \
-                                     another invocation"
-                                        .into(),
-                                );
-                            }
-                        }
+                    match outcome {
+                        Outcome::Skip => {}
                         Outcome::Commit => {
                             let mut parts = CtxParts {
                                 op_slot: &mut op_slot,

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -24,8 +24,9 @@ use crate::tables::MailboxTables;
 ///   into one transaction and one checkpoint write. The batch lands when the
 ///   ready backlog is drained (a deferred op is never held open waiting on
 ///   the network), when `max_batch_size` is reached, when a later event
-///   commits or isolates, or on shutdown. Requires the work to tolerate
-///   whole-batch replay after a mid-batch failure.
+///   commits or isolates, when an ephemeral event arrives, or on shutdown.
+///   Requires the work to tolerate whole-batch replay after a mid-batch
+///   failure.
 /// - [`consume_in_batch`](EventCtx::consume_in_batch) then
 ///   [`commit`](BatchOp::commit) — join the batch and close it with me.
 /// - [`consume_isolated`](EventCtx::consume_isolated) then
@@ -301,8 +302,23 @@ where
 
             match event {
                 OutboxEvent::Ephemeral(event) => {
-                    // Handled inline — ephemerals are an unordered
-                    // best-effort broadcast and never touch the batch op.
+                    // Ephemerals are an unordered best-effort broadcast and
+                    // never touch the batch op — but an open op must not
+                    // span the foreign `handle_ephemeral` await (and steady
+                    // ephemeral traffic must not starve the flush), so an
+                    // ephemeral arriving mid-batch lands the batch first.
+                    if op_slot.is_some() {
+                        let mut parts = CtxParts {
+                            op_slot: &mut op_slot,
+                            current_job: &mut current_job,
+                            state: &state,
+                            tracker: &mut tracker,
+                            on_flush: &on_flush,
+                        };
+                        flush_batch(&mut parts, "ephemeral")
+                            .await
+                            .map_err(|e| e as Box<dyn std::error::Error>)?;
+                    }
                     self.handler
                         .handle_ephemeral(&event)
                         .await

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::sync::Arc;
 
@@ -7,21 +7,48 @@ use job::{
     CurrentJob, Job, JobCompletion, JobInitializer, JobRunner, JobSpawner, JobType, RetrySettings,
 };
 
+use super::ctx::*;
 use super::{Outbox, event::*};
-use crate::{sequence::EventSequence, tables::MailboxTables};
+use crate::tables::MailboxTables;
 
+/// Handles the events of one outbox listener job.
+///
+/// [`handle_persistent`](Self::handle_persistent) receives an [`EventCtx`]
+/// and must resolve it into a [`Handled`] token, deciding the transactional
+/// fate of every event:
+///
+/// - [`skip`](EventCtx::skip) — not my event; costs no transaction at all.
+///   The checkpoint advances lazily.
+/// - [`consume_in_batch`](EventCtx::consume_in_batch) then
+///   [`defer`](BatchOp::defer) — coalesce my work with neighboring events
+///   into one transaction and one checkpoint write. The batch lands when the
+///   ready backlog is drained (a deferred op is never held open waiting on
+///   the network), when `max_batch_size` is reached, when a later event
+///   commits or isolates, or on shutdown. Requires the work to tolerate
+///   whole-batch replay after a mid-batch failure.
+/// - [`consume_in_batch`](EventCtx::consume_in_batch) then
+///   [`commit`](BatchOp::commit) — join the batch and close it with me.
+/// - [`consume_isolated`](EventCtx::consume_isolated) then
+///   [`commit`](IsolatedOp::commit) — my event is its own atomic unit: the
+///   pending batch (work + checkpoint) lands before my work starts, and my
+///   op commits at return. Exact legacy per-event semantics when nothing is
+///   pending. Use for causally significant or risky work.
+///
+/// [`on_flush`](Self::on_flush) is called immediately before *any* batch op
+/// commits — the guaranteed write-back point for handlers that accumulate
+/// state across [`consume_in_batch`](EventCtx::consume_in_batch) calls.
 pub trait OutboxEventHandler<P>: Send + Sync + 'static
 where
     P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
 {
     fn handle_persistent(
         &self,
-        op: &mut es_entity::DbOp<'_>,
+        ctx: EventCtx<'_>,
         event: &PersistentOutboxEvent<P>,
-    ) -> impl std::future::Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send
-    {
-        let _ = (op, event);
-        async { Ok(()) }
+    ) -> impl std::future::Future<Output = Result<Handled, Box<dyn std::error::Error + Send + Sync>>>
+    + Send {
+        let _ = event;
+        async move { Ok(ctx.skip()) }
     }
 
     fn handle_ephemeral(
@@ -32,12 +59,31 @@ where
         let _ = event;
         async { Ok(()) }
     }
+
+    /// Called immediately before a batch op commits (any flush trigger,
+    /// including a later event's [`consume_isolated`](EventCtx::consume_isolated)
+    /// entry). Handlers that accumulate state across deferred events write
+    /// it back here — it lands in the same transaction as the batch and its
+    /// checkpoint.
+    fn on_flush(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+    ) -> impl std::future::Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send
+    {
+        let _ = op;
+        async { Ok(()) }
+    }
 }
+
+const DEFAULT_MAX_BATCH_SIZE: usize = 100;
+const DEFAULT_CHECKPOINT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 
 #[derive(Clone)]
 pub struct OutboxEventJobConfig {
     pub job_type: JobType,
     pub retry_settings: RetrySettings,
+    pub max_batch_size: usize,
+    pub checkpoint_interval: std::time::Duration,
 }
 
 impl OutboxEventJobConfig {
@@ -45,6 +91,8 @@ impl OutboxEventJobConfig {
         Self {
             job_type,
             retry_settings: RetrySettings::repeat_indefinitely(),
+            max_batch_size: DEFAULT_MAX_BATCH_SIZE,
+            checkpoint_interval: DEFAULT_CHECKPOINT_INTERVAL,
         }
     }
 
@@ -52,11 +100,25 @@ impl OutboxEventJobConfig {
         self.retry_settings = settings;
         self
     }
-}
 
-#[derive(Default, Clone, Copy, Serialize, Deserialize)]
-struct OutboxEventJobState {
-    sequence: EventSequence,
+    /// Backstop on how many deferred events may share one op before the
+    /// runner force-flushes. Bounds the replay window and transaction size
+    /// of handlers that always [`defer`](super::BatchOp::defer); handlers
+    /// remain the primary size control by exiting with
+    /// [`commit`](super::BatchOp::commit).
+    pub fn with_max_batch_size(mut self, max_batch_size: usize) -> Self {
+        self.max_batch_size = max_batch_size.max(1);
+        self
+    }
+
+    /// Maximum staleness of the persisted checkpoint over skip-only
+    /// stretches (where no transaction happens at all and the pointer only
+    /// advances in memory). Never delays event handling — it only bounds how
+    /// many harmless no-op replays a crash can cause.
+    pub fn with_checkpoint_interval(mut self, interval: std::time::Duration) -> Self {
+        self.checkpoint_interval = interval;
+        self
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -72,6 +134,8 @@ where
     handler: Arc<H>,
     job_type: JobType,
     retry_settings: RetrySettings,
+    max_batch_size: usize,
+    checkpoint_interval: std::time::Duration,
 }
 
 impl<H, P, Tables> OutboxEventJobInitializer<H, P, Tables>
@@ -86,6 +150,8 @@ where
             handler: Arc::new(handler),
             job_type: config.job_type.clone(),
             retry_settings: config.retry_settings.clone(),
+            max_batch_size: config.max_batch_size,
+            checkpoint_interval: config.checkpoint_interval,
         }
     }
 }
@@ -114,6 +180,8 @@ where
         Ok(Box::new(OutboxEventJobRunner::<H, P, Tables> {
             outbox: self.outbox.clone(),
             handler: self.handler.clone(),
+            max_batch_size: self.max_batch_size,
+            checkpoint_interval: self.checkpoint_interval,
         }))
     }
 }
@@ -126,6 +194,8 @@ where
 {
     outbox: Outbox<P, Tables>,
     handler: Arc<H>,
+    max_batch_size: usize,
+    checkpoint_interval: std::time::Duration,
 }
 
 #[async_trait]
@@ -145,30 +215,152 @@ where
 
         let mut stream = self.outbox.listen_all(Some(state.sequence));
 
+        let mut op_slot: Option<es_entity::DbOp<'static>> = None;
+        let mut tracker = BatchTracker {
+            events_in_op: 0,
+            persisted_seq: state.sequence,
+            last_persist: tokio::time::Instant::now(),
+            invocation_consumed: false,
+        };
+
+        let on_flush: FlushHook = {
+            let handler = self.handler.clone();
+            Box::new(move |op| {
+                let handler = handler.clone();
+                Box::pin(async move { handler.on_flush(op).await })
+            })
+        };
+
         loop {
-            tokio::select! {
-                biased;
-                _ = current_job.shutdown_requested() => {
-                    return Ok(JobCompletion::RescheduleNow);
+            let event = if op_slot.is_some() {
+                // A batch op is open: only take events that are already
+                // buffered — the transaction is never held open waiting on
+                // the network. A pending stream is itself the flush trigger.
+                match stream.next().now_or_never() {
+                    Some(Some(event)) => event,
+                    Some(None) => {
+                        let mut parts = CtxParts {
+                            op_slot: &mut op_slot,
+                            current_job: &mut current_job,
+                            state: &state,
+                            tracker: &mut tracker,
+                            on_flush: &on_flush,
+                        };
+                        flush_batch(&mut parts, "stream_closed")
+                            .await
+                            .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        return Ok(JobCompletion::RescheduleNow);
+                    }
+                    None => {
+                        let mut parts = CtxParts {
+                            op_slot: &mut op_slot,
+                            current_job: &mut current_job,
+                            state: &state,
+                            tracker: &mut tracker,
+                            on_flush: &on_flush,
+                        };
+                        flush_batch(&mut parts, "backlog_drained")
+                            .await
+                            .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        continue;
+                    }
                 }
-                event = stream.next() => {
-                    match event {
-                        Some(OutboxEvent::Persistent(e)) => {
-                            let mut op = es_entity::DbOp::init_with_clock(
-                                current_job.pool(),
-                                current_job.clock(),
-                            ).await?;
-                            self.handler.handle_persistent(&mut op, &e).await
-                                .map_err(|e| e as Box<dyn std::error::Error>)?;
-                            state.sequence = e.sequence;
-                            current_job.update_execution_state_in_op(&mut op, &state).await?;
-                            op.commit().await?;
-                        }
-                        Some(OutboxEvent::Ephemeral(e)) => {
-                            self.handler.handle_ephemeral(&e).await
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = current_job.shutdown_requested() => {
+                        if tracker.persisted_seq < state.sequence {
+                            persist_checkpoint(&mut current_job, &state)
+                                .await
                                 .map_err(|e| e as Box<dyn std::error::Error>)?;
                         }
-                        None => return Ok(JobCompletion::RescheduleNow),
+                        return Ok(JobCompletion::RescheduleNow);
+                    }
+                    _ = tokio::time::sleep_until(tracker.last_persist + self.checkpoint_interval),
+                        if tracker.persisted_seq < state.sequence => {
+                        persist_checkpoint(&mut current_job, &state)
+                            .await
+                            .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        tracker.persisted_seq = state.sequence;
+                        tracker.last_persist = tokio::time::Instant::now();
+                        continue;
+                    }
+                    event = stream.next() => match event {
+                        Some(event) => event,
+                        None => {
+                            if tracker.persisted_seq < state.sequence {
+                                persist_checkpoint(&mut current_job, &state)
+                                    .await
+                                    .map_err(|e| e as Box<dyn std::error::Error>)?;
+                            }
+                            return Ok(JobCompletion::RescheduleNow);
+                        }
+                    },
+                }
+            };
+
+            match event {
+                OutboxEvent::Ephemeral(event) => {
+                    // Handled inline — ephemerals are an unordered
+                    // best-effort broadcast and never touch the batch op.
+                    self.handler
+                        .handle_ephemeral(&event)
+                        .await
+                        .map_err(|e| e as Box<dyn std::error::Error>)?;
+                }
+                OutboxEvent::Persistent(event) => {
+                    tracker.invocation_consumed = false;
+                    let ctx = EventCtx {
+                        parts: CtxParts {
+                            op_slot: &mut op_slot,
+                            current_job: &mut current_job,
+                            state: &state,
+                            tracker: &mut tracker,
+                            on_flush: &on_flush,
+                        },
+                    };
+                    let handled = self
+                        .handler
+                        .handle_persistent(ctx, &event)
+                        .await
+                        .map_err(|e| e as Box<dyn std::error::Error>)?;
+                    state.sequence = event.sequence;
+                    match handled.outcome {
+                        Outcome::Skip => {
+                            if tracker.invocation_consumed {
+                                return Err(
+                                    "handler consumed the event but returned a token from \
+                                     another invocation"
+                                        .into(),
+                                );
+                            }
+                        }
+                        Outcome::Commit => {
+                            let mut parts = CtxParts {
+                                op_slot: &mut op_slot,
+                                current_job: &mut current_job,
+                                state: &state,
+                                tracker: &mut tracker,
+                                on_flush: &on_flush,
+                            };
+                            flush_batch(&mut parts, "commit")
+                                .await
+                                .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        }
+                        Outcome::Defer => {
+                            if tracker.events_in_op >= self.max_batch_size {
+                                let mut parts = CtxParts {
+                                    op_slot: &mut op_slot,
+                                    current_job: &mut current_job,
+                                    state: &state,
+                                    tracker: &mut tracker,
+                                    on_flush: &on_flush,
+                                };
+                                flush_batch(&mut parts, "batch_full")
+                                    .await
+                                    .map_err(|e| e as Box<dyn std::error::Error>)?;
+                            }
+                        }
                     }
                 }
             }

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -34,10 +34,6 @@ use crate::tables::MailboxTables;
 ///   pending batch (work + checkpoint) lands before my work starts, and my
 ///   op commits at return. Exact legacy per-event semantics when nothing is
 ///   pending. Use for causally significant or risky work.
-///
-/// [`on_flush`](Self::on_flush) is called immediately before *any* batch op
-/// commits — the guaranteed write-back point for handlers that accumulate
-/// state across [`consume_in_batch`](EventCtx::consume_in_batch) calls.
 pub trait OutboxEventHandler<P>: Send + Sync + 'static
 where
     P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
@@ -59,20 +55,6 @@ where
     ) -> impl std::future::Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send
     {
         let _ = event;
-        async { Ok(()) }
-    }
-
-    /// Called immediately before a batch op commits (any flush trigger,
-    /// including a later event's [`consume_isolated`](EventCtx::consume_isolated)
-    /// entry). Handlers that accumulate state across deferred events write
-    /// it back here — it lands in the same transaction as the batch and its
-    /// checkpoint.
-    fn on_flush(
-        &self,
-        op: &mut es_entity::DbOp<'_>,
-    ) -> impl std::future::Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send
-    {
-        let _ = op;
         async { Ok(()) }
     }
 }
@@ -224,14 +206,6 @@ where
             last_persist: tokio::time::Instant::now(),
         };
 
-        let on_flush: FlushHook = {
-            let handler = self.handler.clone();
-            Box::new(move |op| {
-                let handler = handler.clone();
-                Box::pin(async move { handler.on_flush(op).await })
-            })
-        };
-
         loop {
             let event = if op_slot.is_some() {
                 // A batch op is open: only take events that are already
@@ -245,7 +219,6 @@ where
                             current_job: &mut current_job,
                             state: &state,
                             tracker: &mut tracker,
-                            on_flush: &on_flush,
                         };
                         flush_batch(&mut parts, "stream_closed")
                             .await
@@ -258,7 +231,6 @@ where
                             current_job: &mut current_job,
                             state: &state,
                             tracker: &mut tracker,
-                            on_flush: &on_flush,
                         };
                         flush_batch(&mut parts, "backlog_drained")
                             .await
@@ -313,7 +285,6 @@ where
                             current_job: &mut current_job,
                             state: &state,
                             tracker: &mut tracker,
-                            on_flush: &on_flush,
                         };
                         flush_batch(&mut parts, "ephemeral")
                             .await
@@ -331,7 +302,6 @@ where
                             current_job: &mut current_job,
                             state: &state,
                             tracker: &mut tracker,
-                            on_flush: &on_flush,
                         },
                     };
                     // The Handled token is branded with the invocation
@@ -355,7 +325,6 @@ where
                                 current_job: &mut current_job,
                                 state: &state,
                                 tracker: &mut tracker,
-                                on_flush: &on_flush,
                             };
                             flush_batch(&mut parts, "commit")
                                 .await
@@ -368,7 +337,6 @@ where
                                     current_job: &mut current_job,
                                     state: &state,
                                     tracker: &mut tracker,
-                                    on_flush: &on_flush,
                                 };
                                 flush_batch(&mut parts, "batch_full")
                                     .await

--- a/src/out/mod.rs
+++ b/src/out/mod.rs
@@ -1,4 +1,5 @@
 mod all_listener;
+mod ctx;
 mod ephemeral;
 mod ephemeral_events_hook;
 mod event;
@@ -13,6 +14,7 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use std::sync::Arc;
 
+pub use self::ctx::{BatchOp, EventCtx, Handled, IsolatedOp};
 pub use self::job::{OutboxEventHandler, OutboxEventJobConfig};
 use crate::{config::*, handle::OwnedTaskHandle, sequence::EventSequence, tables::*};
 pub use all_listener::AllOutboxListener;

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -1,8 +1,11 @@
 mod helpers;
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use obix::{MailboxConfig, OutboxEventHandler, OutboxEventJobConfig, out::Outbox};
+use obix::{
+    EventCtx, Handled, MailboxConfig, OutboxEventHandler, OutboxEventJobConfig, out::Outbox,
+};
 use serde::{Deserialize, Serialize};
 use serial_test::file_serial;
 use tokio::sync::Mutex;
@@ -16,20 +19,41 @@ enum TestEvent {
     Ping(u64),
 }
 
-struct TestPersistentHandler {
+/// Pure observer: records deliveries and skips — no transaction is ever
+/// opened on its behalf.
+struct SkippingObserver {
     received: Arc<Mutex<Vec<u64>>>,
 }
 
-impl OutboxEventHandler<TestEvent> for TestPersistentHandler {
+impl OutboxEventHandler<TestEvent> for SkippingObserver {
     async fn handle_persistent(
         &self,
-        _op: &mut es_entity::DbOp<'_>,
+        ctx: EventCtx<'_>,
         event: &obix::out::PersistentOutboxEvent<TestEvent>,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
         if let Some(TestEvent::Ping(n)) = &event.payload {
             self.received.lock().await.push(*n);
         }
-        Ok(())
+        Ok(ctx.skip())
+    }
+}
+
+/// Legacy-style observer: one isolated op + checkpoint per event.
+struct CheckpointingObserver {
+    received: Arc<Mutex<Vec<u64>>>,
+}
+
+impl OutboxEventHandler<TestEvent> for CheckpointingObserver {
+    async fn handle_persistent(
+        &self,
+        ctx: EventCtx<'_>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(TestEvent::Ping(n)) = &event.payload {
+            self.received.lock().await.push(*n);
+        }
+        let op = ctx.consume_isolated().await?;
+        Ok(op.commit())
     }
 }
 
@@ -56,13 +80,13 @@ struct TestBothHandler {
 impl OutboxEventHandler<TestEvent> for TestBothHandler {
     async fn handle_persistent(
         &self,
-        _op: &mut es_entity::DbOp<'_>,
+        ctx: EventCtx<'_>,
         event: &obix::out::PersistentOutboxEvent<TestEvent>,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
         if let Some(TestEvent::Ping(n)) = &event.payload {
             self.persistent_received.lock().await.push(*n);
         }
-        Ok(())
+        Ok(ctx.skip())
     }
 
     async fn handle_ephemeral(
@@ -75,9 +99,137 @@ impl OutboxEventHandler<TestEvent> for TestBothHandler {
     }
 }
 
+/// Batch-safe worker: inserts one row per event inside the shared batch op
+/// and defers. Optionally fails the first time a given event value is seen.
+/// Sleeps briefly per event so the backfill keeps the ready backlog ahead of
+/// the handler (making batch composition deterministic in tests).
+struct DeferringEffectHandler {
+    deliveries: Arc<Mutex<Vec<u64>>>,
+    fail_on_first: Option<u64>,
+    failed: Arc<AtomicBool>,
+}
+
+impl OutboxEventHandler<TestEvent> for DeferringEffectHandler {
+    async fn handle_persistent(
+        &self,
+        ctx: EventCtx<'_>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
+        use es_entity::AtomicOperation;
+        let Some(TestEvent::Ping(n)) = &event.payload else {
+            return Ok(ctx.skip());
+        };
+        self.deliveries.lock().await.push(*n);
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        let mut op = ctx.consume_in_batch().await?;
+        if self.fail_on_first == Some(*n) && !self.failed.swap(true, Ordering::SeqCst) {
+            return Err("injected mid-batch failure".into());
+        }
+        sqlx::query("INSERT INTO test_batch_effects (n) VALUES ($1)")
+            .bind(*n as i64)
+            .execute(op.as_executor())
+            .await?;
+        Ok(op.defer())
+    }
+}
+
+/// Defers everything except one event value, which it handles isolated —
+/// fencing the pending batch — and fails on its first attempt.
+struct IsolatingEffectHandler {
+    deliveries: Arc<Mutex<Vec<u64>>>,
+    isolate_on: u64,
+    fail_isolated_once: Arc<AtomicBool>,
+}
+
+impl OutboxEventHandler<TestEvent> for IsolatingEffectHandler {
+    async fn handle_persistent(
+        &self,
+        ctx: EventCtx<'_>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
+        use es_entity::AtomicOperation;
+        let Some(TestEvent::Ping(n)) = &event.payload else {
+            return Ok(ctx.skip());
+        };
+        self.deliveries.lock().await.push(*n);
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        if *n == self.isolate_on {
+            let mut op = ctx.consume_isolated().await?;
+            sqlx::query("INSERT INTO test_batch_effects (n) VALUES ($1)")
+                .bind(*n as i64)
+                .execute(op.as_executor())
+                .await?;
+            if !self.fail_isolated_once.swap(true, Ordering::SeqCst) {
+                return Err("injected isolated failure".into());
+            }
+            Ok(op.commit())
+        } else {
+            let mut op = ctx.consume_in_batch().await?;
+            sqlx::query("INSERT INTO test_batch_effects (n) VALUES ($1)")
+                .bind(*n as i64)
+                .execute(op.as_executor())
+                .await?;
+            Ok(op.defer())
+        }
+    }
+}
+
+/// Aggregator: accumulates event values in memory across deferred events and
+/// writes them back in `on_flush` — one write-back per batch, not per event.
+struct AccumulatingHandler {
+    pending: Arc<std::sync::Mutex<Vec<i64>>>,
+    flush_count: Arc<AtomicUsize>,
+}
+
+impl OutboxEventHandler<TestEvent> for AccumulatingHandler {
+    async fn handle_persistent(
+        &self,
+        ctx: EventCtx<'_>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
+        let Some(TestEvent::Ping(n)) = &event.payload else {
+            return Ok(ctx.skip());
+        };
+        self.pending.lock().expect("lock").push(*n as i64);
+        let op = ctx.consume_in_batch().await?;
+        Ok(op.defer())
+    }
+
+    async fn on_flush(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use es_entity::AtomicOperation;
+        let drained: Vec<i64> = std::mem::take(&mut *self.pending.lock().expect("lock"));
+        for n in drained {
+            sqlx::query("INSERT INTO test_batch_effects (n) VALUES ($1)")
+                .bind(n)
+                .execute(op.as_executor())
+                .await?;
+        }
+        self.flush_count.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
 async fn init_outbox_with_handler<H: OutboxEventHandler<TestEvent>>(
     pool: &sqlx::PgPool,
     jobs: &mut job::Jobs,
+    handler: H,
+) -> anyhow::Result<Outbox<TestEvent, TestTables>> {
+    init_outbox_with_handler_config(
+        pool,
+        jobs,
+        OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE)),
+        handler,
+    )
+    .await
+}
+
+async fn init_outbox_with_handler_config<H: OutboxEventHandler<TestEvent>>(
+    pool: &sqlx::PgPool,
+    jobs: &mut job::Jobs,
+    config: OutboxEventJobConfig,
     handler: H,
 ) -> anyhow::Result<Outbox<TestEvent, TestTables>> {
     wipeout_outbox_tables(pool).await?;
@@ -92,15 +244,98 @@ async fn init_outbox_with_handler<H: OutboxEventHandler<TestEvent>>(
     .await?;
 
     outbox
-        .register_event_handler(
-            jobs,
-            OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE)),
-            handler,
-        )
+        .register_event_handler(jobs, config, handler)
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     Ok(outbox)
+}
+
+fn fast_retry_settings() -> job::RetrySettings {
+    let mut settings = job::RetrySettings::repeat_indefinitely();
+    settings.min_backoff = std::time::Duration::from_millis(50);
+    settings.max_backoff = std::time::Duration::from_millis(100);
+    settings.backoff_jitter_pct = 0;
+    settings
+}
+
+async fn wait_for_n_deliveries(
+    received: &Mutex<Vec<u64>>,
+    n: usize,
+    timeout: std::time::Duration,
+) -> anyhow::Result<()> {
+    let start = std::time::Instant::now();
+    loop {
+        if received.lock().await.len() >= n {
+            return Ok(());
+        }
+        if start.elapsed() > timeout {
+            anyhow::bail!("Timeout waiting for {n} deliveries");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+}
+
+async fn checkpoint_sequence(pool: &sqlx::PgPool) -> anyhow::Result<Option<i64>> {
+    let row: Option<(Option<serde_json::Value>,)> = sqlx::query_as(
+        "SELECT je.execution_state_json FROM job_executions je \
+         JOIN jobs j ON j.id = je.id WHERE j.job_type = $1",
+    )
+    .bind(JOB_TYPE)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row
+        .and_then(|(json,)| json)
+        .and_then(|json| json.get("sequence").and_then(|s| s.as_i64())))
+}
+
+async fn wait_for_checkpoint(pool: &sqlx::PgPool, expected: i64) -> anyhow::Result<()> {
+    let start = std::time::Instant::now();
+    loop {
+        if checkpoint_sequence(pool).await? == Some(expected) {
+            return Ok(());
+        }
+        if start.elapsed() > std::time::Duration::from_secs(5) {
+            anyhow::bail!(
+                "Timeout waiting for checkpoint to reach {expected}, at {:?}",
+                checkpoint_sequence(pool).await?
+            );
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+}
+
+async fn reset_batch_effects_table(pool: &sqlx::PgPool) -> anyhow::Result<()> {
+    sqlx::query("DROP TABLE IF EXISTS test_batch_effects")
+        .execute(pool)
+        .await?;
+    sqlx::query("CREATE TABLE test_batch_effects (n BIGINT PRIMARY KEY)")
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+async fn batch_effect_rows(pool: &sqlx::PgPool) -> anyhow::Result<Vec<i64>> {
+    let rows: Vec<(i64,)> = sqlx::query_as("SELECT n FROM test_batch_effects ORDER BY n")
+        .fetch_all(pool)
+        .await?;
+    Ok(rows.into_iter().map(|(n,)| n).collect())
+}
+
+async fn wait_for_effect_rows(pool: &sqlx::PgPool, n: usize) -> anyhow::Result<()> {
+    let start = std::time::Instant::now();
+    loop {
+        if batch_effect_rows(pool).await?.len() >= n {
+            return Ok(());
+        }
+        if start.elapsed() > std::time::Duration::from_secs(10) {
+            anyhow::bail!(
+                "Timeout waiting for {n} effect rows, at {:?}",
+                batch_effect_rows(pool).await?
+            );
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
 }
 
 #[tokio::test]
@@ -118,7 +353,7 @@ async fn handler_receives_persistent_events() -> anyhow::Result<()> {
     let outbox = init_outbox_with_handler(
         &pool,
         &mut jobs,
-        TestPersistentHandler {
+        SkippingObserver {
             received: received.clone(),
         },
     )
@@ -138,19 +373,8 @@ async fn handler_receives_persistent_events() -> anyhow::Result<()> {
         .await?;
     op.commit().await?;
 
-    let start = std::time::Instant::now();
-    loop {
-        let events = received.lock().await;
-        if events.len() >= 3 {
-            assert_eq!(*events, vec![1, 2, 3]);
-            break;
-        }
-        drop(events);
-        if start.elapsed() > std::time::Duration::from_secs(5) {
-            anyhow::bail!("Timeout waiting for persistent events");
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    }
+    wait_for_n_deliveries(&received, 3, std::time::Duration::from_secs(5)).await?;
+    assert_eq!(*received.lock().await, vec![1, 2, 3]);
 
     Ok(())
 }
@@ -220,7 +444,7 @@ async fn handler_resumes_from_last_sequence_on_restart() -> anyhow::Result<()> {
         let outbox = init_outbox_with_handler(
             &pool,
             &mut jobs,
-            TestPersistentHandler {
+            CheckpointingObserver {
                 received: received_first.clone(),
             },
         )
@@ -237,18 +461,7 @@ async fn handler_resumes_from_last_sequence_on_restart() -> anyhow::Result<()> {
             .await?;
         op.commit().await?;
 
-        let start = std::time::Instant::now();
-        loop {
-            let events = received_first.lock().await;
-            if events.len() >= 2 {
-                break;
-            }
-            drop(events);
-            if start.elapsed() > std::time::Duration::from_secs(5) {
-                anyhow::bail!("Timeout waiting for first-run events");
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        }
+        wait_for_n_deliveries(&received_first, 2, std::time::Duration::from_secs(5)).await?;
 
         jobs.shutdown().await?;
     }
@@ -275,7 +488,7 @@ async fn handler_resumes_from_last_sequence_on_restart() -> anyhow::Result<()> {
             .register_event_handler(
                 &mut jobs,
                 OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE)),
-                TestPersistentHandler {
+                CheckpointingObserver {
                     received: received_second.clone(),
                 },
             )
@@ -372,6 +585,277 @@ async fn handler_receives_both_persistent_and_ephemeral() -> anyhow::Result<()> 
         }
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn deferred_batch_replays_wholesale_on_mid_batch_failure() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let deliveries = Arc::new(Mutex::new(Vec::new()));
+    let config = OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE))
+        .with_retry_settings(fast_retry_settings());
+    let outbox = init_outbox_with_handler_config(
+        &pool,
+        &mut jobs,
+        config,
+        DeferringEffectHandler {
+            deliveries: deliveries.clone(),
+            fail_on_first: Some(2),
+            failed: Arc::new(AtomicBool::new(false)),
+        },
+    )
+    .await?;
+
+    // Publish before the job starts so the events arrive as ready backlog.
+    const N: u64 = 5;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    wait_for_effect_rows(&pool, N as usize).await?;
+
+    // Exactly-once DB effects despite the replay.
+    assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3, 4, 5]);
+
+    // Event 1 was deferred into the batch that event 2 poisoned, so the
+    // whole batch rolled back and event 1 was delivered again on replay —
+    // per-batch fate sharing, not per-event.
+    let deliveries = deliveries.lock().await;
+    let event_1_deliveries = deliveries.iter().filter(|&&n| n == 1).count();
+    assert!(
+        event_1_deliveries >= 2,
+        "expected event 1 to replay with the poisoned batch, deliveries: {deliveries:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn isolated_event_fences_prior_batch_from_its_failure() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let deliveries = Arc::new(Mutex::new(Vec::new()));
+    let config = OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE))
+        .with_retry_settings(fast_retry_settings());
+    let outbox = init_outbox_with_handler_config(
+        &pool,
+        &mut jobs,
+        config,
+        IsolatingEffectHandler {
+            deliveries: deliveries.clone(),
+            isolate_on: 3,
+            fail_isolated_once: Arc::new(AtomicBool::new(false)),
+        },
+    )
+    .await?;
+
+    const N: u64 = 3;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    wait_for_effect_rows(&pool, N as usize).await?;
+    assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3]);
+
+    // Events 1 and 2 were landed (batch flush at the isolation fence or
+    // earlier) before event 3's isolated op failed — so only event 3
+    // replays. With PR-#84-style runner batching, the whole batch would
+    // have rolled back and events 1 and 2 would replay too.
+    let deliveries = deliveries.lock().await;
+    let count = |v: u64| deliveries.iter().filter(|&&n| n == v).count();
+    assert_eq!(
+        count(1),
+        1,
+        "event 1 must not replay with the isolated failure, deliveries: {deliveries:?}"
+    );
+    assert_eq!(
+        count(2),
+        1,
+        "event 2 must not replay with the isolated failure, deliveries: {deliveries:?}"
+    );
+    assert!(
+        count(3) >= 2,
+        "event 3 must replay alone, deliveries: {deliveries:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn skipped_events_advance_checkpoint_lazily() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let config = OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE))
+        .with_checkpoint_interval(std::time::Duration::from_millis(100));
+    let outbox = init_outbox_with_handler_config(
+        &pool,
+        &mut jobs,
+        config,
+        SkippingObserver {
+            received: received.clone(),
+        },
+    )
+    .await?;
+
+    jobs.start_poll().await?;
+
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=3u64 {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    wait_for_n_deliveries(&received, 3, std::time::Duration::from_secs(5)).await?;
+
+    // No transaction ever ran for these events, yet the checkpoint catches
+    // up within ~checkpoint_interval via the standalone pointer write.
+    // (Sequences are deterministic: the wipeout restarts identity at 1.)
+    wait_for_checkpoint(&pool, 3).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn on_flush_coalesces_accumulated_writes() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let flush_count = Arc::new(AtomicUsize::new(0));
+    let outbox = init_outbox_with_handler(
+        &pool,
+        &mut jobs,
+        AccumulatingHandler {
+            pending: Arc::new(std::sync::Mutex::new(Vec::new())),
+            flush_count: flush_count.clone(),
+        },
+    )
+    .await?;
+
+    // Publish before the job starts so the events arrive as ready backlog.
+    const N: u64 = 50;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    wait_for_effect_rows(&pool, N as usize).await?;
+    assert_eq!(
+        batch_effect_rows(&pool).await?,
+        (1..=N as i64).collect::<Vec<_>>()
+    );
+
+    // The write-backs were coalesced: strictly fewer flushes than events.
+    let flushes = flush_count.load(Ordering::SeqCst);
+    assert!(
+        flushes < N as usize,
+        "expected fewer flushes than events, got {flushes}"
+    );
+
+    // The checkpoint lands with the last batch. (Sequences are
+    // deterministic: the wipeout restarts identity at 1.)
+    wait_for_checkpoint(&pool, N as i64).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn single_deferred_event_commits_promptly_at_low_traffic() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let deliveries = Arc::new(Mutex::new(Vec::new()));
+    let outbox = init_outbox_with_handler(
+        &pool,
+        &mut jobs,
+        DeferringEffectHandler {
+            deliveries: deliveries.clone(),
+            fail_on_first: None,
+            failed: Arc::new(AtomicBool::new(false)),
+        },
+    )
+    .await?;
+
+    jobs.start_poll().await?;
+
+    // Let the job start and go idle.
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let published_at = std::time::Instant::now();
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+        .await?;
+    op.commit().await?;
+
+    // A deferred op is never held open waiting for future events: the
+    // moment the backlog is drained the batch (of one) lands — work AND
+    // checkpoint — with no configured wait.
+    wait_for_effect_rows(&pool, 1).await?;
+    wait_for_checkpoint(&pool, 1).await?;
+    let latency = published_at.elapsed();
+    assert!(
+        latency < std::time::Duration::from_secs(2),
+        "single deferred event took {latency:?} to land"
+    );
 
     Ok(())
 }

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -174,6 +174,50 @@ impl OutboxEventHandler<TestEvent> for IsolatingEffectHandler {
     }
 }
 
+/// Slow deferring worker that also records ephemerals and counts flushes —
+/// used to prove an ephemeral arriving mid-batch lands the open batch first.
+struct SlowDeferringHandler {
+    ephemeral_received: Arc<Mutex<Vec<u64>>>,
+    flush_count: Arc<AtomicUsize>,
+}
+
+impl OutboxEventHandler<TestEvent> for SlowDeferringHandler {
+    async fn handle_persistent(
+        &self,
+        ctx: EventCtx<'_>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
+        use es_entity::AtomicOperation;
+        let Some(TestEvent::Ping(n)) = &event.payload else {
+            return Ok(ctx.skip());
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let mut op = ctx.consume_in_batch().await?;
+        sqlx::query("INSERT INTO test_batch_effects (n) VALUES ($1)")
+            .bind(*n as i64)
+            .execute(op.as_executor())
+            .await?;
+        Ok(op.defer())
+    }
+
+    async fn handle_ephemeral(
+        &self,
+        event: &obix::out::EphemeralOutboxEvent<TestEvent>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let TestEvent::Ping(n) = &event.payload;
+        self.ephemeral_received.lock().await.push(*n);
+        Ok(())
+    }
+
+    async fn on_flush(
+        &self,
+        _op: &mut es_entity::DbOp<'_>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.flush_count.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
 /// Aggregator: accumulates event values in memory across deferred events and
 /// writes them back in `on_flush` — one write-back per batch, not per event.
 struct AccumulatingHandler {
@@ -806,6 +850,67 @@ async fn on_flush_coalesces_accumulated_writes() -> anyhow::Result<()> {
     // The checkpoint lands with the last batch. (Sequences are
     // deterministic: the wipeout restarts identity at 1.)
     wait_for_checkpoint(&pool, N as i64).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn ephemeral_arriving_mid_batch_lands_the_open_batch_first() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let ephemeral_received = Arc::new(Mutex::new(Vec::new()));
+    let flush_count = Arc::new(AtomicUsize::new(0));
+    let outbox = init_outbox_with_handler(
+        &pool,
+        &mut jobs,
+        SlowDeferringHandler {
+            ephemeral_received: ephemeral_received.clone(),
+            flush_count: flush_count.clone(),
+        },
+    )
+    .await?;
+
+    // Publish a backlog of slow (100ms each) deferring events, then land an
+    // ephemeral while the batch is guaranteed to still be open mid-drain.
+    const N: u64 = 5;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    outbox
+        .publish_ephemeral(
+            obix::out::EphemeralEventType::new("mid_batch"),
+            TestEvent::Ping(9),
+        )
+        .await?;
+
+    wait_for_effect_rows(&pool, N as usize).await?;
+    wait_for_n_deliveries(&ephemeral_received, 1, std::time::Duration::from_secs(5)).await?;
+
+    // The ephemeral truncated the open batch (flush reason "ephemeral"), so
+    // the drain took at least two flushes instead of one — and the open
+    // transaction was never held across the ephemeral handler's await.
+    let flushes = flush_count.load(Ordering::SeqCst);
+    assert!(
+        flushes >= 2,
+        "expected the mid-batch ephemeral to land the open batch, flushes: {flushes}"
+    );
+    assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3, 4, 5]);
 
     Ok(())
 }

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -1,7 +1,7 @@
 mod helpers;
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use obix::{
     EventCtx, Handled, MailboxConfig, OutboxEventHandler, OutboxEventJobConfig, out::Outbox,
@@ -174,11 +174,13 @@ impl OutboxEventHandler<TestEvent> for IsolatingEffectHandler {
     }
 }
 
-/// Slow deferring worker that also records ephemerals and counts flushes —
-/// used to prove an ephemeral arriving mid-batch lands the open batch first.
+/// Slow deferring worker that also records ephemerals and snapshots the
+/// committed effect rows when an ephemeral runs — used to prove an
+/// ephemeral arriving mid-batch lands the open batch first.
 struct SlowDeferringHandler {
+    pool: sqlx::PgPool,
     ephemeral_received: Arc<Mutex<Vec<u64>>>,
-    flush_count: Arc<AtomicUsize>,
+    rows_at_ephemeral: Arc<Mutex<usize>>,
 }
 
 impl OutboxEventHandler<TestEvent> for SlowDeferringHandler {
@@ -206,52 +208,11 @@ impl OutboxEventHandler<TestEvent> for SlowDeferringHandler {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let TestEvent::Ping(n) = &event.payload;
         self.ephemeral_received.lock().await.push(*n);
-        Ok(())
-    }
-
-    async fn on_flush(
-        &self,
-        _op: &mut es_entity::DbOp<'_>,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        self.flush_count.fetch_add(1, Ordering::SeqCst);
-        Ok(())
-    }
-}
-
-/// Aggregator: accumulates event values in memory across deferred events and
-/// writes them back in `on_flush` — one write-back per batch, not per event.
-struct AccumulatingHandler {
-    pending: Arc<std::sync::Mutex<Vec<i64>>>,
-    flush_count: Arc<AtomicUsize>,
-}
-
-impl OutboxEventHandler<TestEvent> for AccumulatingHandler {
-    async fn handle_persistent<'inv>(
-        &self,
-        ctx: EventCtx<'inv>,
-        event: &obix::out::PersistentOutboxEvent<TestEvent>,
-    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
-        let Some(TestEvent::Ping(n)) = &event.payload else {
-            return Ok(ctx.skip());
-        };
-        self.pending.lock().expect("lock").push(*n as i64);
-        let op = ctx.consume_in_batch().await?;
-        Ok(op.defer())
-    }
-
-    async fn on_flush(
-        &self,
-        op: &mut es_entity::DbOp<'_>,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        use es_entity::AtomicOperation;
-        let drained: Vec<i64> = std::mem::take(&mut *self.pending.lock().expect("lock"));
-        for n in drained {
-            sqlx::query("INSERT INTO test_batch_effects (n) VALUES ($1)")
-                .bind(n)
-                .execute(op.as_executor())
-                .await?;
-        }
-        self.flush_count.fetch_add(1, Ordering::SeqCst);
+        let rows = batch_effect_rows(&self.pool)
+            .await
+            .expect("read effect rows")
+            .len();
+        *self.rows_at_ephemeral.lock().await = rows;
         Ok(())
     }
 }
@@ -801,61 +762,6 @@ async fn skipped_events_advance_checkpoint_lazily() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[file_serial]
-async fn on_flush_coalesces_accumulated_writes() -> anyhow::Result<()> {
-    let pool = init_pool().await?;
-    reset_batch_effects_table(&pool).await?;
-
-    let job_config = job::JobSvcConfig::builder()
-        .pool(pool.clone())
-        .build()
-        .unwrap();
-    let mut jobs = job::Jobs::init(job_config).await?;
-
-    let flush_count = Arc::new(AtomicUsize::new(0));
-    let outbox = init_outbox_with_handler(
-        &pool,
-        &mut jobs,
-        AccumulatingHandler {
-            pending: Arc::new(std::sync::Mutex::new(Vec::new())),
-            flush_count: flush_count.clone(),
-        },
-    )
-    .await?;
-
-    // Publish before the job starts so the events arrive as ready backlog.
-    const N: u64 = 50;
-    let mut op = outbox.begin_op().await?;
-    for n in 1..=N {
-        outbox
-            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
-            .await?;
-    }
-    op.commit().await?;
-
-    jobs.start_poll().await?;
-
-    wait_for_effect_rows(&pool, N as usize).await?;
-    assert_eq!(
-        batch_effect_rows(&pool).await?,
-        (1..=N as i64).collect::<Vec<_>>()
-    );
-
-    // The write-backs were coalesced: strictly fewer flushes than events.
-    let flushes = flush_count.load(Ordering::SeqCst);
-    assert!(
-        flushes < N as usize,
-        "expected fewer flushes than events, got {flushes}"
-    );
-
-    // The checkpoint lands with the last batch. (Sequences are
-    // deterministic: the wipeout restarts identity at 1.)
-    wait_for_checkpoint(&pool, N as i64).await?;
-
-    Ok(())
-}
-
-#[tokio::test]
-#[file_serial]
 async fn ephemeral_arriving_mid_batch_lands_the_open_batch_first() -> anyhow::Result<()> {
     let pool = init_pool().await?;
     reset_batch_effects_table(&pool).await?;
@@ -867,13 +773,14 @@ async fn ephemeral_arriving_mid_batch_lands_the_open_batch_first() -> anyhow::Re
     let mut jobs = job::Jobs::init(job_config).await?;
 
     let ephemeral_received = Arc::new(Mutex::new(Vec::new()));
-    let flush_count = Arc::new(AtomicUsize::new(0));
+    let rows_at_ephemeral = Arc::new(Mutex::new(0usize));
     let outbox = init_outbox_with_handler(
         &pool,
         &mut jobs,
         SlowDeferringHandler {
+            pool: pool.clone(),
             ephemeral_received: ephemeral_received.clone(),
-            flush_count: flush_count.clone(),
+            rows_at_ephemeral: rows_at_ephemeral.clone(),
         },
     )
     .await?;
@@ -902,13 +809,18 @@ async fn ephemeral_arriving_mid_batch_lands_the_open_batch_first() -> anyhow::Re
     wait_for_effect_rows(&pool, N as usize).await?;
     wait_for_n_deliveries(&ephemeral_received, 1, std::time::Duration::from_secs(5)).await?;
 
-    // The ephemeral truncated the open batch (flush reason "ephemeral"), so
-    // the drain took at least two flushes instead of one — and the open
+    // The ephemeral truncated the open batch (flush reason "ephemeral"):
+    // the work buffered so far was already committed when the ephemeral
+    // handler ran, and the drain continued afterwards — the open
     // transaction was never held across the ephemeral handler's await.
-    let flushes = flush_count.load(Ordering::SeqCst);
+    let rows_at_ephemeral = *rows_at_ephemeral.lock().await;
     assert!(
-        flushes >= 2,
-        "expected the mid-batch ephemeral to land the open batch, flushes: {flushes}"
+        rows_at_ephemeral >= 1,
+        "expected the open batch to land before the ephemeral ran"
+    );
+    assert!(
+        rows_at_ephemeral < N as usize,
+        "expected the ephemeral to arrive mid-drain, rows_at_ephemeral: {rows_at_ephemeral}"
     );
     assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3, 4, 5]);
 

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -26,11 +26,11 @@ struct SkippingObserver {
 }
 
 impl OutboxEventHandler<TestEvent> for SkippingObserver {
-    async fn handle_persistent(
+    async fn handle_persistent<'inv>(
         &self,
-        ctx: EventCtx<'_>,
+        ctx: EventCtx<'inv>,
         event: &obix::out::PersistentOutboxEvent<TestEvent>,
-    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
         if let Some(TestEvent::Ping(n)) = &event.payload {
             self.received.lock().await.push(*n);
         }
@@ -44,11 +44,11 @@ struct CheckpointingObserver {
 }
 
 impl OutboxEventHandler<TestEvent> for CheckpointingObserver {
-    async fn handle_persistent(
+    async fn handle_persistent<'inv>(
         &self,
-        ctx: EventCtx<'_>,
+        ctx: EventCtx<'inv>,
         event: &obix::out::PersistentOutboxEvent<TestEvent>,
-    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
         if let Some(TestEvent::Ping(n)) = &event.payload {
             self.received.lock().await.push(*n);
         }
@@ -78,11 +78,11 @@ struct TestBothHandler {
 }
 
 impl OutboxEventHandler<TestEvent> for TestBothHandler {
-    async fn handle_persistent(
+    async fn handle_persistent<'inv>(
         &self,
-        ctx: EventCtx<'_>,
+        ctx: EventCtx<'inv>,
         event: &obix::out::PersistentOutboxEvent<TestEvent>,
-    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
         if let Some(TestEvent::Ping(n)) = &event.payload {
             self.persistent_received.lock().await.push(*n);
         }
@@ -110,11 +110,11 @@ struct DeferringEffectHandler {
 }
 
 impl OutboxEventHandler<TestEvent> for DeferringEffectHandler {
-    async fn handle_persistent(
+    async fn handle_persistent<'inv>(
         &self,
-        ctx: EventCtx<'_>,
+        ctx: EventCtx<'inv>,
         event: &obix::out::PersistentOutboxEvent<TestEvent>,
-    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
         use es_entity::AtomicOperation;
         let Some(TestEvent::Ping(n)) = &event.payload else {
             return Ok(ctx.skip());
@@ -142,11 +142,11 @@ struct IsolatingEffectHandler {
 }
 
 impl OutboxEventHandler<TestEvent> for IsolatingEffectHandler {
-    async fn handle_persistent(
+    async fn handle_persistent<'inv>(
         &self,
-        ctx: EventCtx<'_>,
+        ctx: EventCtx<'inv>,
         event: &obix::out::PersistentOutboxEvent<TestEvent>,
-    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
         use es_entity::AtomicOperation;
         let Some(TestEvent::Ping(n)) = &event.payload else {
             return Ok(ctx.skip());
@@ -182,11 +182,11 @@ struct SlowDeferringHandler {
 }
 
 impl OutboxEventHandler<TestEvent> for SlowDeferringHandler {
-    async fn handle_persistent(
+    async fn handle_persistent<'inv>(
         &self,
-        ctx: EventCtx<'_>,
+        ctx: EventCtx<'inv>,
         event: &obix::out::PersistentOutboxEvent<TestEvent>,
-    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
         use es_entity::AtomicOperation;
         let Some(TestEvent::Ping(n)) = &event.payload else {
             return Ok(ctx.skip());
@@ -226,11 +226,11 @@ struct AccumulatingHandler {
 }
 
 impl OutboxEventHandler<TestEvent> for AccumulatingHandler {
-    async fn handle_persistent(
+    async fn handle_persistent<'inv>(
         &self,
-        ctx: EventCtx<'_>,
+        ctx: EventCtx<'inv>,
         event: &obix::out::PersistentOutboxEvent<TestEvent>,
-    ) -> Result<Handled, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
         let Some(TestEvent::Ping(n)) = &event.payload else {
             return Ok(ctx.skip());
         };


### PR DESCRIPTION
## Problem

Same problem as #84: under a 1 loan/sec stress-test sandbox, `UPDATE job_executions SET execution_state_json` was the #1 steady-state DB statement (~250 calls/sec, ~22% of DB time, ~300 BEGIN/sec of txn churn) — 32 `outbox.*` listener jobs each opening one `DbOp` + checkpoint per persistent event, **including events their handler ignores**.

## Approach — alternative to #84

#84 batches uniformly in the runner (N-or-time), which has two structural costs: the handler never knows when its work commits (a batch can sit waiting on events its own uncommitted work is blocking, +flush-timeout latency per causal hop), and no-op events still ride transactions. This PR instead puts the transactional fate of every event **under handler control**.

`handle_persistent` receives an `EventCtx` it must resolve into a `Handled` proof token — the type system forces exactly one legal path per event:

| path | txn cost | fate sharing | commit happens |
|---|---|---|---|
| `ctx.skip()` | **zero** | — | never; pointer advances lazily |
| `ctx.consume_in_batch()` → `.defer()` | shared | past + future neighbors | backlog drained / max_batch_size / a later commit or isolation / shutdown |
| `ctx.consume_in_batch()` → `.commit()` | shared | past only | at return — whole batch lands |
| `ctx.consume_isolated()` → `.commit()` | own op | **none** — pending batch (work + checkpoint) lands at entry | at return |

- **Illegal states are unrepresentable**: `Handled` has no public constructor; `IsolatedOp` has no `defer()`; the raw `DbOp::commit`/rollback are unreachable (they consume by value, `Deref` only yields `&mut`); there is no flush primitive that skips the checkpoint. Reviewing a handler's transactional posture = reading its return expressions.
- **Batching adds no latency**: a deferred op is only open while there is *ready backlog* (`now_or_never` polling — the transaction is never held open waiting on the network; a pending stream is itself the flush trigger). Batching rides bursts that already happened; there is deliberately no batch-time knob. `batch_size` is emergent, capped by `with_max_batch_size` (default 100) as a replay-window backstop — handlers remain the primary size control by exiting with `.commit()`.
- **No-op events cost nothing**: skips advance the pointer in memory; it persists piggybacked on the next flush or via a standalone write bounded by `with_checkpoint_interval` (default 5s — bounds harmless no-op replay after a crash, never delays handling).
- **`on_flush` was split out to #87** during review: the "accumulate in memory, write back on flush" pattern is unsafe across job retries (the handler `Arc` is long-lived, so an in-memory accumulator survives a failed run and double-applies on replay). Fold-style handlers stay on `consume_isolated().commit()` until the retry-safety design lands there.
- **Checkpoint invariant**: every commit persists the last *fully handled* sequence (skips included) atomically with exactly the work it describes. `consume_isolated`'s entry-flush checkpoints history at N-1; there is no representable state where committed work and pointer diverge.

## Example

```rust
use obix::{EventCtx, Handled, OutboxEventHandler};

impl OutboxEventHandler<LanaEvent> for DwRelayHandler {
    async fn handle_persistent<'inv>(
        &self,
        ctx: EventCtx<'inv>,
        event: &PersistentOutboxEvent<LanaEvent>,
    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
        // Not my event → zero cost, no transaction, pointer advances lazily.
        let Some(row) = relay_row(event) else { return Ok(ctx.skip()) };

        // Join the pending batch op (opens one on first use). Under a burst,
        // up to max_batch_size events share ONE transaction + ONE checkpoint.
        let mut op = ctx.consume_in_batch().await?;
        self.spawner.spawn_in_op(&mut *op, insert_job(row)).await?;
        Ok(op.defer()) // leave open for the next event to coalesce into
    }
}

// A causally-significant event instead wants its own atomic unit:
//   let mut op = ctx.consume_isolated().await?; // lands pending batch first
//   apply(&mut *op, cmd).await?;
//   Ok(op.commit())                             // durable at return
```

## Delivery semantics

Unchanged in kind: at-least-once delivery, exactly-once for in-op DB effects. The replay window is **chosen locally**: 1 event for skip/isolated paths (exact legacy), ≤ batch for handlers that opted into `.defer()` — the audit #84 had to run globally ("is every handler batch-safe?") becomes a per-handler, per-line decision.

## Migration (lana-bank, follow-up)

Mechanical: port all 32 handlers to `consume_isolated().commit()` (byte-identical behavior to today), add `skip()` arms where the pattern-match already ignores events (most of the 250/s win), then upgrade the hot always-acting handlers (dw-outbox-relay, dashboard) to `consume_in_batch().defer()` one deliberate line at a time.

## Tests

31/31 green (`cargo nextest run`, 3× stable), clippy clean, `nix flake check` passing. New coverage:

- `deferred_batch_replays_wholesale_on_mid_batch_failure` — batch fate-sharing + exactly-once effects
- `isolated_event_fences_prior_batch_from_its_failure` — events 1–2 land and never replay when isolated event 3 fails; only 3 retries (the differentiator vs #84's whole-batch rollback)
- `skipped_events_advance_checkpoint_lazily` — pointer catch-up with zero transactions
- `ephemeral_arriving_mid_batch_lands_the_open_batch_first` — pre-ephemeral flush proven via committed-row snapshot (the `on_flush`-based coalescing test moved to #87)
- `single_deferred_event_commits_promptly_at_low_traffic` — no added latency on an idle stream
- ported observer/ephemeral/restart tests

Ref: task brief `handoffs/2026-07-22-obix-checkpoint-batching.md`; design write-up: [obix-dev/handler-controlled-tx-scoping.md](https://github.com/GaloyMoney/drua-library/blob/main/spaces/obix-dev/handler-controlled-tx-scoping.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking handler API and redesigned job-runner transaction/checkpoint semantics affect all outbox listeners; incorrect batch vs isolated choices can change replay scope and durability timing.
> 
> **Overview**
> **Breaking change:** `OutboxEventHandler::handle_persistent` no longer takes `&mut DbOp`; it takes `EventCtx` and must return a `Handled` token from `skip()`, or from `consume_in_batch()` / `consume_isolated()` followed by `defer()` or `commit()`.
> 
> The event-handler job runner was rewritten to coalesce work into shared transactions when handlers defer, flush on backlog drain / `max_batch_size` / commit / isolation / ephemeral interleaving / shutdown, and persist checkpoints atomically with batch commits or on a timer for skip-only stretches. `OutboxEventJobConfig` gains `with_max_batch_size` (default 100) and `with_checkpoint_interval` (default 5s).
> 
> New public types `EventCtx`, `Handled`, `BatchOp`, and `IsolatedOp` live in `out/ctx.rs` and are re-exported from the crate root. Integration tests cover batch replay on failure, isolation fencing, lazy skip checkpoints, ephemeral mid-batch flush, and low-traffic defer latency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feb0ff767e7730929aa85ac617702f89553d5533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



