### PR TITLE
feat(outbox): on_flush write-back hook for batching handlers (retry-safety design pending)

### DIFF
--- a/src/out/ctx.rs
+++ b/src/out/ctx.rs
@@ -25,9 +25,10 @@
 //! therefore rides bursts that already happened and adds no latency at low
 //! traffic.
 //!
-//! Every flush — whichever of the triggers fires — persists the checkpoint
-//! at the last *fully handled* sequence (skips included), then commits:
-//! work and pointer are inseparable.
+//! Every flush — whichever of the triggers fires — runs
+//! [`on_flush`](super::OutboxEventHandler::on_flush), then persists the
+//! checkpoint at the last *fully handled* sequence (skips included), then
+//! commits: work and pointer are inseparable.
 
 use serde::{Deserialize, Serialize};
 
@@ -39,6 +40,17 @@ use crate::sequence::EventSequence;
 
 /// Error type shared with the handler trait methods.
 pub(crate) type HandlerError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Type-erased [`on_flush`](super::OutboxEventHandler::on_flush) callback so
+/// that [`EventCtx::consume_isolated`] can flush the pending batch from
+/// within a handler invocation.
+pub(crate) type FlushHook = Box<
+    dyn for<'a> Fn(
+            &'a mut es_entity::DbOp<'static>,
+        ) -> futures::future::BoxFuture<'a, Result<(), HandlerError>>
+        + Send
+        + Sync,
+>;
 
 /// Persisted execution state of an outbox event-handler job: the sequence of
 /// the last fully handled persistent event.
@@ -62,6 +74,7 @@ pub(crate) struct CtxParts<'inv> {
     pub(crate) current_job: &'inv mut CurrentJob,
     pub(crate) state: &'inv OutboxEventJobState,
     pub(crate) tracker: &'inv mut BatchTracker,
+    pub(crate) on_flush: &'inv FlushHook,
 }
 
 /// Proof that a persistent event was resolved in one of the legal ways.
@@ -178,7 +191,7 @@ pub struct BatchOp<'inv> {
 
 impl<'inv> BatchOp<'inv> {
     /// Land the whole batch (my work included) when the invocation returns:
-    /// checkpoint at my sequence → commit.
+    /// `on_flush` → checkpoint at my sequence → commit.
     pub fn commit(self) -> Handled<'inv> {
         Handled {
             outcome: Outcome::Commit,
@@ -258,8 +271,8 @@ impl std::ops::DerefMut for IsolatedOp<'_> {
     }
 }
 
-/// Land the pending batch op, if any: checkpoint at the last fully handled
-/// sequence → commit. No-op when no op is open.
+/// Land the pending batch op, if any: `on_flush` → checkpoint at the last
+/// fully handled sequence → commit. No-op when no op is open.
 #[tracing::instrument(
     name = "outbox.flush_batch",
     skip_all,
@@ -277,6 +290,7 @@ pub(crate) async fn flush_batch(
     let Some(mut op) = parts.op_slot.take() else {
         return Ok(());
     };
+    (parts.on_flush)(&mut op).await?;
     parts
         .current_job
         .update_execution_state_in_op(&mut op, parts.state)

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -34,6 +34,10 @@ use crate::tables::MailboxTables;
 ///   pending batch (work + checkpoint) lands before my work starts, and my
 ///   op commits at return. Exact legacy per-event semantics when nothing is
 ///   pending. Use for causally significant or risky work.
+///
+/// [`on_flush`](Self::on_flush) is called immediately before *any* batch op
+/// commits — the guaranteed write-back point for handlers that accumulate
+/// state across [`consume_in_batch`](EventCtx::consume_in_batch) calls.
 pub trait OutboxEventHandler<P>: Send + Sync + 'static
 where
     P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
@@ -55,6 +59,20 @@ where
     ) -> impl std::future::Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send
     {
         let _ = event;
+        async { Ok(()) }
+    }
+
+    /// Called immediately before a batch op commits (any flush trigger,
+    /// including a later event's [`consume_isolated`](EventCtx::consume_isolated)
+    /// entry). Handlers that accumulate state across deferred events write
+    /// it back here — it lands in the same transaction as the batch and its
+    /// checkpoint.
+    fn on_flush(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+    ) -> impl std::future::Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send
+    {
+        let _ = op;
         async { Ok(()) }
     }
 }
@@ -206,6 +224,14 @@ where
             last_persist: tokio::time::Instant::now(),
         };
 
+        let on_flush: FlushHook = {
+            let handler = self.handler.clone();
+            Box::new(move |op| {
+                let handler = handler.clone();
+                Box::pin(async move { handler.on_flush(op).await })
+            })
+        };
+
         loop {
             let event = if op_slot.is_some() {
                 // A batch op is open: only take events that are already
@@ -219,6 +245,7 @@ where
                             current_job: &mut current_job,
                             state: &state,
                             tracker: &mut tracker,
+                            on_flush: &on_flush,
                         };
                         flush_batch(&mut parts, "stream_closed")
                             .await
@@ -231,6 +258,7 @@ where
                             current_job: &mut current_job,
                             state: &state,
                             tracker: &mut tracker,
+                            on_flush: &on_flush,
                         };
                         flush_batch(&mut parts, "backlog_drained")
                             .await
@@ -285,6 +313,7 @@ where
                             current_job: &mut current_job,
                             state: &state,
                             tracker: &mut tracker,
+                            on_flush: &on_flush,
                         };
                         flush_batch(&mut parts, "ephemeral")
                             .await
@@ -302,6 +331,7 @@ where
                             current_job: &mut current_job,
                             state: &state,
                             tracker: &mut tracker,
+                            on_flush: &on_flush,
                         },
                     };
                     // The Handled token is branded with the invocation
@@ -325,6 +355,7 @@ where
                                 current_job: &mut current_job,
                                 state: &state,
                                 tracker: &mut tracker,
+                                on_flush: &on_flush,
                             };
                             flush_batch(&mut parts, "commit")
                                 .await
@@ -337,6 +368,7 @@ where
                                     current_job: &mut current_job,
                                     state: &state,
                                     tracker: &mut tracker,
+                                    on_flush: &on_flush,
                                 };
                                 flush_batch(&mut parts, "batch_full")
                                     .await

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -1,7 +1,7 @@
 mod helpers;
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use obix::{
     EventCtx, Handled, MailboxConfig, OutboxEventHandler, OutboxEventJobConfig, out::Outbox,
@@ -174,13 +174,11 @@ impl OutboxEventHandler<TestEvent> for IsolatingEffectHandler {
     }
 }
 
-/// Slow deferring worker that also records ephemerals and snapshots the
-/// committed effect rows when an ephemeral runs — used to prove an
-/// ephemeral arriving mid-batch lands the open batch first.
+/// Slow deferring worker that also records ephemerals and counts flushes —
+/// used to prove an ephemeral arriving mid-batch lands the open batch first.
 struct SlowDeferringHandler {
-    pool: sqlx::PgPool,
     ephemeral_received: Arc<Mutex<Vec<u64>>>,
-    rows_at_ephemeral: Arc<Mutex<usize>>,
+    flush_count: Arc<AtomicUsize>,
 }
 
 impl OutboxEventHandler<TestEvent> for SlowDeferringHandler {
@@ -208,11 +206,52 @@ impl OutboxEventHandler<TestEvent> for SlowDeferringHandler {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let TestEvent::Ping(n) = &event.payload;
         self.ephemeral_received.lock().await.push(*n);
-        let rows = batch_effect_rows(&self.pool)
-            .await
-            .expect("read effect rows")
-            .len();
-        *self.rows_at_ephemeral.lock().await = rows;
+        Ok(())
+    }
+
+    async fn on_flush(
+        &self,
+        _op: &mut es_entity::DbOp<'_>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.flush_count.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+/// Aggregator: accumulates event values in memory across deferred events and
+/// writes them back in `on_flush` — one write-back per batch, not per event.
+struct AccumulatingHandler {
+    pending: Arc<std::sync::Mutex<Vec<i64>>>,
+    flush_count: Arc<AtomicUsize>,
+}
+
+impl OutboxEventHandler<TestEvent> for AccumulatingHandler {
+    async fn handle_persistent<'inv>(
+        &self,
+        ctx: EventCtx<'inv>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
+        let Some(TestEvent::Ping(n)) = &event.payload else {
+            return Ok(ctx.skip());
+        };
+        self.pending.lock().expect("lock").push(*n as i64);
+        let op = ctx.consume_in_batch().await?;
+        Ok(op.defer())
+    }
+
+    async fn on_flush(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use es_entity::AtomicOperation;
+        let drained: Vec<i64> = std::mem::take(&mut *self.pending.lock().expect("lock"));
+        for n in drained {
+            sqlx::query("INSERT INTO test_batch_effects (n) VALUES ($1)")
+                .bind(n)
+                .execute(op.as_executor())
+                .await?;
+        }
+        self.flush_count.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
 }
@@ -762,6 +801,61 @@ async fn skipped_events_advance_checkpoint_lazily() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[file_serial]
+async fn on_flush_coalesces_accumulated_writes() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let flush_count = Arc::new(AtomicUsize::new(0));
+    let outbox = init_outbox_with_handler(
+        &pool,
+        &mut jobs,
+        AccumulatingHandler {
+            pending: Arc::new(std::sync::Mutex::new(Vec::new())),
+            flush_count: flush_count.clone(),
+        },
+    )
+    .await?;
+
+    // Publish before the job starts so the events arrive as ready backlog.
+    const N: u64 = 50;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    wait_for_effect_rows(&pool, N as usize).await?;
+    assert_eq!(
+        batch_effect_rows(&pool).await?,
+        (1..=N as i64).collect::<Vec<_>>()
+    );
+
+    // The write-backs were coalesced: strictly fewer flushes than events.
+    let flushes = flush_count.load(Ordering::SeqCst);
+    assert!(
+        flushes < N as usize,
+        "expected fewer flushes than events, got {flushes}"
+    );
+
+    // The checkpoint lands with the last batch. (Sequences are
+    // deterministic: the wipeout restarts identity at 1.)
+    wait_for_checkpoint(&pool, N as i64).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
 async fn ephemeral_arriving_mid_batch_lands_the_open_batch_first() -> anyhow::Result<()> {
     let pool = init_pool().await?;
     reset_batch_effects_table(&pool).await?;
@@ -773,14 +867,13 @@ async fn ephemeral_arriving_mid_batch_lands_the_open_batch_first() -> anyhow::Re
     let mut jobs = job::Jobs::init(job_config).await?;
 
     let ephemeral_received = Arc::new(Mutex::new(Vec::new()));
-    let rows_at_ephemeral = Arc::new(Mutex::new(0usize));
+    let flush_count = Arc::new(AtomicUsize::new(0));
     let outbox = init_outbox_with_handler(
         &pool,
         &mut jobs,
         SlowDeferringHandler {
-            pool: pool.clone(),
             ephemeral_received: ephemeral_received.clone(),
-            rows_at_ephemeral: rows_at_ephemeral.clone(),
+            flush_count: flush_count.clone(),
         },
     )
     .await?;
@@ -809,18 +902,13 @@ async fn ephemeral_arriving_mid_batch_lands_the_open_batch_first() -> anyhow::Re
     wait_for_effect_rows(&pool, N as usize).await?;
     wait_for_n_deliveries(&ephemeral_received, 1, std::time::Duration::from_secs(5)).await?;
 
-    // The ephemeral truncated the open batch (flush reason "ephemeral"):
-    // the work buffered so far was already committed when the ephemeral
-    // handler ran, and the drain continued afterwards — the open
+    // The ephemeral truncated the open batch (flush reason "ephemeral"), so
+    // the drain took at least two flushes instead of one — and the open
     // transaction was never held across the ephemeral handler's await.
-    let rows_at_ephemeral = *rows_at_ephemeral.lock().await;
+    let flushes = flush_count.load(Ordering::SeqCst);
     assert!(
-        rows_at_ephemeral >= 1,
-        "expected the open batch to land before the ephemeral ran"
-    );
-    assert!(
-        rows_at_ephemeral < N as usize,
-        "expected the ephemeral to arrive mid-drain, rows_at_ephemeral: {rows_at_ephemeral}"
+        flushes >= 2,
+        "expected the mid-batch ephemeral to land the open batch, flushes: {flushes}"
     );
     assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3, 4, 5]);
 


### PR DESCRIPTION
## Status: design decision pending — do not merge as-is

Split out of #86 during review. This PR re-adds the `on_flush` hook (called immediately before any batch op commits — the guaranteed write-back point for aggregating handlers) so the main handler-controlled-batching PR can merge without it.

## The problem to solve before this can merge

The advertised pattern — *accumulate N events in memory, write back once per batch in `on_flush`* — **double-applies across job retries**:

1. The handler instance is long-lived across retries: `OutboxEventJobInitializer` holds `handler: Arc<H>` and clones it into every runner; the `job` crate's registry calls `init_job` per execution. An in-memory accumulator (necessarily interior-mutable — `handle_persistent`/`on_flush` take `&self`) **survives a failed run**.
2. On a mid-batch failure the op rolls back and the events **replay into the same handler instance**, whose accumulator still holds the pre-failure values → the next `on_flush` write-back lands the accumulated values twice. Absolute-write, write-and-clear, and relative-write (`v = v + delta`) variants are all unsafe; there is no run-start/reset hook.

The batching PR's "exactly-once for in-op DB effects" guarantee covers op-mediated writes only — in-memory accumulation is precisely not that.

## Options to decide between

1. **Contract the hook to durable-derived write-backs** — `on_flush` recomputes from durable state read *inside the op* (e.g. cala rollups recompute from `cala_*` tables in-transaction), never from cross-run memory. Document + add a test pinning retry behavior of an accumulating handler.
2. **Add a per-run reset hook** (e.g. `on_run_start`) so in-memory accumulators are rebuilt on job retry.
3. **Land it with its first real consumer** (the cala-rollup handler) so semantics are pinned by an actual use case rather than a synthetic one.

## Content

Byte-identical to the `on_flush` code as merged-reviewed in #86 @ 4ddd439 (hook on the trait, `FlushHook` plumbing in the runner, `AccumulatingHandler` test `on_flush_coalesces_accumulated_writes`, flush-count assertion in the ephemeral test). Until this merges, fold-style handlers use `consume_isolated().commit()` — legacy per-event semantics — which is what all current lana-bank handlers do anyway.

Ref: review discussion on #86.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transactional flush ordering for all batching handlers; the advertised in-memory accumulate-then-flush pattern can double-apply effects on job retry until semantics are pinned.
> 
> **Overview**
> Adds an **`on_flush`** lifecycle hook on **`OutboxEventHandler`**, invoked immediately before every batch op commit (all existing flush triggers: backlog drained, commit, batch full, ephemeral mid-batch, isolated entry, stream closed).
> 
> **`flush_batch`** now runs **`on_flush` → checkpoint → commit** instead of checkpoint-only. The runner exposes the handler through a type-erased **`FlushHook`** on **`CtxParts`** so isolated flushes can call back into the same handler instance.
> 
> Tests document the intended aggregating pattern (**`AccumulatingHandler`**: buffer in **`handle_persistent`**, drain inserts in **`on_flush`**) and assert coalesced flushes; the mid-batch ephemeral test now counts **`on_flush`** invocations instead of sampling committed rows.
> 
> **Note:** The PR description flags that in-memory accumulation + **`on_flush`** is not yet safe across job retries without a further design (durable-derived write-backs, per-run reset, or a real consumer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac9eab29954a1f21cb17a09ecc6f1eae0d95d3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->