### PR TITLE
perf(outbox): grace period before proactive gap fill

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,13 @@ use es_entity::clock::{Clock, ClockHandle};
 
 pub const DEFAULT_PERSIST_EVENTS_BATCH_SIZE: usize = 5000;
 
+/// How long the persistent cache waits before gap-filling a missing
+/// sequence. Most gaps are in-flight transactions that committed out of
+/// sequence-allocation order and resolve on their own within a few ms;
+/// filling immediately makes the gap-fill upsert block on exactly those
+/// uncommitted rows (ON CONFLICT speculative insertion) until they commit.
+pub const DEFAULT_GAP_FILL_GRACE: std::time::Duration = std::time::Duration::from_millis(250);
+
 #[derive(Clone, Builder)]
 pub struct MailboxConfig {
     #[builder(default = "100")]
@@ -13,6 +20,11 @@ pub struct MailboxConfig {
     pub event_cache_trim_percent: u8,
     #[builder(default = "DEFAULT_PERSIST_EVENTS_BATCH_SIZE")]
     pub persist_events_batch_size: usize,
+    /// Grace period before the first proactive gap fill for a stalled
+    /// broadcast sequence; see [`DEFAULT_GAP_FILL_GRACE`]. Retries after a
+    /// fill attempt are unaffected (fixed 1s interval).
+    #[builder(default = "DEFAULT_GAP_FILL_GRACE")]
+    pub gap_fill_grace: std::time::Duration,
     #[builder(default = "Clock::handle().clone()")]
     pub clock: ClockHandle,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod tables;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 
-pub use config::{DEFAULT_PERSIST_EVENTS_BATCH_SIZE, MailboxConfig};
+pub use config::{DEFAULT_GAP_FILL_GRACE, DEFAULT_PERSIST_EVENTS_BATCH_SIZE, MailboxConfig};
 pub use inbox::{
     Inbox, InboxConfig, InboxError, InboxEvent, InboxEventId, InboxEventStatus, InboxHandler,
     InboxIdempotencyKey, InboxResult,

--- a/src/out/persistent/cache.rs
+++ b/src/out/persistent/cache.rs
@@ -51,6 +51,18 @@ where
     }
 }
 
+/// How long after a gap-fill attempt the same stalled sequence is
+/// retried (the attempt itself may have raced a still-uncommitted row).
+const GAP_REFILL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Bookkeeping for the sequence the broadcast cursor is stalled on.
+struct GapFillState {
+    /// When the stall was first observed. The first fill is withheld until
+    /// `MailboxConfig::gap_fill_grace` has elapsed since this instant.
+    first_seen: std::time::Instant,
+    last_attempt: Option<std::time::Instant>,
+}
+
 #[derive(Debug)]
 pub struct PersistentOutboxEventCache<P, Tables>
 where
@@ -298,6 +310,7 @@ where
         let cache_size = config.event_cache_size;
         let high_water = cache_size * (100 + config.event_cache_trim_percent as usize) / 100;
         let low_water = cache_size * (100 - config.event_cache_trim_percent as usize) / 100;
+        let gap_fill_grace = config.gap_fill_grace;
 
         let initial_sequence = EventSequence::from(highest_known_sequence.load(Ordering::Relaxed));
 
@@ -305,9 +318,22 @@ where
             let mut persistent_cache: im::OrdMap<EventSequence, Arc<PersistentOutboxEvent<P>>> =
                 im::OrdMap::new();
             let mut last_broadcast_sequence = initial_sequence;
-            let mut gap_fill_in_progress_for: Option<(EventSequence, std::time::Instant)> = None;
+            // State of the sequence the broadcast is stalled on: when the
+            // stall was first observed and when the last gap fill was
+            // attempted. Reset whenever the broadcast cursor advances.
+            let mut gap_state: Option<(EventSequence, GapFillState)> = None;
 
             loop {
+                // Wake up exactly when the next gap-fill action falls due,
+                // so a stalled broadcast is filled even when no further
+                // events or notifications arrive.
+                let gap_fill_at = gap_state.as_ref().map(|(_, state)| {
+                    tokio::time::Instant::from_std(match state.last_attempt {
+                        None => state.first_seen + gap_fill_grace,
+                        Some(attempted) => attempted + GAP_REFILL_INTERVAL,
+                    })
+                });
+
                 tokio::select! {
                     biased;
 
@@ -429,24 +455,48 @@ where
                             }
                         }
                     }
+
+                    _ = async {
+                        match gap_fill_at {
+                            Some(deadline) => tokio::time::sleep_until(deadline).await,
+                            None => std::future::pending::<()>().await,
+                        }
+                    } => {}
                 }
 
                 // Proactive gap fill: if broadcasting is stuck waiting for a missing
                 // sequence, trigger load_next_page which will fill the gap via
-                // fill_gaps_query.
+                // fill_gaps_query. The first fill is delayed by `gap_fill_grace`:
+                // most gaps are transactions that hold a sequence but have not
+                // committed yet, and the gap-fill upsert blocks on exactly those
+                // in-flight rows (ON CONFLICT speculative insertion) until they
+                // commit — filling immediately pays a blocked connection per gap
+                // for what a brief wait resolves without any DB work.
                 let next_needed = last_broadcast_sequence.next();
                 let highest = highest_known_sequence.load(Ordering::Relaxed);
                 if u64::from(next_needed) <= highest && !persistent_cache.contains_key(&next_needed)
                 {
-                    let should_fill = match gap_fill_in_progress_for {
-                        Some((seq, started)) if seq == last_broadcast_sequence => {
-                            started.elapsed() > std::time::Duration::from_secs(1)
-                        }
-                        _ => true,
+                    let now = std::time::Instant::now();
+                    if !matches!(&gap_state, Some((seq, _)) if *seq == last_broadcast_sequence) {
+                        gap_state = Some((
+                            last_broadcast_sequence,
+                            GapFillState {
+                                first_seen: now,
+                                last_attempt: None,
+                            },
+                        ));
+                    }
+                    let should_fill = match &gap_state {
+                        Some((_, state)) => match state.last_attempt {
+                            None => state.first_seen.elapsed() >= gap_fill_grace,
+                            Some(attempted) => attempted.elapsed() >= GAP_REFILL_INTERVAL,
+                        },
+                        None => false,
                     };
                     if should_fill {
-                        gap_fill_in_progress_for =
-                            Some((last_broadcast_sequence, std::time::Instant::now()));
+                        if let Some((_, state)) = &mut gap_state {
+                            state.last_attempt = Some(now);
+                        }
                         tokio::spawn(Self::fill_gap(
                             pool.clone(),
                             last_broadcast_sequence,
@@ -455,7 +505,7 @@ where
                         ));
                     }
                 } else {
-                    gap_fill_in_progress_for = None;
+                    gap_state = None;
                 }
 
                 if persistent_cache.len() > high_water {

--- a/src/out/persistent/cache.rs
+++ b/src/out/persistent/cache.rs
@@ -51,16 +51,55 @@ where
     }
 }
 
-/// How long after a gap-fill attempt the same stalled sequence is
-/// retried (the attempt itself may have raced a still-uncommitted row).
-const GAP_REFILL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
-
 /// Bookkeeping for the sequence the broadcast cursor is stalled on.
 struct GapFillState {
+    /// Grace period before the first fill (`MailboxConfig::gap_fill_grace`).
+    grace: std::time::Duration,
+    /// The sequence the broadcast cursor is stalled on. The state is
+    /// discarded when the cursor advances past it.
+    stalled_on: EventSequence,
     /// When the stall was first observed. The first fill is withheld until
-    /// `MailboxConfig::gap_fill_grace` has elapsed since this instant.
-    first_seen: std::time::Instant,
-    last_attempt: Option<std::time::Instant>,
+    /// `grace` has elapsed since this instant.
+    first_seen: tokio::time::Instant,
+    last_attempt: Option<tokio::time::Instant>,
+}
+
+impl GapFillState {
+    /// How long after a gap-fill attempt the same stalled sequence is
+    /// retried (the attempt itself may have raced a still-uncommitted row).
+    const REFILL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
+    fn new(grace: std::time::Duration, stalled_on: EventSequence) -> Self {
+        Self {
+            grace,
+            stalled_on,
+            first_seen: tokio::time::Instant::now(),
+            last_attempt: None,
+        }
+    }
+
+    /// Whether this state tracks the sequence the broadcast cursor is
+    /// currently stalled on.
+    fn is_up_to_date(&self, stalled_on: EventSequence) -> bool {
+        self.stalled_on == stalled_on
+    }
+
+    /// When the next gap-fill action falls due: `grace` after the stall was
+    /// first observed, or [`Self::REFILL_INTERVAL`] after the last attempt.
+    fn next_fill_due(&self) -> tokio::time::Instant {
+        match self.last_attempt {
+            None => self.first_seen + self.grace,
+            Some(attempted) => attempted + Self::REFILL_INTERVAL,
+        }
+    }
+
+    fn fill_is_due(&self) -> bool {
+        self.next_fill_due() <= tokio::time::Instant::now()
+    }
+
+    fn record_attempt(&mut self) {
+        self.last_attempt = Some(tokio::time::Instant::now());
+    }
 }
 
 #[derive(Debug)]
@@ -318,21 +357,15 @@ where
             let mut persistent_cache: im::OrdMap<EventSequence, Arc<PersistentOutboxEvent<P>>> =
                 im::OrdMap::new();
             let mut last_broadcast_sequence = initial_sequence;
-            // State of the sequence the broadcast is stalled on: when the
-            // stall was first observed and when the last gap fill was
-            // attempted. Reset whenever the broadcast cursor advances.
-            let mut gap_state: Option<(EventSequence, GapFillState)> = None;
+            // Bookkeeping for the sequence the broadcast is stalled on.
+            // Reset whenever the broadcast cursor advances.
+            let mut gap_state: Option<GapFillState> = None;
 
             loop {
                 // Wake up exactly when the next gap-fill action falls due,
                 // so a stalled broadcast is filled even when no further
                 // events or notifications arrive.
-                let gap_fill_at = gap_state.as_ref().map(|(_, state)| {
-                    tokio::time::Instant::from_std(match state.last_attempt {
-                        None => state.first_seen + gap_fill_grace,
-                        Some(attempted) => attempted + GAP_REFILL_INTERVAL,
-                    })
-                });
+                let gap_fill_at = gap_state.as_ref().map(GapFillState::next_fill_due);
 
                 tokio::select! {
                     biased;
@@ -476,27 +509,17 @@ where
                 let highest = highest_known_sequence.load(Ordering::Relaxed);
                 if u64::from(next_needed) <= highest && !persistent_cache.contains_key(&next_needed)
                 {
-                    let now = std::time::Instant::now();
-                    if !matches!(&gap_state, Some((seq, _)) if *seq == last_broadcast_sequence) {
-                        gap_state = Some((
-                            last_broadcast_sequence,
-                            GapFillState {
-                                first_seen: now,
-                                last_attempt: None,
-                            },
-                        ));
+                    if gap_state
+                        .as_ref()
+                        .is_some_and(|state| !state.is_up_to_date(last_broadcast_sequence))
+                    {
+                        gap_state = None;
                     }
-                    let should_fill = match &gap_state {
-                        Some((_, state)) => match state.last_attempt {
-                            None => state.first_seen.elapsed() >= gap_fill_grace,
-                            Some(attempted) => attempted.elapsed() >= GAP_REFILL_INTERVAL,
-                        },
-                        None => false,
-                    };
-                    if should_fill {
-                        if let Some((_, state)) = &mut gap_state {
-                            state.last_attempt = Some(now);
-                        }
+                    let state = gap_state.get_or_insert_with(|| {
+                        GapFillState::new(gap_fill_grace, last_broadcast_sequence)
+                    });
+                    if state.fill_is_due() {
+                        state.record_attempt();
                         tokio::spawn(Self::fill_gap(
                             pool.clone(),
                             last_broadcast_sequence,

--- a/tests/outbox.rs
+++ b/tests/outbox.rs
@@ -392,6 +392,146 @@ async fn sequence_gap_from_rolled_back_transaction() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[file_serial]
+async fn gap_fill_waits_for_grace_period() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let outbox = init_outbox::<TestEvent>(
+        &pool,
+        MailboxConfig::builder()
+            .gap_fill_grace(std::time::Duration::from_secs(2))
+            .build()
+            .expect("Couldn't build MailboxConfig"),
+    )
+    .await?;
+
+    let mut listener = outbox.listen_persisted(None);
+
+    // Publish an event (seq N)
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(0))
+        .await?;
+    op.commit().await?;
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
+        .await?
+        .expect("should receive first event");
+    assert!(matches!(event.payload, Some(TestEvent::Ping(0))));
+
+    // Burn a sequence number (gap at N+1), then publish seq N+2
+    sqlx::query!("SELECT nextval('persistent_outbox_events_sequence_seq')")
+        .fetch_one(&pool)
+        .await?;
+
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+        .await?;
+    op.commit().await?;
+
+    // Within the grace period nothing may be yielded: no premature
+    // placeholder for the gap, and the real event is contiguous-blocked
+    // behind it.
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(500), listener.next())
+            .await
+            .is_err(),
+        "no gap-fill placeholder before the grace period elapses"
+    );
+
+    // After the grace period the placeholder arrives, then the real event.
+    let gap_event = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
+        .await?
+        .expect("should receive gap-filled placeholder after grace period");
+    assert!(
+        gap_event.payload.is_none(),
+        "gap-filled event should have None payload"
+    );
+
+    let real_event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
+        .await?
+        .expect("should receive real event after gap");
+    assert!(matches!(real_event.payload, Some(TestEvent::Ping(1))));
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn in_flight_transaction_gap_resolves_without_placeholder() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    // Default grace (250ms) — the in-flight transaction below commits well
+    // within it, so the gap must resolve with the real row, never a
+    // placeholder.
+    let outbox = init_outbox::<TestEvent>(
+        &pool,
+        MailboxConfig::builder()
+            .build()
+            .expect("Couldn't build MailboxConfig"),
+    )
+    .await?;
+
+    let mut listener = outbox.listen_persisted(None);
+
+    // Publish an event (seq N)
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(0))
+        .await?;
+    op.commit().await?;
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
+        .await?
+        .expect("should receive first event");
+    assert!(matches!(event.payload, Some(TestEvent::Ping(0))));
+
+    // Insert seq N+1 directly in a transaction that stays open…
+    let mut tx = pool.begin().await?;
+    sqlx::query("INSERT INTO persistent_outbox_events (payload) VALUES ($1::jsonb)")
+        .bind(r#"{"Ping": 7}"#)
+        .execute(&mut *tx)
+        .await?;
+
+    // …while a later event (seq N+2) commits first, creating the classic
+    // allocation-order vs commit-order gap.
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+        .await?;
+    op.commit().await?;
+
+    // Nothing is yielded while the gap is unresolved (contiguous broadcast).
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(100), listener.next())
+            .await
+            .is_err(),
+        "no event may be yielded while the gap sequence is uncommitted"
+    );
+
+    // Commit the in-flight transaction within the grace period: the gap
+    // resolves with the real event, not a placeholder.
+    tx.commit().await?;
+
+    let gap_event = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
+        .await?
+        .expect("should receive the committed gap event");
+    assert!(
+        matches!(gap_event.payload, Some(TestEvent::Ping(7))),
+        "gap must resolve with the real committed event, got {:?}",
+        gap_event.payload
+    );
+
+    let real_event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
+        .await?
+        .expect("should receive real event after gap");
+    assert!(matches!(real_event.payload, Some(TestEvent::Ping(1))));
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
 async fn ephemeral_events_via_cache() -> anyhow::Result<()> {
     let pool = init_pool().await?;
 


### PR DESCRIPTION
`sequence` is a BIGSERIAL, so allocation order diverges from commit order under concurrency. The persistent cache fired `fill_gap` the instant it noticed a missing sequence, and the gap-fill upsert (`INSERT ... ON CONFLICT (sequence) DO UPDATE`) then **blocked on the still-uncommitted row** (speculative-insertion conflict) until the owner transaction committed.

Measured in a 30-min stress test of a lana-bank sandbox (10 loans/s target, ~4/s achieved): ~10–16 such blocked upserts/sec at 22–24ms mean — the listener was paying other transactions' commit latency with a blocked connection, for gaps that mostly resolve by themselves a few ms later. ~0.25–0.3 DB-core of pure waiting across the core and cala outboxes.

## Change

The first fill for a stalled sequence is withheld for `MailboxConfig.gap_fill_grace` (default **250ms**, builder-configurable). Most gaps resolve via the normal broadcast/NOTIFY path before the grace elapses. Retries after a fill attempt keep the existing 1s interval. A deadline arm in the cache loop's `select!` guarantees the fill fires at grace expiry even when no further events arrive (no regression for a stalled broadcast at the tail of a traffic burst). Real gaps (rolled-back transactions) surface one grace period later — bounded and acceptable.

## Test plan

- New: `gap_fill_waits_for_grace_period` — with a 2s grace, no placeholder is broadcast within 500ms of the gap; the placeholder arrives after grace, followed by the real event. (Fails against the old immediate-fill behavior.)
- New: `in_flight_transaction_gap_resolves_without_placeholder` — a gap whose owning transaction commits within the grace period resolves with the real event, never a placeholder.
- Existing `sequence_gap_from_rolled_back_transaction` still passes with the default grace (placeholder within its 5s timeout).
- Full suite green (54 tests), fmt/clippy clean.

Companion PR: slims the persistent-event NOTIFY payload (#101).
