### PR TITLE
feat(outbox): implement AtomicOperation directly on BatchOp and IsolatedOp

### DIFF
--- a/src/out/ctx.rs
+++ b/src/out/ctx.rs
@@ -219,6 +219,45 @@ impl std::ops::DerefMut for BatchOp<'_> {
     }
 }
 
+/// Full delegation to the inner [`es_entity::DbOp`] — including the provided
+/// methods, which [`es_entity::DbOp`] overrides (`supports_hooks` is `true`,
+/// `commit_hook` returns registered hooks, `maybe_now`/`clock` carry the op's
+/// cached time and clock). Inheriting the trait defaults instead would
+/// silently report `supports_hooks() == false` and lose the op time.
+///
+/// This lets handlers pass `&mut op` directly to any
+/// `fn(&mut impl AtomicOperation)` API (service `*_in_op` methods,
+/// `spawn_in_op`, `publish_persisted_in_op`, …) without `&mut *op`.
+impl es_entity::AtomicOperation for BatchOp<'_> {
+    fn maybe_now(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        (**self).maybe_now()
+    }
+
+    fn clock(&self) -> &es_entity::clock::ClockHandle {
+        es_entity::AtomicOperation::clock(&**self)
+    }
+
+    fn connection(&mut self) -> &mut es_entity::db::Connection {
+        (**self).connection()
+    }
+
+    fn as_executor(&mut self) -> es_entity::OneTimeExecutor<'_, &mut es_entity::db::Connection> {
+        (**self).as_executor()
+    }
+
+    fn add_commit_hook<H: es_entity::hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
+        (**self).add_commit_hook(hook)
+    }
+
+    fn commit_hook<H: es_entity::hooks::CommitHook>(&self) -> Option<&H> {
+        (**self).commit_hook::<H>()
+    }
+
+    fn supports_hooks(&self) -> bool {
+        (**self).supports_hooks()
+    }
+}
+
 /// An op holding exactly this event's work, fenced from the batch history.
 /// Derefs to [`es_entity::DbOp`]. The only exit is [`commit`](Self::commit) —
 /// isolation from future events is guaranteed by construction.
@@ -255,6 +294,38 @@ impl std::ops::DerefMut for IsolatedOp<'_> {
             .op_slot
             .as_mut()
             .expect("IsolatedOp always holds a materialized op")
+    }
+}
+
+/// Full delegation to the inner [`es_entity::DbOp`] — see the note on
+/// [`BatchOp`]'s impl for why every provided method is delegated too.
+impl es_entity::AtomicOperation for IsolatedOp<'_> {
+    fn maybe_now(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        (**self).maybe_now()
+    }
+
+    fn clock(&self) -> &es_entity::clock::ClockHandle {
+        es_entity::AtomicOperation::clock(&**self)
+    }
+
+    fn connection(&mut self) -> &mut es_entity::db::Connection {
+        (**self).connection()
+    }
+
+    fn as_executor(&mut self) -> es_entity::OneTimeExecutor<'_, &mut es_entity::db::Connection> {
+        (**self).as_executor()
+    }
+
+    fn add_commit_hook<H: es_entity::hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
+        (**self).add_commit_hook(hook)
+    }
+
+    fn commit_hook<H: es_entity::hooks::CommitHook>(&self) -> Option<&H> {
+        (**self).commit_hook::<H>()
+    }
+
+    fn supports_hooks(&self) -> bool {
+        (**self).supports_hooks()
     }
 }
 

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -99,6 +99,20 @@ impl OutboxEventHandler<TestEvent> for TestBothHandler {
     }
 }
 
+/// Generic `*_in_op`-style helper: takes any `AtomicOperation`, so handlers
+/// can pass `&mut op` (a `BatchOp`/`IsolatedOp`) directly — exercising the
+/// direct `AtomicOperation` impls instead of the `&mut *op` deref.
+async fn insert_effect_in_op(
+    op: &mut impl es_entity::AtomicOperation,
+    n: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("INSERT INTO test_batch_effects (n) VALUES ($1)")
+        .bind(n)
+        .execute(op.as_executor())
+        .await?;
+    Ok(())
+}
+
 /// Batch-safe worker: inserts one row per event inside the shared batch op
 /// and defers. Optionally fails the first time a given event value is seen.
 /// Sleeps briefly per event so the backfill keeps the ready backlog ahead of
@@ -125,10 +139,12 @@ impl OutboxEventHandler<TestEvent> for DeferringEffectHandler {
         if self.fail_on_first == Some(*n) && !self.failed.swap(true, Ordering::SeqCst) {
             return Err("injected mid-batch failure".into());
         }
-        sqlx::query("INSERT INTO test_batch_effects (n) VALUES ($1)")
-            .bind(*n as i64)
-            .execute(op.as_executor())
-            .await?;
+        // Provided-method delegation pinned: inheriting the trait default
+        // would report false here (DbOp overrides it to true).
+        if !op.supports_hooks() {
+            return Err("BatchOp must delegate supports_hooks to the inner DbOp".into());
+        }
+        insert_effect_in_op(&mut op, *n as i64).await?;
         Ok(op.defer())
     }
 }
@@ -147,7 +163,6 @@ impl OutboxEventHandler<TestEvent> for IsolatingEffectHandler {
         ctx: EventCtx<'inv>,
         event: &obix::out::PersistentOutboxEvent<TestEvent>,
     ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
-        use es_entity::AtomicOperation;
         let Some(TestEvent::Ping(n)) = &event.payload else {
             return Ok(ctx.skip());
         };
@@ -155,20 +170,14 @@ impl OutboxEventHandler<TestEvent> for IsolatingEffectHandler {
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         if *n == self.isolate_on {
             let mut op = ctx.consume_isolated().await?;
-            sqlx::query("INSERT INTO test_batch_effects (n) VALUES ($1)")
-                .bind(*n as i64)
-                .execute(op.as_executor())
-                .await?;
+            insert_effect_in_op(&mut op, *n as i64).await?;
             if !self.fail_isolated_once.swap(true, Ordering::SeqCst) {
                 return Err("injected isolated failure".into());
             }
             Ok(op.commit())
         } else {
             let mut op = ctx.consume_in_batch().await?;
-            sqlx::query("INSERT INTO test_batch_effects (n) VALUES ($1)")
-                .bind(*n as i64)
-                .execute(op.as_executor())
-                .await?;
+            insert_effect_in_op(&mut op, *n as i64).await?;
             Ok(op.defer())
         }
     }


### PR DESCRIPTION
## Problem

`BatchOp` / `IsolatedOp` (obix 0.3.0, #86) only `DerefMut` to the inner `es_entity::DbOp`, so autoderef covers method calls — but **not generic parameter positions**. Passing a guard to any `fn(&mut impl AtomicOperation)` API (service `*_in_op` methods, `spawn_in_op`, `publish_persisted_in_op`, …) required the explicit reborrow:

```rust
self.spawner.spawn_in_op(&mut *op, insert(row)).await?;   // before
self.spawner.spawn_in_op(&mut op, insert(row)).await?;    // after
```

Since `*_in_op` calls are the dominant thing lana-bank handlers do with the op, this removes the main ergonomic wart of the migration.

## Change

Implement `es_entity::AtomicOperation` directly on both guards, delegating **every** trait method to the inner `DbOp` — including the provided ones:

```rust
impl es_entity::AtomicOperation for BatchOp<'_> {
    fn maybe_now(&self) -> Option<DateTime<Utc>>                  { (**self).maybe_now() }
    fn clock(&self) -> &ClockHandle                               { AtomicOperation::clock(&**self) }
    fn connection(&mut self) -> &mut db::Connection               { (**self).connection() }
    fn as_executor(&mut self) -> OneTimeExecutor<'_, _>           { (**self).as_executor() }
    fn add_commit_hook<H: CommitHook>(&mut self, h: H) -> Result<(), H> { (**self).add_commit_hook(h) }
    fn commit_hook<H: CommitHook>(&self) -> Option<&H>            { (**self).commit_hook::<H>() }
    fn supports_hooks(&self) -> bool                              { (**self).supports_hooks() }
}
```

Delegating only the mandatory `connection()` would be a silent correctness trap: the wrappers would inherit the trait *defaults* — `supports_hooks() == false`, `commit_hook() == None`, global clock, no cached op time — while `DbOp` overrides all of them. That would break commit-hook buffering and `Outbox::cursor(&op)` through a guard, and desync `maybe_now` from the op's clock. `as_executor` is delegated too (its default would currently compose identically from the delegated parts, but direct delegation tracks any future `DbOp` override).

The typestate is unaffected: nothing on `AtomicOperation` can commit or roll back (those consume `DbOp` by value), so the runner's flush → checkpoint → commit remains the only exit.

## Tests

Effect inserts in the batching/isolation tests now route through a generic `fn(&mut impl AtomicOperation)` helper called with `&mut op` on **both** guard types — the exact call shape that previously needed `&mut *op`. A `supports_hooks()` check inside a batching handler pins the provided-method delegation (inheriting defaults would return `false` and fail the run). 31/31 nextest green (3×), clippy clean, `nix flake check` passing.

Ref: design doc [obix-dev/handler-controlled-tx-scoping.md](https://github.com/GaloyMoney/drua-library/blob/main/spaces/obix-dev/handler-controlled-tx-scoping.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transactional op wiring and commit-hook/time semantics for outbox handlers; behavior should match inner `DbOp` but mistakes in delegation would affect batch commits and `*_in_op` call sites.
> 
> **Overview**
> **`BatchOp` and `IsolatedOp` now implement `es_entity::AtomicOperation`**, forwarding every trait method (including provided ones like `supports_hooks`, `maybe_now`, `clock`, commit hooks, and `as_executor`) to the inner `DbOp`. Handlers can pass **`&mut op`** into generic `fn(&mut impl AtomicOperation)` APIs without **`&mut *op`**.
> 
> Outbox batch/isolation integration tests route effect inserts through a small **`insert_effect_in_op`** helper and assert **`supports_hooks()`** on batch paths so partial delegation cannot regress silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 831e60bd8c1543d05f47c6fd40e821e6c1494bb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->