### PR TITLE
chore(deps): bump job to 0.6.35 and es-entity to 0.11.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,9 +446,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.11.7"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149610235b18ea5a41dba4cf2c2fc4e6b9d85350952692522487bc4d3a2bf8ea"
+checksum = "b77820b8cd056d9f3831d49f00bb01fe80216e7c8e04f6e39be29c11d2d1fcd2"
 dependencies = [
  "async-stream",
  "chrono",
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.11.7"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded7e94dbbf52311ad4599f0ee920b8b47c9bf0554a80fb9c6958948ddf2f20"
+checksum = "d894eda6b6c6bf66bce9b984af814e51c65366261fdd131c509c23849980914b"
 dependencies = [
  "convert_case",
  "darling 0.23.0",
@@ -957,9 +957,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.32"
+version = "0.6.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2309bb299d6c93e637940573b727202557649a635dee2d2ad34b3f26c67940f0"
+checksum = "39448f226d50f033db27ed58401ce4b7e2414a5fff95b3a956e36e451b00bbc6"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ obix-macros = { path = "obix-macros", version = "0.4.2-dev" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-es-entity = "0.11.7"
+es-entity = "0.11.9"
 anyhow = "1.0"
 tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
@@ -64,7 +64,7 @@ chrono = { version = "0.4", features = ["clock", "serde"], default-features = fa
 tracing = { version = "0.1" }
 futures = "0.3"
 im = { version = "15.1", features = ["serde"] }
-job = "0.6.32"
+job = "0.6.35"
 thiserror = "2.0"
 async-trait = "0.1"
 derive_builder = "0.20"


### PR DESCRIPTION
Bumps `job` to 0.6.35 (SKIP LOCKED poll query) and aligns `es-entity` to 0.11.9 as required by job 0.6.35.