### PR TITLE
ci: retry release git puts

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -10,6 +10,18 @@
 #@   "nix_task_image_config",
 #@ )
 
+#@ def retry_task():
+task: wait-and-retry
+config:
+  platform: linux
+  image_resource: #@ release_task_image_config()
+  run:
+    path: sh
+    args:
+    - "-c"
+    - "sleep 5"
+#@ end
+
 groups:
 - name: obix
   jobs:
@@ -121,18 +133,22 @@ jobs:
       run:
         path: pipeline-tasks/ci/tasks/publish-to-crates.sh
   - put: repo
+    attempts: 3
     params:
       tag: artifacts/gh-release-tag
       repository: repo
       merge: true
+    on_failure: #@ retry_task()
   - put: gh-release
     params:
       name: artifacts/gh-release-name
       tag: artifacts/gh-release-tag
       body: artifacts/gh-release-notes.md
   - put: version
+    attempts: 3
     params:
       file: version/version
+    on_failure: #@ retry_task()
 
 - name: set-dev-version
   plan:


### PR DESCRIPTION
## Summary
- retry the Git-backed repo and semver version release puts up to three times
- add the same wait-and-retry failure hook used by Lana Bank
- leave gh-release unretried because release creation is side-effecting

## Context
Concourse release build 24 pushed version 0.3.2, then failed during the implicit post-put repo checkout with exit status 128:
https://ci.galoy.io/teams/dev/pipelines/obix/jobs/release/builds/24

## Validation
- ytt render passes strict Concourse pipeline validation
- git diff --check passes