### PR TITLE
fix(outbox): skip-and-log undeserializable payloads instead of panicking

### DIFF
--- a/obix-macros/src/tables.rs
+++ b/obix-macros/src/tables.rs
@@ -37,9 +37,14 @@ impl ToTokens for MailboxTables {
             quote! {
                 let tracing_context = row.tracing_context
                     .filter(|v| !v.is_null())
-                    .map(|p| {
-                        #crate_name::prelude::serde_json::from_value(p)
-                            .expect("Could not deserialize tracing context")
+                    .and_then(|p| {
+                        match #crate_name::prelude::serde_json::from_value(p) {
+                            Ok(context) => Some(context),
+                            Err(error) => {
+                                #crate_name::record_tracing_context_deserialize_failed(&error);
+                                None
+                            }
+                        }
                     });
             },
         );
@@ -396,7 +401,13 @@ FROM {}persistent_outbox_events_sequence_seq",
                                 sequence: #crate_name::EventSequence::from(sequence as u64),
                                 payload: row
                                     .payload
-                                    .map(|p| #crate_name::prelude::serde_json::from_value(p).expect("Could not deserialize payload")),
+                                    .and_then(|p| match #crate_name::prelude::serde_json::from_value(p) {
+                                        Ok(payload) => Some(payload),
+                                        Err(error) => {
+                                            #crate_name::record_persistent_payload_deserialize_failed(&error, sequence as u64);
+                                            None
+                                        }
+                                    }),
                                 recorded_at: row.recorded_at.unwrap_or_default(),
                                 #set_context
                             });
@@ -424,7 +435,13 @@ FROM {}persistent_outbox_events_sequence_seq",
                                     sequence: #crate_name::EventSequence::from(row.sequence as u64),
                                     payload: row
                                         .payload
-                                        .map(|p| #crate_name::prelude::serde_json::from_value(p).expect("Could not deserialize payload")),
+                                        .and_then(|p| match #crate_name::prelude::serde_json::from_value(p) {
+                                            Ok(payload) => Some(payload),
+                                            Err(error) => {
+                                                #crate_name::record_persistent_payload_deserialize_failed(&error, row.sequence as u64);
+                                                None
+                                            }
+                                        }),
                                     recorded_at: row.recorded_at,
                                     #set_context
                                 });
@@ -464,7 +481,13 @@ FROM {}persistent_outbox_events_sequence_seq",
                                     sequence: #crate_name::EventSequence::from(row.sequence as u64),
                                     payload: row
                                         .payload
-                                        .map(|p| #crate_name::prelude::serde_json::from_value(p).expect("Could not deserialize payload")),
+                                        .and_then(|p| match #crate_name::prelude::serde_json::from_value(p) {
+                                            Ok(payload) => Some(payload),
+                                            Err(error) => {
+                                                #crate_name::record_persistent_payload_deserialize_failed(&error, row.sequence as u64);
+                                                None
+                                            }
+                                        }),
                                     recorded_at: row.recorded_at,
                                     #set_context
                                 }
@@ -509,9 +532,14 @@ FROM {}persistent_outbox_events_sequence_seq",
 
                         let events = rows
                             .into_iter()
-                            .map(|(event_type_str, payload_json, tracing_context_json, recorded_at)| {
-                                let payload = #crate_name::prelude::serde_json::from_value(payload_json)
-                                    .expect("Couldn't deserialize payload");
+                            .filter_map(|(event_type_str, payload_json, tracing_context_json, recorded_at)| {
+                                let payload = match #crate_name::prelude::serde_json::from_value(payload_json) {
+                                    Ok(payload) => payload,
+                                    Err(error) => {
+                                        #crate_name::record_ephemeral_payload_deserialize_failed(&error, &event_type_str);
+                                        return None;
+                                    }
+                                };
                                 let event_type = #crate_name::prelude::serde_json::from_value(
                                     #crate_name::prelude::serde_json::Value::String(event_type_str)
                                 ).expect("Couldn't deserialize event_type");
@@ -526,12 +554,12 @@ FROM {}persistent_outbox_events_sequence_seq",
                                 };
                                 #deserialize_context
 
-                                #crate_name::out::EphemeralOutboxEvent {
+                                Some(#crate_name::out::EphemeralOutboxEvent {
                                     event_type,
                                     payload,
                                     #set_context
                                     recorded_at,
-                                }
+                                })
                             })
                             .collect::<Vec<_>>();
                         Ok(events)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,3 +31,8 @@ pub use out::{
 };
 pub use sequence::EventSequence;
 pub use tables::MailboxTables;
+#[doc(hidden)]
+pub use tables::{
+    record_ephemeral_payload_deserialize_failed, record_persistent_payload_deserialize_failed,
+    record_tracing_context_deserialize_failed,
+};

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -13,6 +13,43 @@ use crate::{
 #[cfg_attr(feature = "default-tables", obix(crate = "crate"))]
 pub struct DefaultMailboxTables;
 
+/// Invoked from `MailboxTables` derive output when a stored persistent event
+/// payload cannot be deserialized into the caller's event type (e.g. rows
+/// written into a shared database by a different event enum). The payload is
+/// treated as a placeholder (`None`) so the sequence still advances — a
+/// single unknown event must neither crash nor stall the whole event
+/// pipeline.
+#[doc(hidden)]
+#[tracing::instrument(
+    name = "obix.tables.persistent_payload_deserialize_failed",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", error = %error, sequence = sequence)
+)]
+pub fn record_persistent_payload_deserialize_failed(error: &serde_json::Error, sequence: u64) {}
+
+/// Same as [`record_persistent_payload_deserialize_failed`] but for the
+/// tracing context envelope; the event is kept with no context attached.
+#[doc(hidden)]
+#[tracing::instrument(
+    name = "obix.tables.tracing_context_deserialize_failed",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", error = %error)
+)]
+pub fn record_tracing_context_deserialize_failed(error: &serde_json::Error) {}
+
+/// Invoked from `MailboxTables` derive output when a stored ephemeral event
+/// payload cannot be deserialized; the event is dropped from the result.
+#[doc(hidden)]
+#[tracing::instrument(
+    name = "obix.tables.ephemeral_payload_deserialize_failed",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", error = %error, event_type = %event_type)
+)]
+pub fn record_ephemeral_payload_deserialize_failed(error: &serde_json::Error, event_type: &str) {}
+
 pub trait MailboxTables: Send + Sync + 'static {
     fn highest_known_persistent_sequence<'a>(
         op: impl es_entity::IntoOneTimeExecutor<'a>,

--- a/tests/outbox.rs
+++ b/tests/outbox.rs
@@ -779,3 +779,66 @@ async fn delivers_events_notified_while_listen_connection_down() -> anyhow::Resu
 
     Ok(())
 }
+
+// Rows written into a shared database by a different event enum (e.g.
+// test-only module tags) must neither crash the reader nor stall the
+// pipeline: the undeserializable payload is skipped with placeholder
+// semantics (`None`) and later events still flow.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, OutboxEvent)]
+#[serde(tag = "module")]
+enum ForeignEvent {
+    CoreParty {
+        id: u64,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[tokio::test]
+#[file_serial]
+async fn unknown_payload_is_skipped_and_pipeline_advances() -> anyhow::Result<()> {
+    use obix::{MailboxTables as _, out::Outbox};
+
+    let pool = init_pool().await?;
+    helpers::wipeout_outbox_tables(&pool).await?;
+
+    let config = MailboxConfig::builder()
+        .build()
+        .expect("Couldn't build MailboxConfig");
+
+    // Publish via a foreign event enum, like tests sharing the database do.
+    let foreign = Outbox::<ForeignEvent, helpers::TestTables>::init(&pool, config.clone()).await?;
+    let mut op = pool.begin().await?;
+    foreign
+        .publish_persisted_in_op(&mut op, ForeignEvent::CoreParty { id: 1 })
+        .await?;
+    op.commit().await?;
+
+    let outbox = Outbox::<TestEvent, helpers::TestTables>::init(&pool, config).await?;
+    let mut listener = outbox.listen_persisted(Some(obix::EventSequence::from(0)));
+
+    let mut op = pool.begin().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(0))
+        .await?;
+    op.commit().await?;
+
+    let events =
+        helpers::TestTables::load_next_page::<TestEvent>(&pool, obix::EventSequence::from(0), 10)
+            .await?;
+    assert_eq!(events.len(), 2);
+    assert!(events[0].payload.is_none());
+    assert!(matches!(events[1].payload, Some(TestEvent::Ping(0))));
+
+    let first = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("listener stream ended"))?;
+    assert!(first.payload.is_none());
+
+    let second = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("listener stream ended"))?;
+    assert!(matches!(second.payload, Some(TestEvent::Ping(0))));
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

One row in `persistent_outbox_events` whose payload doesn't match the consumer's event enum takes down the **entire** outbox pipeline. Observed in lana-bank (issue details there): integration tests running against a shared dev database wrote events tagged with test-only module variants (`CoreParty`, ...); the lana server's `LanaEvent` enum doesn't know them, so the `MailboxTables` derive's generated load paths hit:

```
Could not deserialize payload: Error("unknown variant `CoreParty`, ...")
  at obix-0.4.2/src/tables.rs:12
```

The `.expect()` panics inside the spawned backfill/gap-fill tasks → the backfill channel closes → `PersistentOutboxListener` immediately re-requests backfill → the task panics again → **hot panic/retry loop**: ~100% CPU and 31.7M panic lines / 26 GB of logs in 30 minutes. No other events flow meanwhile.

## Fix

Skip-and-log instead of panic in the derive's generated load paths:

- **Persistent payloads** (`load_next_page` main rows, gap-fill rows, `load_events_in_range`): an undeserializable payload becomes `payload: None` — the exact placeholder semantics consumers already use for sequence-gap rows (`as_event()` returns `None`, handlers skip). The sequence is cached and broadcast, so the cursor advances past the poison event.
- **Ephemeral payloads** (`load_ephemeral_events`): the event is dropped from the result.
- **Tracing context envelope**: degrades to no context instead of panicking.

Each case records an `obix.tables.*_deserialize_failed` **error** span (`otel.status_code = ERROR`, serde error, sequence / event type) so poison rows are observable in tracing/OTEL instead of silent.

Serialization-side `expect`s are unchanged (a write failure is the publisher's own bug).

## Regression test

`unknown_payload_is_skipped_and_pipeline_advances` publishes an event through a foreign event enum (mirroring the lana-bank test pollution) and asserts that for the real enum:

- `load_next_page` returns the poison row with `payload: None` and the valid row intact, and
- a `PersistentOutboxListener` yields the poison event (skipped downstream) and then keeps flowing.

Verified failing (panic) without the macro change and passing with it. Full suite: **56/56 pass**; `nix flake check` (fmt, clippy, deny) green.
