### PR TITLE
feat(outbox)!: collect/flush statement batching, two-stream runner, sealed op guards

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,8 @@ pub use inbox::{
 };
 pub use obix_macros::{MailboxTables, OutboxEvent};
 pub use out::{
-    BatchOp, CursorError, EventCtx, FlushError, FlushOp, Handled, IsolatedOp, OpCursor, Outbox,
-    OutboxEventHandler, OutboxEventJobConfig, PostPersistHook,
+    BatchOp, CursorError, EventCtx, EventSubscription, FlushError, FlushOp, Handled, IsolatedOp,
+    OpCursor, Outbox, OutboxEventHandler, OutboxEventJobConfig, PostPersistHook,
 };
 pub use sequence::EventSequence;
 pub use tables::MailboxTables;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,8 @@ pub use inbox::{
 };
 pub use obix_macros::{MailboxTables, OutboxEvent};
 pub use out::{
-    BatchOp, CursorError, EventCtx, Handled, IsolatedOp, OpCursor, Outbox, OutboxEventHandler,
-    OutboxEventJobConfig, PostPersistHook,
+    BatchOp, CursorError, EventCtx, FlushError, FlushOp, Handled, IsolatedOp, OpCursor, Outbox,
+    OutboxEventHandler, OutboxEventJobConfig, PostPersistHook,
 };
 pub use sequence::EventSequence;
 pub use tables::MailboxTables;

--- a/src/out/ctx.rs
+++ b/src/out/ctx.rs
@@ -168,15 +168,28 @@ impl<'inv> EventCtx<'inv> {
     }
 }
 
-/// An op joined to the pending batch. Derefs to [`es_entity::DbOp`] — use it
-/// exactly like any atomic operation, then exit with [`commit`](Self::commit)
-/// or [`defer`](Self::defer).
+/// An op joined to the pending batch. Implements
+/// [`AtomicOperation`](es_entity::AtomicOperation) — use it exactly like any
+/// atomic operation, then exit with [`commit`](Self::commit) or
+/// [`defer`](Self::defer).
+///
+/// There is no mutable access to the raw [`es_entity::DbOp`] (only a shared
+/// [`Deref`](std::ops::Deref) view): committing, rolling back, or swapping
+/// out the underlying op is unrepresentable, so work and checkpoint can only
+/// land together, through the runner.
 #[must_use = "exit with .commit() or .defer() to produce the Handled token"]
 pub struct BatchOp<'inv> {
     parts: CtxParts<'inv>,
 }
 
 impl<'inv> BatchOp<'inv> {
+    fn op_mut(&mut self) -> &mut es_entity::DbOp<'static> {
+        self.parts
+            .op_slot
+            .as_mut()
+            .expect("BatchOp always holds a materialized op")
+    }
+
     /// Land the whole batch (my work included) when the invocation returns:
     /// checkpoint at my sequence → commit.
     pub fn commit(self) -> Handled<'inv> {
@@ -210,15 +223,6 @@ impl std::ops::Deref for BatchOp<'_> {
     }
 }
 
-impl std::ops::DerefMut for BatchOp<'_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.parts
-            .op_slot
-            .as_mut()
-            .expect("BatchOp always holds a materialized op")
-    }
-}
-
 /// Full delegation to the inner [`es_entity::DbOp`] — including the provided
 /// methods, which [`es_entity::DbOp`] overrides (`supports_hooks` is `true`,
 /// `commit_hook` returns registered hooks, `maybe_now`/`clock` carry the op's
@@ -227,7 +231,10 @@ impl std::ops::DerefMut for BatchOp<'_> {
 ///
 /// This lets handlers pass `&mut op` directly to any
 /// `fn(&mut impl AtomicOperation)` API (service `*_in_op` methods,
-/// `spawn_in_op`, `publish_persisted_in_op`, …) without `&mut *op`.
+/// `spawn_in_op`, `publish_persisted_in_op`, …) — and it is the *only*
+/// mutable surface: with no `DerefMut`, a `&mut es_entity::DbOp` can never be
+/// obtained from the guard (which would allow `std::mem::swap`-ing in a decoy
+/// op and committing the real one without its checkpoint).
 impl es_entity::AtomicOperation for BatchOp<'_> {
     fn maybe_now(&self) -> Option<chrono::DateTime<chrono::Utc>> {
         (**self).maybe_now()
@@ -238,15 +245,15 @@ impl es_entity::AtomicOperation for BatchOp<'_> {
     }
 
     fn connection(&mut self) -> &mut es_entity::db::Connection {
-        (**self).connection()
+        self.op_mut().connection()
     }
 
     fn as_executor(&mut self) -> es_entity::OneTimeExecutor<'_, &mut es_entity::db::Connection> {
-        (**self).as_executor()
+        self.op_mut().as_executor()
     }
 
     fn add_commit_hook<H: es_entity::hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
-        (**self).add_commit_hook(hook)
+        self.op_mut().add_commit_hook(hook)
     }
 
     fn commit_hook<H: es_entity::hooks::CommitHook>(&self) -> Option<&H> {
@@ -259,14 +266,23 @@ impl es_entity::AtomicOperation for BatchOp<'_> {
 }
 
 /// An op holding exactly this event's work, fenced from the batch history.
-/// Derefs to [`es_entity::DbOp`]. The only exit is [`commit`](Self::commit) —
-/// isolation from future events is guaranteed by construction.
+/// Implements [`AtomicOperation`](es_entity::AtomicOperation). The only exit
+/// is [`commit`](Self::commit) — isolation from future events is guaranteed
+/// by construction, and (as with [`BatchOp`]) no mutable access to the raw
+/// [`es_entity::DbOp`] exists, so the op can only land through the runner.
 #[must_use = "exit with .commit() to produce the Handled token"]
 pub struct IsolatedOp<'inv> {
     parts: CtxParts<'inv>,
 }
 
 impl<'inv> IsolatedOp<'inv> {
+    fn op_mut(&mut self) -> &mut es_entity::DbOp<'static> {
+        self.parts
+            .op_slot
+            .as_mut()
+            .expect("IsolatedOp always holds a materialized op")
+    }
+
     /// Land my work and my checkpoint, atomically, when the invocation
     /// returns.
     pub fn commit(self) -> Handled<'inv> {
@@ -288,17 +304,9 @@ impl std::ops::Deref for IsolatedOp<'_> {
     }
 }
 
-impl std::ops::DerefMut for IsolatedOp<'_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.parts
-            .op_slot
-            .as_mut()
-            .expect("IsolatedOp always holds a materialized op")
-    }
-}
-
-/// Full delegation to the inner [`es_entity::DbOp`] — see the note on
-/// [`BatchOp`]'s impl for why every provided method is delegated too.
+/// Full delegation to the inner [`es_entity::DbOp`] — see the notes on
+/// [`BatchOp`]'s impl for why every provided method is delegated too, and why
+/// this is deliberately the only mutable surface (no `DerefMut`).
 impl es_entity::AtomicOperation for IsolatedOp<'_> {
     fn maybe_now(&self) -> Option<chrono::DateTime<chrono::Utc>> {
         (**self).maybe_now()
@@ -309,15 +317,15 @@ impl es_entity::AtomicOperation for IsolatedOp<'_> {
     }
 
     fn connection(&mut self) -> &mut es_entity::db::Connection {
-        (**self).connection()
+        self.op_mut().connection()
     }
 
     fn as_executor(&mut self) -> es_entity::OneTimeExecutor<'_, &mut es_entity::db::Connection> {
-        (**self).as_executor()
+        self.op_mut().as_executor()
     }
 
     fn add_commit_hook<H: es_entity::hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
-        (**self).add_commit_hook(hook)
+        self.op_mut().add_commit_hook(hook)
     }
 
     fn commit_hook<H: es_entity::hooks::CommitHook>(&self) -> Option<&H> {

--- a/src/out/ctx.rs
+++ b/src/out/ctx.rs
@@ -24,8 +24,12 @@
 //! stream while a batch is pending, so a pending stream is itself a flush
 //! trigger. Batching therefore rides bursts that already happened and adds
 //! no latency at low traffic. Ephemeral events travel on their own stream
-//! and are handled between batches — they never interrupt a batch and a
-//! transaction never spans the foreign `handle_ephemeral` await.
+//! and are handled between batches — they never interrupt a batch, a
+//! transaction never spans the foreign `handle_ephemeral` await, and between
+//! batches the two streams race fairly so neither can starve the other.
+//! Handlers that only consume one stream should declare it via
+//! [`SUBSCRIPTION`](super::OutboxEventHandler::SUBSCRIPTION) — the other
+//! stream is then never subscribed at all.
 //!
 //! Every flush — whichever of the triggers fires — first hands all collected
 //! items to the handler's [`flush`](super::OutboxEventHandler::flush) inside

--- a/src/out/ctx.rs
+++ b/src/out/ctx.rs
@@ -3,31 +3,37 @@
 //! Every persistent event delivered to an
 //! [`OutboxEventHandler`](super::OutboxEventHandler) comes with an
 //! [`EventCtx`] that the handler must resolve into a [`Handled`] token by
-//! choosing exactly one of three entry verbs:
+//! choosing exactly one of four entry verbs — a monotone cost ladder:
 //!
 //! | verb | meaning | cost |
 //! |------|---------|------|
 //! | [`EventCtx::skip`] | not my event | zero — no transaction is opened |
+//! | [`EventCtx::collect_with`] (and the [`collect`](EventCtx::collect) sugar) | contribute an item to the pending batch's accumulator | zero at collect time — one [`flush`](super::OutboxEventHandler::flush) call per batch applies all items |
 //! | [`EventCtx::consume_in_batch`] | do work joined to the pending batch op | shares one transaction (and one checkpoint) with neighboring events |
 //! | [`EventCtx::consume_isolated`] | land the pending batch first, then do my work in a fresh op | my event is its own atomic unit, fenced from history |
 //!
-//! and — when work was done — one of two exit verbs:
+//! and — when an op was taken — one of two exit verbs:
 //!
 //! | verb | meaning |
 //! |------|---------|
 //! | [`BatchOp::commit`] / [`IsolatedOp::commit`] | land the op (work + checkpoint, atomically) when the invocation returns |
 //! | [`BatchOp::defer`] | leave the op open so subsequent events can coalesce into it |
 //!
-//! A deferred op is only ever open while there is ready backlog: the runner
-//! never awaits the stream while a transaction is open, so a pending stream
-//! is itself a flush trigger — as is an interleaved ephemeral event (the op
-//! never spans the foreign `handle_ephemeral` await either). Batching
-//! therefore rides bursts that already happened and adds no latency at low
-//! traffic.
+//! A pending batch — an open op, collected items, or both — only ever exists
+//! while there is ready persistent backlog: the runner never awaits the
+//! stream while a batch is pending, so a pending stream is itself a flush
+//! trigger. Batching therefore rides bursts that already happened and adds
+//! no latency at low traffic. Ephemeral events travel on their own stream
+//! and are handled between batches — they never interrupt a batch and a
+//! transaction never spans the foreign `handle_ephemeral` await.
 //!
-//! Every flush — whichever of the triggers fires — persists the checkpoint
-//! at the last *fully handled* sequence (skips included), then commits:
-//! work and pointer are inseparable.
+//! Every flush — whichever of the triggers fires — first hands all collected
+//! items to the handler's [`flush`](super::OutboxEventHandler::flush) inside
+//! the batch transaction, then persists the checkpoint at the last *fully
+//! handled* sequence (skips included), then commits: items, work and pointer
+//! are inseparable. A failed flush rolls everything back and replays the
+//! whole batch (items are re-collected), so collected work must tolerate
+//! wholesale replay — the same contract as [`defer`](BatchOp::defer).
 
 use serde::{Deserialize, Serialize};
 
@@ -49,8 +55,13 @@ pub(crate) struct OutboxEventJobState {
 
 /// Book-keeping the runner shares with [`EventCtx`].
 pub(crate) struct BatchTracker {
-    /// Number of events whose work is in the currently open op.
+    /// Number of events contributing to the pending batch (consumed into the
+    /// op or collected into the accumulator) — drives `max_batch_size`.
     pub(crate) events_in_op: usize,
+    /// Number of events that collected items since the last flush. Nonzero
+    /// means the accumulator is dirty: the batch is open even without an op,
+    /// and no checkpoint may be persisted before the items are flushed.
+    pub(crate) collected: usize,
     /// Highest sequence whose checkpoint has been persisted to the database.
     pub(crate) persisted_seq: EventSequence,
     /// When the checkpoint was last persisted (any flush or standalone write).
@@ -66,7 +77,8 @@ pub(crate) struct CtxParts<'inv> {
 
 /// Proof that a persistent event was resolved in one of the legal ways.
 ///
-/// Only obtainable from [`EventCtx::skip`], [`BatchOp::commit`],
+/// Only obtainable from [`EventCtx::skip`], [`EventCtx::collect_with`] (or
+/// its [`collect`](EventCtx::collect) sugar), [`BatchOp::commit`],
 /// [`BatchOp::defer`] or [`IsolatedOp::commit`] — the type system forces
 /// every [`handle_persistent`](super::OutboxEventHandler::handle_persistent)
 /// invocation to decide the transactional fate of its event.
@@ -100,6 +112,7 @@ pub struct Handled<'inv> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum Outcome {
     Skip,
+    Collect,
     Commit,
     Defer,
 }
@@ -107,19 +120,46 @@ pub(crate) enum Outcome {
 /// Per-event decision point handed to
 /// [`handle_persistent`](super::OutboxEventHandler::handle_persistent).
 ///
-/// See the [module docs](self) for the semantics of the three entry verbs.
-#[must_use = "resolve the EventCtx via skip / consume_in_batch / consume_isolated"]
-pub struct EventCtx<'inv> {
+/// Generic over the handler's
+/// [`Batch`](super::OutboxEventHandler::Batch) accumulator `B` (defaulting
+/// to `()` for handlers that never collect). See the [module docs](self)
+/// for the semantics of the four entry verbs.
+#[must_use = "resolve the EventCtx via skip / collect / consume_in_batch / consume_isolated"]
+pub struct EventCtx<'inv, B = ()> {
     pub(crate) parts: CtxParts<'inv>,
+    pub(crate) batch: &'inv mut B,
+    pub(crate) flusher: &'inv dyn ItemFlush<B>,
 }
 
-impl<'inv> EventCtx<'inv> {
+impl<'inv, B> EventCtx<'inv, B> {
     /// This event is not for me — no transaction is opened, an open batch op
     /// is left untouched, and the checkpoint advances lazily (piggybacked on
     /// the next flush, or persisted on the configured checkpoint interval).
     pub fn skip(self) -> Handled<'inv> {
         Handled {
             outcome: Outcome::Skip,
+            _invocation: PhantomData,
+        }
+    }
+
+    /// Contribute to the pending batch's accumulator — a pure memory write:
+    /// no transaction is opened and no statement is executed now. The runner
+    /// hands the accumulated batch to the handler's
+    /// [`flush`](super::OutboxEventHandler::flush) exactly once per batch
+    /// landing, inside the transaction that commits the checkpoint.
+    ///
+    /// Like [`defer`](BatchOp::defer), collected work shares fate with its
+    /// neighbors and must tolerate whole-batch replay: on a failed flush the
+    /// events replay and their items are re-collected.
+    ///
+    /// For `Vec` and `HashMap` accumulators the [`collect`](Self::collect)
+    /// sugar is usually more convenient.
+    pub fn collect_with(self, f: impl FnOnce(&mut B)) -> Handled<'inv> {
+        f(self.batch);
+        self.parts.tracker.events_in_op += 1;
+        self.parts.tracker.collected += 1;
+        Handled {
+            outcome: Outcome::Collect,
             _invocation: PhantomData,
         }
     }
@@ -147,24 +187,55 @@ impl<'inv> EventCtx<'inv> {
         Ok(BatchOp { parts })
     }
 
-    /// Land the pending batch first (its work and its checkpoint, at the
-    /// last fully handled sequence), then hand back a fresh op: this event
-    /// is its own atomic unit, sharing no fate with history — and none with
-    /// the future either, since [`IsolatedOp`] only offers
-    /// [`commit`](IsolatedOp::commit).
+    /// Land the pending batch first (its collected items, its work and its
+    /// checkpoint, at the last fully handled sequence), then hand back a
+    /// fresh op: this event is its own atomic unit, sharing no fate with
+    /// history — and none with the future either, since [`IsolatedOp`] only
+    /// offers [`commit`](IsolatedOp::commit).
     ///
     /// This is the failure-isolation fence: if this event's work fails, only
     /// this event replays; and it is the exact legacy per-event semantics
     /// when no batch is pending.
-    pub async fn consume_isolated(self) -> Result<IsolatedOp<'inv>, HandlerError> {
-        let mut parts = self.parts;
-        flush_batch(&mut parts, "isolated_entry").await?;
+    pub async fn consume_isolated(self) -> Result<IsolatedOp<'inv>, HandlerError>
+    where
+        B: Default,
+    {
+        let EventCtx {
+            mut parts,
+            batch,
+            flusher,
+        } = self;
+        flush_batch(&mut parts, batch, flusher, "isolated_entry").await?;
         *parts.op_slot = Some(
             es_entity::DbOp::init_with_clock(parts.current_job.pool(), parts.current_job.clock())
                 .await?,
         );
         parts.tracker.events_in_op = 1;
         Ok(IsolatedOp { parts })
+    }
+}
+
+impl<'inv, T> EventCtx<'inv, Vec<T>> {
+    /// [`collect_with`](Self::collect_with) sugar for `Vec` accumulators:
+    /// append one item to the pending batch.
+    pub fn collect(self, item: T) -> Handled<'inv> {
+        self.collect_with(|batch| batch.push(item))
+    }
+}
+
+impl<'inv, K, V, S> EventCtx<'inv, std::collections::HashMap<K, V, S>>
+where
+    K: std::hash::Hash + Eq,
+    S: std::hash::BuildHasher,
+{
+    /// [`collect_with`](Self::collect_with) sugar for `HashMap` accumulators:
+    /// keyed last-write-wins insert. Persistent events arrive in ascending
+    /// sequence, so within a batch this naturally keeps the newest item per
+    /// key — the coalescing fold (N updates per key → 1 flushed entry).
+    pub fn collect(self, key: K, value: V) -> Handled<'inv> {
+        self.collect_with(|batch| {
+            batch.insert(key, value);
+        })
     }
 }
 
@@ -200,10 +271,9 @@ impl<'inv> BatchOp<'inv> {
     }
 
     /// Leave the op open so subsequent events can coalesce into it. The
-    /// runner lands it when the ready backlog is drained, when the
-    /// configured max batch size is reached, when a later event commits or
-    /// isolates, when an ephemeral event arrives (the op never spans the
-    /// foreign `handle_ephemeral` await), or on shutdown.
+    /// runner lands it when the ready persistent backlog is drained, when
+    /// the configured max batch size is reached, when a later event commits
+    /// or isolates, or on shutdown.
     pub fn defer(self) -> Handled<'inv> {
         Handled {
             outcome: Outcome::Defer,
@@ -337,25 +407,161 @@ impl es_entity::AtomicOperation for IsolatedOp<'_> {
     }
 }
 
-/// Land the pending batch op, if any: checkpoint at the last fully handled
-/// sequence → commit. No-op when no op is open.
+pub(crate) type BoxFuture<'a, T> =
+    std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+
+/// Object-safe bridge from the runner (and [`EventCtx::consume_isolated`]'s
+/// entry fence) to the handler's typed
+/// [`flush`](super::OutboxEventHandler::flush) — erases the handler type so
+/// [`EventCtx`] only needs to know the accumulator `B`.
+pub(crate) trait ItemFlush<B>: Send + Sync {
+    fn flush_items<'a>(
+        &'a self,
+        op: &'a mut es_entity::DbOp<'static>,
+        items: B,
+    ) -> BoxFuture<'a, Result<(), HandlerError>>;
+}
+
+/// Restricted view of the batch op handed to
+/// [`flush`](super::OutboxEventHandler::flush) — everything an
+/// [`AtomicOperation`](es_entity::AtomicOperation) can do, and nothing else.
+///
+/// Committing belongs to the runner: after `flush` returns `Ok`, the
+/// checkpoint is written and the transaction commits — items, work and
+/// pointer land atomically. There is no access to the raw
+/// [`es_entity::DbOp`], mirroring [`BatchOp`]/[`IsolatedOp`]'s sealing.
+pub struct FlushOp<'a>(&'a mut es_entity::DbOp<'static>);
+
+impl<'a> FlushOp<'a> {
+    pub(crate) fn new(op: &'a mut es_entity::DbOp<'static>) -> Self {
+        Self(op)
+    }
+}
+
+/// Full delegation to the inner [`es_entity::DbOp`] — see the notes on
+/// [`BatchOp`]'s impl for why every provided method is delegated too.
+/// `add_commit_hook` delegation is what lets a flush body publish onto the
+/// batch op (e.g. `publish_all_persisted`) with the events buffered on the
+/// runner's commit.
+impl es_entity::AtomicOperation for FlushOp<'_> {
+    fn maybe_now(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.0.maybe_now()
+    }
+
+    fn clock(&self) -> &es_entity::clock::ClockHandle {
+        es_entity::AtomicOperation::clock(self.0)
+    }
+
+    fn connection(&mut self) -> &mut es_entity::db::Connection {
+        self.0.connection()
+    }
+
+    fn as_executor(&mut self) -> es_entity::OneTimeExecutor<'_, &mut es_entity::db::Connection> {
+        self.0.as_executor()
+    }
+
+    fn add_commit_hook<H: es_entity::hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
+        self.0.add_commit_hook(hook)
+    }
+
+    fn commit_hook<H: es_entity::hooks::CommitHook>(&self) -> Option<&H> {
+        self.0.commit_hook::<H>()
+    }
+
+    fn supports_hooks(&self) -> bool {
+        self.0.supports_hooks()
+    }
+}
+
+/// A batch flush failed. Carries the sequence range actually at fault, so
+/// the failure is not misattributed to the (innocent) event whose verb
+/// happened to trigger the landing — e.g. a later event entering
+/// [`consume_isolated`](EventCtx::consume_isolated).
+///
+/// Propagates through `handle_persistent` as a boxed error; downcast to
+/// re-attribute in logs or traces.
+#[derive(Debug)]
+pub struct FlushError {
+    /// Which trigger landed the batch (`"backlog_drained"`, `"batch_full"`,
+    /// `"commit"`, `"isolated_entry"`, `"shutdown"`, `"stream_closed"`).
+    pub reason: &'static str,
+    /// The batch covers sequences strictly after this (the last durable
+    /// checkpoint)…
+    pub after: EventSequence,
+    /// …through this (the last fully handled event).
+    pub through: EventSequence,
+    pub source: HandlerError,
+}
+
+impl std::fmt::Display for FlushError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "flush of batch ({}, {}] failed (reason={}): {}",
+            self.after, self.through, self.reason, self.source
+        )
+    }
+}
+
+impl std::error::Error for FlushError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+/// Land the pending batch, if any: hand collected items to the handler's
+/// flush (inside the batch transaction, opening one if only items are
+/// pending) → checkpoint at the last fully handled sequence → commit. No-op
+/// when nothing is pending.
 #[tracing::instrument(
     name = "outbox.flush_batch",
     skip_all,
     fields(
         reason = reason,
         batch_size = parts.tracker.events_in_op,
+        collected = parts.tracker.collected,
         checkpoint_seq = u64::from(parts.state.sequence),
     ),
     err
 )]
-pub(crate) async fn flush_batch(
+pub(crate) async fn flush_batch<B: Default>(
     parts: &mut CtxParts<'_>,
+    batch: &mut B,
+    flusher: &dyn ItemFlush<B>,
     reason: &'static str,
 ) -> Result<(), HandlerError> {
-    let Some(mut op) = parts.op_slot.take() else {
+    if parts.op_slot.is_none() && parts.tracker.collected == 0 {
         return Ok(());
-    };
+    }
+    if parts.tracker.collected > 0 {
+        if parts.op_slot.is_none() {
+            *parts.op_slot = Some(
+                es_entity::DbOp::init_with_clock(
+                    parts.current_job.pool(),
+                    parts.current_job.clock(),
+                )
+                .await?,
+            );
+        }
+        // Drain before the call: on error the items are dropped with the op,
+        // and the replayed events re-collect them — the accumulator never
+        // leaks stale state into a retry.
+        let items = std::mem::take(batch);
+        parts.tracker.collected = 0;
+        let op = parts.op_slot.as_mut().expect("op was materialized above");
+        if let Err(source) = flusher.flush_items(op, items).await {
+            return Err(Box::new(FlushError {
+                reason,
+                after: parts.tracker.persisted_seq,
+                through: parts.state.sequence,
+                source,
+            }));
+        }
+    }
+    let mut op = parts
+        .op_slot
+        .take()
+        .expect("a pending batch always has an op by now");
     parts
         .current_job
         .update_execution_state_in_op(&mut op, parts.state)

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -19,34 +19,69 @@ use crate::tables::MailboxTables;
 ///
 /// - [`skip`](EventCtx::skip) — not my event; costs no transaction at all.
 ///   The checkpoint advances lazily.
+/// - [`collect_with`](EventCtx::collect_with) / the
+///   [`collect`](EventCtx::collect) sugar — contribute an item to the
+///   pending batch's [`Batch`](Self::Batch) accumulator; a pure memory
+///   write. The runner applies the whole accumulator via
+///   [`flush`](Self::flush) exactly once per batch landing, inside the
+///   transaction that commits the checkpoint — N per-event statements
+///   become one batched flush. Same replay contract as `defer`.
 /// - [`consume_in_batch`](EventCtx::consume_in_batch) then
 ///   [`defer`](BatchOp::defer) — coalesce my work with neighboring events
 ///   into one transaction and one checkpoint write. The batch lands when the
-///   ready backlog is drained (a deferred op is never held open waiting on
-///   the network), when `max_batch_size` is reached, when a later event
-///   commits or isolates, when an ephemeral event arrives, or on shutdown.
-///   Requires the work to tolerate whole-batch replay after a mid-batch
-///   failure.
+///   ready persistent backlog is drained (a pending batch is never held open
+///   waiting on the network), when `max_batch_size` is reached, when a later
+///   event commits or isolates, or on shutdown. Requires the work to
+///   tolerate whole-batch replay after a mid-batch failure.
 /// - [`consume_in_batch`](EventCtx::consume_in_batch) then
 ///   [`commit`](BatchOp::commit) — join the batch and close it with me.
 /// - [`consume_isolated`](EventCtx::consume_isolated) then
 ///   [`commit`](IsolatedOp::commit) — my event is its own atomic unit: the
-///   pending batch (work + checkpoint) lands before my work starts, and my
-///   op commits at return. Exact legacy per-event semantics when nothing is
-///   pending. Use for causally significant or risky work.
+///   pending batch (items + work + checkpoint) lands before my work starts,
+///   and my op commits at return. Exact legacy per-event semantics when
+///   nothing is pending. Use for causally significant or risky work.
+///
+/// Ephemeral events are delivered on their own stream and are handled
+/// between batches: they never interrupt a pending batch, and nothing is
+/// pending while [`handle_ephemeral`](Self::handle_ephemeral) runs.
 pub trait OutboxEventHandler<P>: Send + Sync + 'static
 where
     P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
 {
+    /// Accumulator for events resolved via
+    /// [`collect_with`](EventCtx::collect_with) — `Vec<T>` for append-style
+    /// batching, `HashMap<K, V>` for keyed coalescing folds, or any other
+    /// `Default` container. Handlers that never collect use `()`.
+    type Batch: Default + Send + 'static;
+
     fn handle_persistent<'inv>(
         &self,
-        ctx: EventCtx<'inv>,
+        ctx: EventCtx<'inv, Self::Batch>,
         event: &PersistentOutboxEvent<P>,
     ) -> impl std::future::Future<
         Output = Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>>,
     > + Send {
         let _ = event;
         async move { Ok(ctx.skip()) }
+    }
+
+    /// Apply everything collected since the last flush. Called at most once
+    /// per batch landing, inside the batch transaction, before the
+    /// checkpoint commits — items and pointer land atomically.
+    ///
+    /// `op` is the batch op behind a restricted [`FlushOp`] view: execute
+    /// statements or register commit hooks on it for work that must share
+    /// the checkpoint's fate; ignore it when flushing to a foreign database
+    /// (then make the writes idempotent — the checkpoint only advances after
+    /// `Ok`, and a failure replays and re-collects the whole batch).
+    fn flush(
+        &self,
+        op: &mut FlushOp<'_>,
+        items: Self::Batch,
+    ) -> impl std::future::Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send
+    {
+        let _ = (op, items);
+        async { Ok(()) }
     }
 
     fn handle_ephemeral(
@@ -56,6 +91,33 @@ where
     {
         let _ = event;
         async { Ok(()) }
+    }
+}
+
+/// Object-safe bridge handing the handler's typed [`flush`] to the runner's
+/// flush path (and to [`EventCtx::consume_isolated`]'s entry fence) with the
+/// handler type erased.
+///
+/// [`flush`]: OutboxEventHandler::flush
+struct HandlerFlusher<H, P> {
+    handler: Arc<H>,
+    _payload: std::marker::PhantomData<fn() -> P>,
+}
+
+impl<H, P> ItemFlush<H::Batch> for HandlerFlusher<H, P>
+where
+    H: OutboxEventHandler<P>,
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+{
+    fn flush_items<'a>(
+        &'a self,
+        op: &'a mut es_entity::DbOp<'static>,
+        items: H::Batch,
+    ) -> BoxFuture<'a, Result<(), HandlerError>> {
+        Box::pin(async move {
+            let mut op = FlushOp::new(op);
+            self.handler.flush(&mut op, items).await
+        })
     }
 }
 
@@ -85,10 +147,12 @@ impl OutboxEventJobConfig {
         self
     }
 
-    /// Backstop on how many deferred events may share one op before the
-    /// runner force-flushes. Bounds the replay window and transaction size
-    /// of handlers that always [`defer`](super::BatchOp::defer); handlers
-    /// remain the primary size control by exiting with
+    /// Backstop on how many deferred or collected events may share one
+    /// batch before the runner force-flushes. Bounds the replay window, the
+    /// transaction size and the flushed accumulator size of handlers that
+    /// always [`defer`](super::BatchOp::defer) or
+    /// [`collect`](super::EventCtx::collect_with); handlers remain the
+    /// primary size control by exiting with
     /// [`commit`](super::BatchOp::commit).
     pub fn with_max_batch_size(mut self, max_batch_size: usize) -> Self {
         self.max_batch_size = max_batch_size.max(1);
@@ -197,21 +261,32 @@ where
             .execution_state::<OutboxEventJobState>()?
             .unwrap_or_default();
 
-        let mut stream = self.outbox.listen_all(Some(state.sequence));
+        // Two independent streams: the persistent backlog alone governs the
+        // batch lifecycle, so ephemeral traffic can never shrink a batch —
+        // and ephemerals are only handled while nothing is pending.
+        let mut persistent = self.outbox.listen_persisted(Some(state.sequence));
+        let mut ephemeral = self.outbox.listen_ephemeral();
 
         let mut op_slot: Option<es_entity::DbOp<'static>> = None;
         let mut tracker = BatchTracker {
             events_in_op: 0,
+            collected: 0,
             persisted_seq: state.sequence,
             last_persist: tokio::time::Instant::now(),
         };
+        let mut batch = H::Batch::default();
+        let flusher = HandlerFlusher::<H, P> {
+            handler: self.handler.clone(),
+            _payload: std::marker::PhantomData,
+        };
 
         loop {
-            let event = if op_slot.is_some() {
-                // A batch op is open: only take events that are already
-                // buffered — the transaction is never held open waiting on
-                // the network. A pending stream is itself the flush trigger.
-                match stream.next().now_or_never() {
+            let event = if op_slot.is_some() || tracker.collected > 0 {
+                // A batch is pending (an open op, collected items, or both):
+                // only take persistent events that are already buffered —
+                // the batch is never held open waiting on the network. A
+                // pending stream is itself the flush trigger.
+                match persistent.next().now_or_never() {
                     Some(Some(event)) => event,
                     Some(None) => {
                         let mut parts = CtxParts {
@@ -220,7 +295,7 @@ where
                             state: &state,
                             tracker: &mut tracker,
                         };
-                        flush_batch(&mut parts, "stream_closed")
+                        flush_batch(&mut parts, &mut batch, &flusher, "stream_closed")
                             .await
                             .map_err(|e| e as Box<dyn std::error::Error>)?;
                         return Ok(JobCompletion::RescheduleNow);
@@ -232,7 +307,7 @@ where
                             state: &state,
                             tracker: &mut tracker,
                         };
-                        flush_batch(&mut parts, "backlog_drained")
+                        flush_batch(&mut parts, &mut batch, &flusher, "backlog_drained")
                             .await
                             .map_err(|e| e as Box<dyn std::error::Error>)?;
                         continue;
@@ -249,6 +324,20 @@ where
                         }
                         return Ok(JobCompletion::RescheduleNow);
                     }
+                    // Nothing is pending in this branch by construction, so
+                    // no transaction spans the foreign `handle_ephemeral`
+                    // await and a failure here discards no batch work.
+                    // Draining ephemerals ahead of the persistent arm bounds
+                    // their latency to one batch under sustained persistent
+                    // traffic; the ephemeral channel is lossy under lag, so
+                    // its backlog is bounded by construction.
+                    Some(event) = ephemeral.next() => {
+                        self.handler
+                            .handle_ephemeral(&event)
+                            .await
+                            .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        continue;
+                    }
                     _ = tokio::time::sleep_until(tracker.last_persist + self.checkpoint_interval),
                         if tracker.persisted_seq < state.sequence => {
                         persist_checkpoint(&mut current_job, &state)
@@ -258,7 +347,7 @@ where
                         tracker.last_persist = tokio::time::Instant::now();
                         continue;
                     }
-                    event = stream.next() => match event {
+                    event = persistent.next() => match event {
                         Some(event) => event,
                         None => {
                             if tracker.persisted_seq < state.sequence {
@@ -272,77 +361,52 @@ where
                 }
             };
 
-            match event {
-                OutboxEvent::Ephemeral(event) => {
-                    // Ephemerals are an unordered best-effort broadcast and
-                    // never touch the batch op — but an open op must not
-                    // span the foreign `handle_ephemeral` await (and steady
-                    // ephemeral traffic must not starve the flush), so an
-                    // ephemeral arriving mid-batch lands the batch first.
-                    if op_slot.is_some() {
+            let ctx = EventCtx {
+                parts: CtxParts {
+                    op_slot: &mut op_slot,
+                    current_job: &mut current_job,
+                    state: &state,
+                    tracker: &mut tracker,
+                },
+                batch: &mut batch,
+                flusher: &flusher,
+            };
+            // The Handled token is branded with the invocation lifetime (it
+            // cannot leave this call) and every path that mints one consumes
+            // the ctx — so the outcome is authentic by construction. Extract
+            // it in the same statement so the token (and with it the ctx
+            // borrows) ends before the state advance below.
+            let outcome = self
+                .handler
+                .handle_persistent(ctx, &event)
+                .await
+                .map_err(|e| e as Box<dyn std::error::Error>)?
+                .outcome;
+            state.sequence = event.sequence;
+            match outcome {
+                Outcome::Skip => {}
+                Outcome::Commit => {
+                    let mut parts = CtxParts {
+                        op_slot: &mut op_slot,
+                        current_job: &mut current_job,
+                        state: &state,
+                        tracker: &mut tracker,
+                    };
+                    flush_batch(&mut parts, &mut batch, &flusher, "commit")
+                        .await
+                        .map_err(|e| e as Box<dyn std::error::Error>)?;
+                }
+                Outcome::Defer | Outcome::Collect => {
+                    if tracker.events_in_op >= self.max_batch_size {
                         let mut parts = CtxParts {
                             op_slot: &mut op_slot,
                             current_job: &mut current_job,
                             state: &state,
                             tracker: &mut tracker,
                         };
-                        flush_batch(&mut parts, "ephemeral")
+                        flush_batch(&mut parts, &mut batch, &flusher, "batch_full")
                             .await
                             .map_err(|e| e as Box<dyn std::error::Error>)?;
-                    }
-                    self.handler
-                        .handle_ephemeral(&event)
-                        .await
-                        .map_err(|e| e as Box<dyn std::error::Error>)?;
-                }
-                OutboxEvent::Persistent(event) => {
-                    let ctx = EventCtx {
-                        parts: CtxParts {
-                            op_slot: &mut op_slot,
-                            current_job: &mut current_job,
-                            state: &state,
-                            tracker: &mut tracker,
-                        },
-                    };
-                    // The Handled token is branded with the invocation
-                    // lifetime (it cannot leave this call) and every path
-                    // that mints one consumes the ctx — so the outcome is
-                    // authentic by construction. Extract it in the same
-                    // statement so the token (and with it the ctx borrows)
-                    // ends before the state advance below.
-                    let outcome = self
-                        .handler
-                        .handle_persistent(ctx, &event)
-                        .await
-                        .map_err(|e| e as Box<dyn std::error::Error>)?
-                        .outcome;
-                    state.sequence = event.sequence;
-                    match outcome {
-                        Outcome::Skip => {}
-                        Outcome::Commit => {
-                            let mut parts = CtxParts {
-                                op_slot: &mut op_slot,
-                                current_job: &mut current_job,
-                                state: &state,
-                                tracker: &mut tracker,
-                            };
-                            flush_batch(&mut parts, "commit")
-                                .await
-                                .map_err(|e| e as Box<dyn std::error::Error>)?;
-                        }
-                        Outcome::Defer => {
-                            if tracker.events_in_op >= self.max_batch_size {
-                                let mut parts = CtxParts {
-                                    op_slot: &mut op_slot,
-                                    current_job: &mut current_job,
-                                    state: &state,
-                                    tracker: &mut tracker,
-                                };
-                                flush_batch(&mut parts, "batch_full")
-                                    .await
-                                    .map_err(|e| e as Box<dyn std::error::Error>)?;
-                            }
-                        }
                     }
                 }
             }

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -8,8 +8,25 @@ use job::{
 };
 
 use super::ctx::*;
-use super::{Outbox, event::*};
+use super::{EphemeralOutboxListener, Outbox, event::*};
 use crate::tables::MailboxTables;
+
+/// Which delivery streams an event-handler job subscribes to — see
+/// [`OutboxEventHandler::SUBSCRIPTION`].
+///
+/// - [`PersistentOnly`](Self::PersistentOnly): only the durable, checkpointed
+///   stream. The ephemeral stream is never subscribed, so batching is
+///   entirely immune to ephemeral traffic.
+/// - [`EphemeralOnly`](Self::EphemeralOnly): only the best-effort broadcast.
+///   No persistent deliveries, and none of the checkpoint/batch machinery —
+///   the job never reads or writes execution state.
+/// - [`All`](Self::All): both streams, raced fairly between batches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventSubscription {
+    All,
+    PersistentOnly,
+    EphemeralOnly,
+}
 
 /// Handles the events of one outbox listener job.
 ///
@@ -43,11 +60,25 @@ use crate::tables::MailboxTables;
 ///
 /// Ephemeral events are delivered on their own stream and are handled
 /// between batches: they never interrupt a pending batch, and nothing is
-/// pending while [`handle_ephemeral`](Self::handle_ephemeral) runs.
+/// pending while [`handle_ephemeral`](Self::handle_ephemeral) runs. Most
+/// handlers only consume one of the two streams — declare it via
+/// [`SUBSCRIPTION`](Self::SUBSCRIPTION) and the other stream is never even
+/// subscribed.
 pub trait OutboxEventHandler<P>: Send + Sync + 'static
 where
     P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
 {
+    /// Which delivery streams this handler's job subscribes to. Defaults to
+    /// [`All`](EventSubscription::All).
+    ///
+    /// Declaring a single-stream mode is a contract, not a filter: the other
+    /// stream is never subscribed, so its handler method is never called —
+    /// overriding [`handle_ephemeral`](Self::handle_ephemeral) on a
+    /// [`PersistentOnly`](EventSubscription::PersistentOnly) handler (or
+    /// [`handle_persistent`](Self::handle_persistent) on an
+    /// [`EphemeralOnly`](EventSubscription::EphemeralOnly) one) is dead code.
+    const SUBSCRIPTION: EventSubscription = EventSubscription::All;
+
     /// Accumulator for events resolved via
     /// [`collect_with`](EventCtx::collect_with) — `Vec<T>` for append-style
     /// batching, `HashMap<K, V>` for keyed coalescing folds, or any other
@@ -118,6 +149,30 @@ where
             let mut op = FlushOp::new(op);
             self.handler.flush(&mut op, items).await
         })
+    }
+}
+
+/// What the fair two-stream race yielded while no batch was pending.
+enum NextDelivery<P>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    Persistent(Option<Arc<PersistentOutboxEvent<P>>>),
+    Ephemeral(Arc<EphemeralOutboxEvent<P>>),
+}
+
+/// Next ephemeral event — or pend forever when the handler's
+/// [`SUBSCRIPTION`](OutboxEventHandler::SUBSCRIPTION) never subscribed the
+/// ephemeral stream.
+async fn next_if_subscribed<P>(
+    listener: &mut Option<EphemeralOutboxListener<P>>,
+) -> Option<Arc<EphemeralOutboxEvent<P>>>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+{
+    match listener {
+        Some(listener) => listener.next().await,
+        None => std::future::pending().await,
     }
 }
 
@@ -255,6 +310,52 @@ where
 {
     async fn run(
         &self,
+        current_job: CurrentJob,
+    ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        match H::SUBSCRIPTION {
+            EventSubscription::EphemeralOnly => self.run_ephemeral_only(current_job).await,
+            EventSubscription::All | EventSubscription::PersistentOnly => {
+                self.run_with_persistent(current_job).await
+            }
+        }
+    }
+}
+
+impl<H, P, Tables> OutboxEventJobRunner<H, P, Tables>
+where
+    H: OutboxEventHandler<P>,
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+    Tables: MailboxTables,
+{
+    /// [`EphemeralOnly`](EventSubscription::EphemeralOnly): a bare dispatch
+    /// loop — no persistent subscription, no execution state, no batch or
+    /// checkpoint machinery.
+    async fn run_ephemeral_only(
+        &self,
+        mut current_job: CurrentJob,
+    ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        let mut ephemeral = self.outbox.listen_ephemeral();
+        loop {
+            tokio::select! {
+                biased;
+                _ = current_job.shutdown_requested() => {
+                    return Ok(JobCompletion::RescheduleNow);
+                }
+                event = ephemeral.next() => match event {
+                    Some(event) => {
+                        self.handler
+                            .handle_ephemeral(&event)
+                            .await
+                            .map_err(|e| e as Box<dyn std::error::Error>)?;
+                    }
+                    None => return Ok(JobCompletion::RescheduleNow),
+                },
+            }
+        }
+    }
+
+    async fn run_with_persistent(
+        &self,
         mut current_job: CurrentJob,
     ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
         let mut state = current_job
@@ -263,9 +364,12 @@ where
 
         // Two independent streams: the persistent backlog alone governs the
         // batch lifecycle, so ephemeral traffic can never shrink a batch —
-        // and ephemerals are only handled while nothing is pending.
+        // and ephemerals are only handled while nothing is pending. A
+        // `PersistentOnly` handler never subscribes the ephemeral stream at
+        // all.
         let mut persistent = self.outbox.listen_persisted(Some(state.sequence));
-        let mut ephemeral = self.outbox.listen_ephemeral();
+        let mut ephemeral =
+            (H::SUBSCRIPTION == EventSubscription::All).then(|| self.outbox.listen_ephemeral());
 
         let mut op_slot: Option<es_entity::DbOp<'static>> = None;
         let mut tracker = BatchTracker {
@@ -314,7 +418,7 @@ where
                     }
                 }
             } else {
-                tokio::select! {
+                let next = tokio::select! {
                     biased;
                     _ = current_job.shutdown_requested() => {
                         if tracker.persisted_seq < state.sequence {
@@ -323,20 +427,6 @@ where
                                 .map_err(|e| e as Box<dyn std::error::Error>)?;
                         }
                         return Ok(JobCompletion::RescheduleNow);
-                    }
-                    // Nothing is pending in this branch by construction, so
-                    // no transaction spans the foreign `handle_ephemeral`
-                    // await and a failure here discards no batch work.
-                    // Draining ephemerals ahead of the persistent arm bounds
-                    // their latency to one batch under sustained persistent
-                    // traffic; the ephemeral channel is lossy under lag, so
-                    // its backlog is bounded by construction.
-                    Some(event) = ephemeral.next() => {
-                        self.handler
-                            .handle_ephemeral(&event)
-                            .await
-                            .map_err(|e| e as Box<dyn std::error::Error>)?;
-                        continue;
                     }
                     _ = tokio::time::sleep_until(tracker.last_persist + self.checkpoint_interval),
                         if tracker.persisted_seq < state.sequence => {
@@ -347,17 +437,42 @@ where
                         tracker.last_persist = tokio::time::Instant::now();
                         continue;
                     }
-                    event = persistent.next() => match event {
-                        Some(event) => event,
-                        None => {
-                            if tracker.persisted_seq < state.sequence {
-                                persist_checkpoint(&mut current_job, &state)
-                                    .await
-                                    .map_err(|e| e as Box<dyn std::error::Error>)?;
+                    // The two streams race in an UNBIASED inner select: the
+                    // poll order is randomized per wait, so when both are
+                    // continuously ready each gets a fair share of batch
+                    // boundaries — neither channel can starve the other
+                    // under any traffic pattern (N consecutive wins against
+                    // a ready peer has probability 2^-N). Shutdown and the
+                    // checkpoint timer keep deterministic priority above.
+                    next = async {
+                        tokio::select! {
+                            Some(event) = next_if_subscribed(&mut ephemeral) => {
+                                NextDelivery::Ephemeral(event)
                             }
-                            return Ok(JobCompletion::RescheduleNow);
+                            event = persistent.next() => NextDelivery::Persistent(event),
                         }
-                    },
+                    } => next,
+                };
+                match next {
+                    // Nothing is pending here by construction, so no
+                    // transaction spans the foreign `handle_ephemeral` await
+                    // and a failure discards no batch work.
+                    NextDelivery::Ephemeral(event) => {
+                        self.handler
+                            .handle_ephemeral(&event)
+                            .await
+                            .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        continue;
+                    }
+                    NextDelivery::Persistent(Some(event)) => event,
+                    NextDelivery::Persistent(None) => {
+                        if tracker.persisted_seq < state.sequence {
+                            persist_checkpoint(&mut current_job, &state)
+                                .await
+                                .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        }
+                        return Ok(JobCompletion::RescheduleNow);
+                    }
                 }
             };
 

--- a/src/out/mod.rs
+++ b/src/out/mod.rs
@@ -16,7 +16,7 @@ use serde::{Serialize, de::DeserializeOwned};
 use std::sync::Arc;
 
 pub use self::ctx::{BatchOp, EventCtx, FlushError, FlushOp, Handled, IsolatedOp};
-pub use self::job::{OutboxEventHandler, OutboxEventJobConfig};
+pub use self::job::{EventSubscription, OutboxEventHandler, OutboxEventJobConfig};
 use crate::{config::*, handle::OwnedTaskHandle, sequence::EventSequence, tables::*};
 pub use all_listener::AllOutboxListener;
 use ephemeral::EphemeralOutboxEventCache;

--- a/src/out/mod.rs
+++ b/src/out/mod.rs
@@ -15,7 +15,7 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use std::sync::Arc;
 
-pub use self::ctx::{BatchOp, EventCtx, Handled, IsolatedOp};
+pub use self::ctx::{BatchOp, EventCtx, FlushError, FlushOp, Handled, IsolatedOp};
 pub use self::job::{OutboxEventHandler, OutboxEventJobConfig};
 use crate::{config::*, handle::OwnedTaskHandle, sequence::EventSequence, tables::*};
 pub use all_listener::AllOutboxListener;

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -284,7 +284,7 @@ impl OutboxEventHandler<TestEvent> for CollectingHandler {
         }
         self.flush_sizes.lock().await.push(items.len());
         for n in items {
-            insert_effect_in_op(&mut *op, n).await?;
+            insert_effect_in_op(op, n).await?;
         }
         Ok(())
     }
@@ -320,7 +320,7 @@ impl OutboxEventHandler<TestEvent> for CoalescingHandler {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.flush_sizes.lock().await.push(items.len());
         for (_key, latest) in items {
-            insert_effect_in_op(&mut *op, latest).await?;
+            insert_effect_in_op(op, latest).await?;
         }
         Ok(())
     }
@@ -362,7 +362,7 @@ impl OutboxEventHandler<TestEvent> for MixedHandler {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.flush_sizes.lock().await.push(items.len());
         for n in items {
-            insert_effect_in_op(&mut *op, n).await?;
+            insert_effect_in_op(op, n).await?;
         }
         Ok(())
     }
@@ -408,7 +408,7 @@ impl OutboxEventHandler<TestEvent> for CollectThenIsolateHandler {
         items: Vec<i64>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         for n in items {
-            insert_effect_in_op(&mut *op, n).await?;
+            insert_effect_in_op(op, n).await?;
         }
         Ok(())
     }

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use obix::{
-    EventCtx, Handled, MailboxConfig, OutboxEventHandler, OutboxEventJobConfig, out::Outbox,
+    EventCtx, EventSubscription, Handled, MailboxConfig, OutboxEventHandler, OutboxEventJobConfig,
+    out::Outbox,
 };
 use serde::{Deserialize, Serialize};
 use serial_test::file_serial;
@@ -409,6 +410,103 @@ impl OutboxEventHandler<TestEvent> for CollectThenIsolateHandler {
         for n in items {
             insert_effect_in_op(&mut *op, n).await?;
         }
+        Ok(())
+    }
+}
+
+/// `All`-subscription probe with a deliberately slow ephemeral path: under a
+/// saturating ephemeral flood the ephemeral stream is *always* ready, so any
+/// static priority toward it would starve persistent progress forever — the
+/// fair race must still deliver persistent events.
+struct FairnessProbeHandler {
+    persistent_received: Arc<Mutex<Vec<u64>>>,
+}
+
+impl OutboxEventHandler<TestEvent> for FairnessProbeHandler {
+    type Batch = ();
+
+    async fn handle_persistent<'inv>(
+        &self,
+        ctx: EventCtx<'inv>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(TestEvent::Ping(n)) = &event.payload {
+            self.persistent_received.lock().await.push(*n);
+        }
+        Ok(ctx.skip())
+    }
+
+    async fn handle_ephemeral(
+        &self,
+        _event: &obix::out::EphemeralOutboxEvent<TestEvent>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // Slower than the flood's inter-arrival time: the ephemeral channel
+        // never goes empty while the flood runs.
+        tokio::time::sleep(std::time::Duration::from_millis(15)).await;
+        Ok(())
+    }
+}
+
+/// Declares `PersistentOnly`: the ephemeral stream must never even be
+/// subscribed — the (dead-code) `handle_ephemeral` override must never run.
+struct PersistentOnlyHandler {
+    persistent_received: Arc<Mutex<Vec<u64>>>,
+    ephemeral_received: Arc<Mutex<Vec<u64>>>,
+}
+
+impl OutboxEventHandler<TestEvent> for PersistentOnlyHandler {
+    const SUBSCRIPTION: EventSubscription = EventSubscription::PersistentOnly;
+    type Batch = ();
+
+    async fn handle_persistent<'inv>(
+        &self,
+        ctx: EventCtx<'inv>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(TestEvent::Ping(n)) = &event.payload {
+            self.persistent_received.lock().await.push(*n);
+        }
+        Ok(ctx.skip())
+    }
+
+    async fn handle_ephemeral(
+        &self,
+        event: &obix::out::EphemeralOutboxEvent<TestEvent>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let TestEvent::Ping(n) = &event.payload;
+        self.ephemeral_received.lock().await.push(*n);
+        Ok(())
+    }
+}
+
+/// Declares `EphemeralOnly`: no persistent deliveries and no checkpoint
+/// machinery — the job must never write execution state.
+struct EphemeralOnlyHandler {
+    persistent_received: Arc<Mutex<Vec<u64>>>,
+    ephemeral_received: Arc<Mutex<Vec<u64>>>,
+}
+
+impl OutboxEventHandler<TestEvent> for EphemeralOnlyHandler {
+    const SUBSCRIPTION: EventSubscription = EventSubscription::EphemeralOnly;
+    type Batch = ();
+
+    async fn handle_persistent<'inv>(
+        &self,
+        ctx: EventCtx<'inv>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(TestEvent::Ping(n)) = &event.payload {
+            self.persistent_received.lock().await.push(*n);
+        }
+        Ok(ctx.skip())
+    }
+
+    async fn handle_ephemeral(
+        &self,
+        event: &obix::out::EphemeralOutboxEvent<TestEvent>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let TestEvent::Ping(n) = &event.payload;
+        self.ephemeral_received.lock().await.push(*n);
         Ok(())
     }
 }
@@ -1417,6 +1515,175 @@ async fn single_collected_event_flushes_promptly_at_low_traffic() -> anyhow::Res
         "single collected event took {latency:?} to land"
     );
     assert_eq!(*flush_sizes.lock().await, vec![1]);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn continuous_ephemeral_traffic_does_not_starve_persistent_events() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let persistent_received = Arc::new(Mutex::new(Vec::new()));
+    let outbox = init_outbox_with_handler(
+        &pool,
+        &mut jobs,
+        FairnessProbeHandler {
+            persistent_received: persistent_received.clone(),
+        },
+    )
+    .await?;
+
+    jobs.start_poll().await?;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Saturating flood: inter-arrival (~5ms) is shorter than the handler's
+    // ephemeral handling time (15ms), so the ephemeral stream is always
+    // ready. A static ephemeral-first priority would never poll the
+    // persistent stream again.
+    let flood_outbox = outbox.clone();
+    let flood = tokio::spawn(async move {
+        let event_type = obix::out::EphemeralEventType::new("flood");
+        loop {
+            if flood_outbox
+                .publish_ephemeral(event_type.clone(), TestEvent::Ping(0))
+                .await
+                .is_err()
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    });
+
+    // Let the flood saturate the channel before the persistent event lands.
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+        .await?;
+    op.commit().await?;
+
+    // The fair race guarantees the persistent stream keeps winning boundary
+    // slots despite the flood.
+    let delivered =
+        wait_for_n_deliveries(&persistent_received, 1, std::time::Duration::from_secs(5)).await;
+    flood.abort();
+    delivered?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn persistent_only_handler_never_subscribes_ephemerals() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let persistent_received = Arc::new(Mutex::new(Vec::new()));
+    let ephemeral_received = Arc::new(Mutex::new(Vec::new()));
+    let outbox = init_outbox_with_handler(
+        &pool,
+        &mut jobs,
+        PersistentOnlyHandler {
+            persistent_received: persistent_received.clone(),
+            ephemeral_received: ephemeral_received.clone(),
+        },
+    )
+    .await?;
+
+    jobs.start_poll().await?;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let event_type = obix::out::EphemeralEventType::new("unsubscribed");
+    outbox
+        .publish_ephemeral(event_type.clone(), TestEvent::Ping(99))
+        .await?;
+
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+        .await?;
+    op.commit().await?;
+
+    wait_for_n_deliveries(&persistent_received, 1, std::time::Duration::from_secs(5)).await?;
+
+    // Settle, then prove the dead-code contract: the ephemeral stream was
+    // never subscribed, so the handler's override never ran.
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    assert_eq!(*persistent_received.lock().await, vec![1]);
+    assert!(
+        ephemeral_received.lock().await.is_empty(),
+        "PersistentOnly handler must never receive ephemeral events"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn ephemeral_only_handler_skips_checkpoint_machinery() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let persistent_received = Arc::new(Mutex::new(Vec::new()));
+    let ephemeral_received = Arc::new(Mutex::new(Vec::new()));
+    let outbox = init_outbox_with_handler(
+        &pool,
+        &mut jobs,
+        EphemeralOnlyHandler {
+            persistent_received: persistent_received.clone(),
+            ephemeral_received: ephemeral_received.clone(),
+        },
+    )
+    .await?;
+
+    jobs.start_poll().await?;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+        .await?;
+    op.commit().await?;
+
+    let event_type = obix::out::EphemeralEventType::new("only");
+    outbox
+        .publish_ephemeral(event_type, TestEvent::Ping(7))
+        .await?;
+
+    wait_for_n_deliveries(&ephemeral_received, 1, std::time::Duration::from_secs(5)).await?;
+
+    // Settle, then prove both halves of the contract: no persistent
+    // delivery, and no execution state ever written (the job sheds the
+    // whole checkpoint machinery, not just the stream).
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    assert!(
+        persistent_received.lock().await.is_empty(),
+        "EphemeralOnly handler must never receive persistent events"
+    );
+    assert_eq!(
+        checkpoint_sequence(&pool).await?,
+        None,
+        "EphemeralOnly job must never write execution state"
+    );
 
     Ok(())
 }

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -26,6 +26,8 @@ struct SkippingObserver {
 }
 
 impl OutboxEventHandler<TestEvent> for SkippingObserver {
+    type Batch = ();
+
     async fn handle_persistent<'inv>(
         &self,
         ctx: EventCtx<'inv>,
@@ -44,6 +46,8 @@ struct CheckpointingObserver {
 }
 
 impl OutboxEventHandler<TestEvent> for CheckpointingObserver {
+    type Batch = ();
+
     async fn handle_persistent<'inv>(
         &self,
         ctx: EventCtx<'inv>,
@@ -62,6 +66,8 @@ struct TestEphemeralHandler {
 }
 
 impl OutboxEventHandler<TestEvent> for TestEphemeralHandler {
+    type Batch = ();
+
     async fn handle_ephemeral(
         &self,
         event: &obix::out::EphemeralOutboxEvent<TestEvent>,
@@ -78,6 +84,8 @@ struct TestBothHandler {
 }
 
 impl OutboxEventHandler<TestEvent> for TestBothHandler {
+    type Batch = ();
+
     async fn handle_persistent<'inv>(
         &self,
         ctx: EventCtx<'inv>,
@@ -124,6 +132,8 @@ struct DeferringEffectHandler {
 }
 
 impl OutboxEventHandler<TestEvent> for DeferringEffectHandler {
+    type Batch = ();
+
     async fn handle_persistent<'inv>(
         &self,
         ctx: EventCtx<'inv>,
@@ -158,6 +168,8 @@ struct IsolatingEffectHandler {
 }
 
 impl OutboxEventHandler<TestEvent> for IsolatingEffectHandler {
+    type Batch = ();
+
     async fn handle_persistent<'inv>(
         &self,
         ctx: EventCtx<'inv>,
@@ -185,7 +197,8 @@ impl OutboxEventHandler<TestEvent> for IsolatingEffectHandler {
 
 /// Slow deferring worker that also records ephemerals and snapshots the
 /// committed effect rows when an ephemeral runs — used to prove an
-/// ephemeral arriving mid-batch lands the open batch first.
+/// ephemeral arriving mid-batch never interrupts the batch: it is handled
+/// at the batch boundary, after the full batch has landed.
 struct SlowDeferringHandler {
     pool: sqlx::PgPool,
     ephemeral_received: Arc<Mutex<Vec<u64>>>,
@@ -193,6 +206,8 @@ struct SlowDeferringHandler {
 }
 
 impl OutboxEventHandler<TestEvent> for SlowDeferringHandler {
+    type Batch = ();
+
     async fn handle_persistent<'inv>(
         &self,
         ctx: EventCtx<'inv>,
@@ -222,6 +237,178 @@ impl OutboxEventHandler<TestEvent> for SlowDeferringHandler {
             .expect("read effect rows")
             .len();
         *self.rows_at_ephemeral.lock().await = rows;
+        Ok(())
+    }
+}
+
+/// Collect-only worker: contributes each event to a `Vec` accumulator — a
+/// pure memory write, no per-event transaction or statement — and applies
+/// the whole batch in one `flush` call through the [`obix::FlushOp`].
+/// Sleeps briefly per event so backfill keeps the ready backlog ahead of the
+/// handler (making batch composition deterministic in tests). Optionally
+/// fails the first flush to prove replay re-collects from scratch.
+struct CollectingHandler {
+    flush_sizes: Arc<Mutex<Vec<usize>>>,
+    fail_first_flush: Arc<AtomicBool>,
+}
+
+impl OutboxEventHandler<TestEvent> for CollectingHandler {
+    type Batch = Vec<i64>;
+
+    async fn handle_persistent<'inv>(
+        &self,
+        ctx: EventCtx<'inv, Vec<i64>>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
+        let Some(TestEvent::Ping(n)) = &event.payload else {
+            return Ok(ctx.skip());
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        Ok(ctx.collect(*n as i64))
+    }
+
+    async fn flush(
+        &self,
+        op: &mut obix::FlushOp<'_>,
+        items: Vec<i64>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use es_entity::AtomicOperation;
+        // Provided-method delegation pinned on FlushOp too: inheriting the
+        // trait default would report false here.
+        if !op.supports_hooks() {
+            return Err("FlushOp must delegate supports_hooks to the inner DbOp".into());
+        }
+        if self.fail_first_flush.swap(false, Ordering::SeqCst) {
+            return Err("injected flush failure".into());
+        }
+        self.flush_sizes.lock().await.push(items.len());
+        for n in items {
+            insert_effect_in_op(&mut *op, n).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Keyed fold: coalesces events into a `HashMap` by key (`n % 2`), so only
+/// the last value per key reaches the flush — N updates per key become one
+/// applied row.
+struct CoalescingHandler {
+    flush_sizes: Arc<Mutex<Vec<usize>>>,
+}
+
+impl OutboxEventHandler<TestEvent> for CoalescingHandler {
+    type Batch = std::collections::HashMap<i64, i64>;
+
+    async fn handle_persistent<'inv>(
+        &self,
+        ctx: EventCtx<'inv, Self::Batch>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
+        let Some(TestEvent::Ping(n)) = &event.payload else {
+            return Ok(ctx.skip());
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        let n = *n as i64;
+        Ok(ctx.collect(n % 2, n))
+    }
+
+    async fn flush(
+        &self,
+        op: &mut obix::FlushOp<'_>,
+        items: Self::Batch,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.flush_sizes.lock().await.push(items.len());
+        for (_key, latest) in items {
+            insert_effect_in_op(&mut *op, latest).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Mixes the two batching channels in one handler: odd events are collected
+/// (applied at flush), even events write directly into the shared batch op
+/// and defer — everything lands in the same transaction.
+struct MixedHandler {
+    flush_sizes: Arc<Mutex<Vec<usize>>>,
+}
+
+impl OutboxEventHandler<TestEvent> for MixedHandler {
+    type Batch = Vec<i64>;
+
+    async fn handle_persistent<'inv>(
+        &self,
+        ctx: EventCtx<'inv, Vec<i64>>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
+        let Some(TestEvent::Ping(n)) = &event.payload else {
+            return Ok(ctx.skip());
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        let n = *n as i64;
+        if n % 2 == 1 {
+            Ok(ctx.collect(n))
+        } else {
+            let mut op = ctx.consume_in_batch().await?;
+            insert_effect_in_op(&mut op, n).await?;
+            Ok(op.defer())
+        }
+    }
+
+    async fn flush(
+        &self,
+        op: &mut obix::FlushOp<'_>,
+        items: Vec<i64>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.flush_sizes.lock().await.push(items.len());
+        for n in items {
+            insert_effect_in_op(&mut *op, n).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Collects everything except one event value, which it handles isolated —
+/// the isolation fence must land the collected items (and their checkpoint)
+/// before the isolated op exists, so the isolated failure replays alone.
+struct CollectThenIsolateHandler {
+    deliveries: Arc<Mutex<Vec<u64>>>,
+    isolate_on: u64,
+    fail_isolated_once: Arc<AtomicBool>,
+}
+
+impl OutboxEventHandler<TestEvent> for CollectThenIsolateHandler {
+    type Batch = Vec<i64>;
+
+    async fn handle_persistent<'inv>(
+        &self,
+        ctx: EventCtx<'inv, Vec<i64>>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
+        let Some(TestEvent::Ping(n)) = &event.payload else {
+            return Ok(ctx.skip());
+        };
+        self.deliveries.lock().await.push(*n);
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        if *n == self.isolate_on {
+            let mut op = ctx.consume_isolated().await?;
+            insert_effect_in_op(&mut op, *n as i64).await?;
+            if !self.fail_isolated_once.swap(true, Ordering::SeqCst) {
+                return Err("injected isolated failure".into());
+            }
+            Ok(op.commit())
+        } else {
+            Ok(ctx.collect(*n as i64))
+        }
+    }
+
+    async fn flush(
+        &self,
+        op: &mut obix::FlushOp<'_>,
+        items: Vec<i64>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        for n in items {
+            insert_effect_in_op(&mut *op, n).await?;
+        }
         Ok(())
     }
 }
@@ -771,7 +958,7 @@ async fn skipped_events_advance_checkpoint_lazily() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[file_serial]
-async fn ephemeral_arriving_mid_batch_lands_the_open_batch_first() -> anyhow::Result<()> {
+async fn ephemeral_never_interrupts_an_open_batch() -> anyhow::Result<()> {
     let pool = init_pool().await?;
     reset_batch_effects_table(&pool).await?;
 
@@ -794,8 +981,8 @@ async fn ephemeral_arriving_mid_batch_lands_the_open_batch_first() -> anyhow::Re
     )
     .await?;
 
-    // Publish a backlog of slow (100ms each) deferring events, then land an
-    // ephemeral while the batch is guaranteed to still be open mid-drain.
+    // Publish a backlog of slow (100ms each) deferring events, then publish
+    // an ephemeral while the batch is guaranteed to still be open mid-drain.
     const N: u64 = 5;
     let mut op = outbox.begin_op().await?;
     for n in 1..=N {
@@ -818,18 +1005,15 @@ async fn ephemeral_arriving_mid_batch_lands_the_open_batch_first() -> anyhow::Re
     wait_for_effect_rows(&pool, N as usize).await?;
     wait_for_n_deliveries(&ephemeral_received, 1, std::time::Duration::from_secs(5)).await?;
 
-    // The ephemeral truncated the open batch (flush reason "ephemeral"):
-    // the work buffered so far was already committed when the ephemeral
-    // handler ran, and the drain continued afterwards — the open
-    // transaction was never held across the ephemeral handler's await.
+    // Ephemerals travel on their own stream and are only handled between
+    // batches: the mid-drain arrival did NOT truncate the batch — all N
+    // events coalesced into it — and by the time the ephemeral handler ran,
+    // the full batch had landed (so no transaction spanned its await and
+    // its failure could have discarded nothing).
     let rows_at_ephemeral = *rows_at_ephemeral.lock().await;
-    assert!(
-        rows_at_ephemeral >= 1,
-        "expected the open batch to land before the ephemeral ran"
-    );
-    assert!(
-        rows_at_ephemeral < N as usize,
-        "expected the ephemeral to arrive mid-drain, rows_at_ephemeral: {rows_at_ephemeral}"
+    assert_eq!(
+        rows_at_ephemeral, N as usize,
+        "expected the ephemeral to run at the batch boundary, after the whole batch landed"
     );
     assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3, 4, 5]);
 
@@ -882,6 +1066,357 @@ async fn single_deferred_event_commits_promptly_at_low_traffic() -> anyhow::Resu
         latency < std::time::Duration::from_secs(2),
         "single deferred event took {latency:?} to land"
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn collected_events_flush_once_per_batch() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let flush_sizes = Arc::new(Mutex::new(Vec::new()));
+    let outbox = init_outbox_with_handler(
+        &pool,
+        &mut jobs,
+        CollectingHandler {
+            flush_sizes: flush_sizes.clone(),
+            fail_first_flush: Arc::new(AtomicBool::new(false)),
+        },
+    )
+    .await?;
+
+    // Publish before the job starts so the events arrive as ready backlog.
+    const N: u64 = 5;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    wait_for_effect_rows(&pool, N as usize).await?;
+    wait_for_checkpoint(&pool, N as i64).await?;
+
+    // One flush applied the whole burst: N per-event statements became a
+    // single batched flush call inside the checkpoint's transaction.
+    assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3, 4, 5]);
+    assert_eq!(*flush_sizes.lock().await, vec![N as usize]);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn batch_full_bounds_collected_batches() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let flush_sizes = Arc::new(Mutex::new(Vec::new()));
+    let config = OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE)).with_max_batch_size(3);
+    let outbox = init_outbox_with_handler_config(
+        &pool,
+        &mut jobs,
+        config,
+        CollectingHandler {
+            flush_sizes: flush_sizes.clone(),
+            fail_first_flush: Arc::new(AtomicBool::new(false)),
+        },
+    )
+    .await?;
+
+    const N: u64 = 5;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    wait_for_effect_rows(&pool, N as usize).await?;
+
+    // Collected events count toward max_batch_size: the burst of 5 was
+    // force-flushed at 3, bounding the replay window and the flushed
+    // accumulator size.
+    assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3, 4, 5]);
+    assert_eq!(*flush_sizes.lock().await, vec![3, 2]);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn failed_flush_replays_and_recollects() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let flush_sizes = Arc::new(Mutex::new(Vec::new()));
+    let config = OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE))
+        .with_retry_settings(fast_retry_settings());
+    let outbox = init_outbox_with_handler_config(
+        &pool,
+        &mut jobs,
+        config,
+        CollectingHandler {
+            flush_sizes: flush_sizes.clone(),
+            fail_first_flush: Arc::new(AtomicBool::new(true)),
+        },
+    )
+    .await?;
+
+    const N: u64 = 5;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    wait_for_effect_rows(&pool, N as usize).await?;
+    wait_for_checkpoint(&pool, N as i64).await?;
+
+    // The failed flush dropped its drained items with the op; the retry
+    // re-delivered the events and re-collected from scratch. The primary
+    // key on the effects table proves nothing was applied twice — a stale
+    // accumulator surviving into the retry would have double-inserted.
+    assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3, 4, 5]);
+    assert_eq!(*flush_sizes.lock().await, vec![N as usize]);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn mixed_collect_and_defer_land_in_one_batch() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let flush_sizes = Arc::new(Mutex::new(Vec::new()));
+    let outbox = init_outbox_with_handler(
+        &pool,
+        &mut jobs,
+        MixedHandler {
+            flush_sizes: flush_sizes.clone(),
+        },
+    )
+    .await?;
+
+    const N: u64 = 4;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    wait_for_effect_rows(&pool, N as usize).await?;
+    wait_for_checkpoint(&pool, N as i64).await?;
+
+    // Odd events were collected (applied at flush), even events wrote into
+    // the shared op at handle time — one batch, one transaction, one
+    // checkpoint for all four.
+    assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3, 4]);
+    assert_eq!(*flush_sizes.lock().await, vec![2]);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn isolated_entry_flushes_collected_items_first() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let deliveries = Arc::new(Mutex::new(Vec::new()));
+    let config = OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE))
+        .with_retry_settings(fast_retry_settings());
+    let outbox = init_outbox_with_handler_config(
+        &pool,
+        &mut jobs,
+        config,
+        CollectThenIsolateHandler {
+            deliveries: deliveries.clone(),
+            isolate_on: 3,
+            fail_isolated_once: Arc::new(AtomicBool::new(false)),
+        },
+    )
+    .await?;
+
+    const N: u64 = 3;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    wait_for_effect_rows(&pool, N as usize).await?;
+    assert_eq!(batch_effect_rows(&pool).await?, vec![1, 2, 3]);
+
+    // The isolation fence flushed the collected items (and their
+    // checkpoint) before event 3's op existed — so the injected isolated
+    // failure replayed event 3 alone; events 1 and 2 were already durable
+    // and re-delivery would have double-inserted into the primary key.
+    let deliveries = deliveries.lock().await;
+    let count = |v: u64| deliveries.iter().filter(|&&n| n == v).count();
+    assert_eq!(
+        count(1),
+        1,
+        "event 1 must not replay with the isolated failure, deliveries: {deliveries:?}"
+    );
+    assert_eq!(
+        count(2),
+        1,
+        "event 2 must not replay with the isolated failure, deliveries: {deliveries:?}"
+    );
+    assert!(
+        count(3) >= 2,
+        "event 3 must replay alone, deliveries: {deliveries:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn hashmap_collect_coalesces_by_key() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let flush_sizes = Arc::new(Mutex::new(Vec::new()));
+    let outbox = init_outbox_with_handler(
+        &pool,
+        &mut jobs,
+        CoalescingHandler {
+            flush_sizes: flush_sizes.clone(),
+        },
+    )
+    .await?;
+
+    // Five events over two keys (n % 2): events arrive in ascending
+    // sequence, so the HashMap's last-write-wins keeps 4 (key 0) and 5
+    // (key 1).
+    const N: u64 = 5;
+    let mut op = outbox.begin_op().await?;
+    for n in 1..=N {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(n))
+            .await?;
+    }
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    wait_for_effect_rows(&pool, 2).await?;
+    wait_for_checkpoint(&pool, N as i64).await?;
+
+    // N updates per key coalesced in the accumulator: only the newest value
+    // per key reached the flush.
+    assert_eq!(batch_effect_rows(&pool).await?, vec![4, 5]);
+    assert_eq!(*flush_sizes.lock().await, vec![2]);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn single_collected_event_flushes_promptly_at_low_traffic() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset_batch_effects_table(&pool).await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let flush_sizes = Arc::new(Mutex::new(Vec::new()));
+    let outbox = init_outbox_with_handler(
+        &pool,
+        &mut jobs,
+        CollectingHandler {
+            flush_sizes: flush_sizes.clone(),
+            fail_first_flush: Arc::new(AtomicBool::new(false)),
+        },
+    )
+    .await?;
+
+    jobs.start_poll().await?;
+
+    // Let the job start and go idle.
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let published_at = std::time::Instant::now();
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+        .await?;
+    op.commit().await?;
+
+    // Collected items are never held waiting for future events either: the
+    // moment the backlog is drained the batch (of one) flushes — items AND
+    // checkpoint — with no configured wait, and no transaction existed
+    // before the flush instant.
+    wait_for_effect_rows(&pool, 1).await?;
+    wait_for_checkpoint(&pool, 1).await?;
+    let latency = published_at.elapsed();
+    assert!(
+        latency < std::time::Duration::from_secs(2),
+        "single collected event took {latency:?} to land"
+    );
+    assert_eq!(*flush_sizes.lock().await, vec![1]);
 
     Ok(())
 }


### PR DESCRIPTION
## What

Four pieces, one breaking release (0.4.0):

1. **`collect` / `flush` — statement-level batching (layer 3).** A fourth entry verb completes the `EventCtx` cost ladder — each rung strictly more machinery:

   | verb | cost |
   |---|---|
   | `skip()` | nothing |
   | `collect(…)` / `collect_with(…)` | memory write now; one `flush` per batch |
   | `consume_in_batch()` | shared transaction |
   | `consume_isolated()` | own transaction |

   The handler declares `type Batch: Default + Send + 'static` (any accumulator — `Vec`, `HashMap`, custom) and implements `flush(&self, op: &mut FlushOp<'_>, items: Self::Batch)`. The runner hands the accumulator to `flush` **exactly once per batch landing, inside the transaction that commits the checkpoint** — N per-event statements become one batched call. `collect_with` is the general verb; `collect` sugar exists for `Vec` (append) and `HashMap` (keyed last-write-wins — the coalescing fold: N updates per key → 1 flushed entry, correct because events arrive in ascending sequence). Sugar impls are inherent impls on concrete `B` instantiations, so more shapes can land in any future minor.

2. **`SUBSCRIPTION` — per-handler stream declaration.** Most handlers only consume one of the two streams; now they say so:

   ```rust
   const SUBSCRIPTION: EventSubscription = EventSubscription::PersistentOnly; // default: All
   ```

   `PersistentOnly` never subscribes the ephemeral stream — batching is *structurally* immune to ephemeral traffic, and one fewer broadcast receiver exists. `EphemeralOnly` runs a bare dispatch loop: no persistent subscription, no batches, no checkpoints — the job never reads or writes execution state (previously such handlers skip-processed every persistent event and wrote pointer updates forever). Additive: the const defaults to `All`, and declaring a mode is a contract — the other stream's handler method becomes dead code, never called.

3. **Two-stream runner with fair scheduling.** Persistent and ephemeral events are consumed from separate listeners; the batch lifecycle is governed solely by the *persistent* backlog. Ephemeral traffic can no longer truncate a batch (the old forced-flush-on-ephemeral rule — and its `"ephemeral"` flush reason — are gone). Ephemerals are handled between batches, where nothing is pending by construction: no transaction ever spans the foreign `handle_ephemeral` await, and an ephemeral failure can discard no batch work. For `All` handlers the two streams race in an **unbiased** inner select (shutdown and the checkpoint timer keep deterministic priority): poll order is randomized per wait, so neither channel can starve the other under any traffic pattern — N consecutive wins against a ready peer has probability 2⁻ᴺ. Still one sequential loop — the "one handler method at a time" execution model is unchanged.

4. **Sealed op guards** (first commit). `DerefMut` removed from `BatchOp`/`IsolatedOp`: the `AtomicOperation` impls are the only mutable surface, closing the `mem::swap`-a-decoy-op hole that could commit work without its checkpoint. `FlushOp` follows the same philosophy from birth — full `AtomicOperation` delegation, no raw `DbOp` access, commit stays with the runner.

## Example — dw-relay style (foreign-DB batch insert)

```rust
impl OutboxEventHandler<OutboxEventPayload> for DwCalaRelayHandler {
    const SUBSCRIPTION: EventSubscription = EventSubscription::PersistentOnly;
    type Batch = Vec<CalaEventRow>;

    async fn handle_persistent<'inv>(
        &self,
        ctx: EventCtx<'inv, Vec<CalaEventRow>>,
        event: &PersistentOutboxEvent<OutboxEventPayload>,
    ) -> Result<Handled<'inv>, Box<dyn Error + Send + Sync>> {
        if let Some(cala_event @ (…)) = event.as_event() {
            return Ok(ctx.collect(CalaEventRow::from(event, cala_event)?)); // zero round trips
        }
        Ok(ctx.skip())
    }

    async fn flush(&self, _op: &mut FlushOp<'_>, rows: Vec<CalaEventRow>) -> Result<(), _> {
        insert_cala_events_batch(&self.dw_pool, rows).await?; // one multi-row INSERT per batch
        Ok(())
    }
}
```

At the default batch size this collapses ~100 autocommit round trips + WAL fsyncs on the target DB into 1+1. Same-DB consumers write through `op` instead and get flush↔checkpoint atomicity for free.

## Semantics

- **Flush triggers** (unchanged set, minus `ephemeral`): `backlog_drained` (primary — a pending persistent stream lands the batch, so a lone collected event at low traffic flushes immediately, no timers), `batch_full` (collected events count toward `max_batch_size`), commit-exit, `isolated_entry` (the fence lands items + checkpoint *before* the isolated op exists), shutdown, stream-close.
- **Retry safety by ownership**: the accumulator is runner-owned and *drained into* each flush call. A failed flush drops the items with the op; the replayed events re-collect from scratch. This is the retry-safe realization of what #87's `on_flush` wanted — supersedes that approach.
- **Checkpoint fencing**: a checkpoint can never advance past unflushed items — the lazy-checkpoint timer arm is only reachable when nothing is pending, structurally.
- **Error attribution**: flush failures propagate as `FlushError { reason, after, through }`, carrying the at-fault sequence range instead of blaming the (innocent) event whose verb triggered the landing.

## Breaking / migration

- Every `OutboxEventHandler` impl adds one line: `type Batch = ();` (or a real accumulator). Declaring `SUBSCRIPTION` is optional but recommended for single-stream handlers.
- Guard call sites relying on `DerefMut` coercion into concrete `&mut es_entity::DbOp<'_>` params must widen the callee to `&mut impl AtomicOperation`. lana-bank survey found five such methods (`wallet_collateral_sync`, `credit_facility::activate_in_op` + transitive `complete_in_op`, `customer::apply_verification_{approval,decline}_in_op`, `deposit::record_deposit_from_settled_receipt_in_op`); everything else (generated repos, audit, job spawners, `op.clock()` trait calls) is already generic and unaffected.
- Ephemerals are handled at batch boundaries rather than at their merged-stream arrival position (fair-share bounded; the ephemeral channel remains lossy-by-design under lag).

Design record: [obix-dev/handler-controlled-tx-scoping.md](https://github.com/GaloyMoney/drua-library/blob/main/spaces/obix-dev/handler-controlled-tx-scoping.md)

## Verification

- 41/41 `cargo nextest run` (stable across repeats) against dev Postgres — including: one-flush-per-batch, `batch_full` counting collects, failed-flush replay/re-collect (PK-pinned no-double-apply), mixed collect+defer in one transaction, isolated-entry fence landing items first, HashMap coalescing, single-collected-event latency, the inverted ephemeral test (`ephemeral_never_interrupts_an_open_batch`), a saturating-ephemeral-flood starvation regression (fails under any static stream priority), and dead-code/no-execution-state proofs for both `SUBSCRIPTION` modes
- `cargo test --doc` (incl. the `Handled` compile_fail proof), clippy `fail-on-warnings` clean, `nix flake check` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)