### PR TITLE
feat(outbox)!: deliver undecodable payloads as errors instead of panicking

### DIFF
--- a/obix-macros/src/tables.rs
+++ b/obix-macros/src/tables.rs
@@ -292,7 +292,6 @@ FROM {}persistent_outbox_events_sequence_seq",
                                 sequence: #crate_name::EventSequence::from(row.sequence as u64),
                                 recorded_at: row.recorded_at,
                                 payload: Some(payload),
-                                decode_failure: None,
                                 #set_context
                             })
                             .collect::<Vec<_>>();
@@ -370,7 +369,7 @@ FROM {}persistent_outbox_events_sequence_seq",
                     pool: &#crate_name::prelude::sqlx::PgPool,
                     from_sequence: #crate_name::EventSequence,
                     buffer_size: usize,
-                ) -> impl std::future::Future<Output = Result<Vec<#crate_name::out::PersistentOutboxEvent<P>>, sqlx::Error>> + Send
+                ) -> impl std::future::Future<Output = Result<Vec<Result<#crate_name::out::PersistentOutboxEvent<P>, #crate_name::out::UndecodableEventError>>, sqlx::Error>> + Send
                 where
                     P: #crate_name::prelude::serde::Serialize + #crate_name::prelude::serde::de::DeserializeOwned + Send
                 {
@@ -397,18 +396,13 @@ FROM {}persistent_outbox_events_sequence_seq",
                             };
                             present.insert(sequence);
                             #deserialize_context
-                            let (payload, decode_failure) = match row.payload {
-                                Some(payload) => #crate_name::decode_persistent_payload(payload, sequence as u64),
-                                None => (None, None),
-                            };
-                            events.push(#crate_name::out::PersistentOutboxEvent {
-                                id: #crate_name::out::OutboxEventId::from(row.id.expect("matched row has id")),
-                                sequence: #crate_name::EventSequence::from(sequence as u64),
-                                payload,
-                                decode_failure,
-                                recorded_at: row.recorded_at.unwrap_or_default(),
-                                #set_context
-                            });
+                            events.push(#crate_name::decode_persistent_event(
+                                #crate_name::out::OutboxEventId::from(row.id.expect("matched row has id")),
+                                sequence as u64,
+                                row.recorded_at.unwrap_or_default(),
+                                tracing_context,
+                                row.payload,
+                            ));
                         }
 
                         // Fill sequence gaps in the page with placeholder rows,
@@ -428,22 +422,20 @@ FROM {}persistent_outbox_events_sequence_seq",
 
                             for row in gap_rows {
                                 #deserialize_context
-                                let (payload, decode_failure) = match row.payload {
-                                    Some(payload) => #crate_name::decode_persistent_payload(payload, row.sequence as u64),
-                                    None => (None, None),
-                                };
-                                events.push(#crate_name::out::PersistentOutboxEvent {
-                                    id: #crate_name::out::OutboxEventId::from(row.id),
-                                    sequence: #crate_name::EventSequence::from(row.sequence as u64),
-                                    payload,
-                                    decode_failure,
-                                    recorded_at: row.recorded_at,
-                                    #set_context
-                                });
+                                events.push(#crate_name::decode_persistent_event(
+                                    #crate_name::out::OutboxEventId::from(row.id),
+                                    row.sequence as u64,
+                                    row.recorded_at,
+                                    tracing_context,
+                                    row.payload,
+                                ));
                             }
                             // Gap-fill rows were appended after the page rows, so
                             // re-establish the ascending order consumers rely on.
-                            events.sort_by(|a, b| a.sequence.cmp(&b.sequence));
+                            events.sort_by_key(|item| match item {
+                                Ok(event) => event.sequence,
+                                Err(error) => error.sequence,
+                            });
                         }
 
                         Ok(events)
@@ -454,7 +446,7 @@ FROM {}persistent_outbox_events_sequence_seq",
                     pool: &#crate_name::prelude::sqlx::PgPool,
                     after_sequence: #crate_name::EventSequence,
                     up_to_sequence: #crate_name::EventSequence,
-                ) -> impl std::future::Future<Output = Result<Vec<#crate_name::out::PersistentOutboxEvent<P>>, sqlx::Error>> + Send
+                ) -> impl std::future::Future<Output = Result<Vec<Result<#crate_name::out::PersistentOutboxEvent<P>, #crate_name::out::UndecodableEventError>>, sqlx::Error>> + Send
                 where
                     P: #crate_name::prelude::serde::Serialize + #crate_name::prelude::serde::de::DeserializeOwned + Send
                 {
@@ -471,18 +463,13 @@ FROM {}persistent_outbox_events_sequence_seq",
                             .into_iter()
                             .map(|row| {
                                 #deserialize_context
-                                let (payload, decode_failure) = match row.payload {
-                                    Some(payload) => #crate_name::decode_persistent_payload(payload, row.sequence as u64),
-                                    None => (None, None),
-                                };
-                                #crate_name::out::PersistentOutboxEvent {
-                                    id: #crate_name::out::OutboxEventId::from(row.id),
-                                    sequence: #crate_name::EventSequence::from(row.sequence as u64),
-                                    payload,
-                                    decode_failure,
-                                    recorded_at: row.recorded_at,
-                                    #set_context
-                                }
+                                #crate_name::decode_persistent_event(
+                                    #crate_name::out::OutboxEventId::from(row.id),
+                                    row.sequence as u64,
+                                    row.recorded_at,
+                                    tracing_context,
+                                    row.payload,
+                                )
                             })
                             .collect();
                         Ok(events)

--- a/obix-macros/src/tables.rs
+++ b/obix-macros/src/tables.rs
@@ -37,9 +37,14 @@ impl ToTokens for MailboxTables {
             quote! {
                 let tracing_context = row.tracing_context
                     .filter(|v| !v.is_null())
-                    .map(|p| {
-                        #crate_name::prelude::serde_json::from_value(p)
-                            .expect("Could not deserialize tracing context")
+                    .and_then(|p| {
+                        match #crate_name::prelude::serde_json::from_value(p) {
+                            Ok(context) => Some(context),
+                            Err(error) => {
+                                #crate_name::record_tracing_context_undecodable(&error);
+                                None
+                            }
+                        }
                     });
             },
         );
@@ -287,6 +292,7 @@ FROM {}persistent_outbox_events_sequence_seq",
                                 sequence: #crate_name::EventSequence::from(row.sequence as u64),
                                 recorded_at: row.recorded_at,
                                 payload: Some(payload),
+                                decode_failure: None,
                                 #set_context
                             })
                             .collect::<Vec<_>>();
@@ -391,12 +397,15 @@ FROM {}persistent_outbox_events_sequence_seq",
                             };
                             present.insert(sequence);
                             #deserialize_context
+                            let (payload, decode_failure) = match row.payload {
+                                Some(payload) => #crate_name::decode_persistent_payload(payload, sequence as u64),
+                                None => (None, None),
+                            };
                             events.push(#crate_name::out::PersistentOutboxEvent {
                                 id: #crate_name::out::OutboxEventId::from(row.id.expect("matched row has id")),
                                 sequence: #crate_name::EventSequence::from(sequence as u64),
-                                payload: row
-                                    .payload
-                                    .map(|p| #crate_name::prelude::serde_json::from_value(p).expect("Could not deserialize payload")),
+                                payload,
+                                decode_failure,
                                 recorded_at: row.recorded_at.unwrap_or_default(),
                                 #set_context
                             });
@@ -419,12 +428,15 @@ FROM {}persistent_outbox_events_sequence_seq",
 
                             for row in gap_rows {
                                 #deserialize_context
+                                let (payload, decode_failure) = match row.payload {
+                                    Some(payload) => #crate_name::decode_persistent_payload(payload, row.sequence as u64),
+                                    None => (None, None),
+                                };
                                 events.push(#crate_name::out::PersistentOutboxEvent {
                                     id: #crate_name::out::OutboxEventId::from(row.id),
                                     sequence: #crate_name::EventSequence::from(row.sequence as u64),
-                                    payload: row
-                                        .payload
-                                        .map(|p| #crate_name::prelude::serde_json::from_value(p).expect("Could not deserialize payload")),
+                                    payload,
+                                    decode_failure,
                                     recorded_at: row.recorded_at,
                                     #set_context
                                 });
@@ -459,12 +471,15 @@ FROM {}persistent_outbox_events_sequence_seq",
                             .into_iter()
                             .map(|row| {
                                 #deserialize_context
+                                let (payload, decode_failure) = match row.payload {
+                                    Some(payload) => #crate_name::decode_persistent_payload(payload, row.sequence as u64),
+                                    None => (None, None),
+                                };
                                 #crate_name::out::PersistentOutboxEvent {
                                     id: #crate_name::out::OutboxEventId::from(row.id),
                                     sequence: #crate_name::EventSequence::from(row.sequence as u64),
-                                    payload: row
-                                        .payload
-                                        .map(|p| #crate_name::prelude::serde_json::from_value(p).expect("Could not deserialize payload")),
+                                    payload,
+                                    decode_failure,
                                     recorded_at: row.recorded_at,
                                     #set_context
                                 }
@@ -509,9 +524,14 @@ FROM {}persistent_outbox_events_sequence_seq",
 
                         let events = rows
                             .into_iter()
-                            .map(|(event_type_str, payload_json, tracing_context_json, recorded_at)| {
-                                let payload = #crate_name::prelude::serde_json::from_value(payload_json)
-                                    .expect("Couldn't deserialize payload");
+                            .filter_map(|(event_type_str, payload_json, tracing_context_json, recorded_at)| {
+                                let payload = match #crate_name::prelude::serde_json::from_value(payload_json) {
+                                    Ok(payload) => payload,
+                                    Err(error) => {
+                                        #crate_name::record_ephemeral_payload_undecodable(&error, &event_type_str);
+                                        return None;
+                                    }
+                                };
                                 let event_type = #crate_name::prelude::serde_json::from_value(
                                     #crate_name::prelude::serde_json::Value::String(event_type_str)
                                 ).expect("Couldn't deserialize event_type");
@@ -526,12 +546,12 @@ FROM {}persistent_outbox_events_sequence_seq",
                                 };
                                 #deserialize_context
 
-                                #crate_name::out::EphemeralOutboxEvent {
+                                Some(#crate_name::out::EphemeralOutboxEvent {
                                     event_type,
                                     payload,
                                     #set_context
                                     recorded_at,
-                                }
+                                })
                             })
                             .collect::<Vec<_>>();
                         Ok(events)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,14 @@ pub use inbox::{
 };
 pub use obix_macros::{MailboxTables, OutboxEvent};
 pub use out::{
-    BatchOp, CursorError, EventCtx, EventSubscription, FlushError, FlushOp, Handled, IsolatedOp,
-    OpCursor, Outbox, OutboxEventHandler, OutboxEventJobConfig, PostPersistHook,
+    BatchOp, CursorError, DecodeFailure, EventCtx, EventSubscription, FlushError, FlushOp, Handled,
+    IsolatedOp, OpCursor, Outbox, OutboxEventHandler, OutboxEventJobConfig, PostPersistHook,
+    UndecodableAction, UndecodableEventError,
 };
 pub use sequence::EventSequence;
 pub use tables::MailboxTables;
+#[doc(hidden)]
+pub use tables::{
+    decode_persistent_payload, record_ephemeral_payload_undecodable,
+    record_tracing_context_undecodable,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use obix_macros::{MailboxTables, OutboxEvent};
 pub use out::{
     BatchOp, CursorError, DecodeFailure, EventCtx, EventSubscription, FlushError, FlushOp, Handled,
     IsolatedOp, OpCursor, Outbox, OutboxEventHandler, OutboxEventJobConfig, PostPersistHook,
-    UndecodableAction, UndecodableEventError,
+    UndecodableEventError,
 };
 pub use sequence::EventSequence;
 pub use tables::MailboxTables;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,6 @@ pub use sequence::EventSequence;
 pub use tables::MailboxTables;
 #[doc(hidden)]
 pub use tables::{
-    decode_persistent_payload, record_ephemeral_payload_undecodable,
+    decode_persistent_event, record_ephemeral_payload_undecodable,
     record_tracing_context_undecodable,
 };

--- a/src/out/all_listener.rs
+++ b/src/out/all_listener.rs
@@ -4,7 +4,7 @@ use std::{pin::Pin, task::Poll};
 
 use super::{
     ephemeral::{CacheHandle as EphemeralCacheHandle, EphemeralOutboxListener},
-    event::OutboxEvent,
+    event::{OutboxEvent, UndecodableEventError},
     persistent::{CacheHandle as PersistentCacheHandle, PersistentOutboxListener},
 };
 use crate::sequence::EventSequence;
@@ -46,7 +46,9 @@ impl<P> Stream for AllOutboxListener<P>
 where
     P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
 {
-    type Item = OutboxEvent<P>;
+    /// Undecodable persistent events surface as the `Err` arm (see
+    /// [`PersistentOutboxListener`]); ephemeral events are always `Ok`.
+    type Item = Result<OutboxEvent<P>, UndecodableEventError>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -57,11 +59,11 @@ where
         let result = if this.poll_count.is_multiple_of(2) {
             Pin::new(&mut this.persistent_listener)
                 .poll_next(cx)
-                .map(|opt| opt.map(OutboxEvent::Persistent))
+                .map(|opt| opt.map(|item| item.map(OutboxEvent::Persistent)))
         } else {
             Pin::new(&mut this.ephemeral_listener)
                 .poll_next(cx)
-                .map(|opt| opt.map(OutboxEvent::Ephemeral))
+                .map(|opt| opt.map(|event| Ok(OutboxEvent::Ephemeral(event))))
         };
 
         this.poll_count = this.poll_count.wrapping_add(1);

--- a/src/out/ctx.rs
+++ b/src/out/ctx.rs
@@ -487,7 +487,8 @@ impl es_entity::AtomicOperation for FlushOp<'_> {
 #[derive(Debug)]
 pub struct FlushError {
     /// Which trigger landed the batch (`"backlog_drained"`, `"batch_full"`,
-    /// `"commit"`, `"isolated_entry"`, `"shutdown"`, `"stream_closed"`).
+    /// `"commit"`, `"isolated_entry"`, `"shutdown"`, `"stream_closed"`,
+    /// `"undecodable_event"`).
     pub reason: &'static str,
     /// The batch covers sequences strictly after this (the last durable
     /// checkpoint)…

--- a/src/out/event.rs
+++ b/src/out/event.rs
@@ -161,32 +161,55 @@ pub struct UndecodableEventError {
 /// broadcast, backfill): an undecodable event rides it as the `Err` arm so
 /// it still occupies its sequence position — the contiguity machinery treats
 /// both arms alike. `Arc` on both arms keeps broadcast fan-out cheap; the
-/// listeners unwrap to the public owned [`UndecodableEventError`] at their
-/// yield boundary.
-pub(crate) type PersistentDelivery<P> =
-    Result<Arc<PersistentOutboxEvent<P>>, Arc<UndecodableEventError>>;
+/// listeners unwrap to the public owned [`UndecodableEventError`] via
+/// [`into_item`](Self::into_item) at their yield boundary.
+pub(crate) struct PersistentDelivery<P>(
+    Result<Arc<PersistentOutboxEvent<P>>, Arc<UndecodableEventError>>,
+)
+where
+    P: Serialize + DeserializeOwned + Send;
 
-/// The sequence a delivery occupies, whichever arm it is.
-pub(crate) fn delivery_sequence<P>(delivery: &PersistentDelivery<P>) -> EventSequence
+impl<P> PersistentDelivery<P>
 where
     P: Serialize + DeserializeOwned + Send,
 {
-    match delivery {
-        Ok(event) => event.sequence,
-        Err(error) => error.sequence,
+    /// The sequence this delivery occupies, whichever arm it is.
+    pub(crate) fn sequence(&self) -> EventSequence {
+        match &self.0 {
+            Ok(event) => event.sequence,
+            Err(error) => error.sequence,
+        }
+    }
+
+    /// Unwrap into the public listener stream item, cloning the `Err` arm
+    /// out of its transport `Arc`.
+    pub(crate) fn into_item(self) -> Result<Arc<PersistentOutboxEvent<P>>, UndecodableEventError> {
+        match self.0 {
+            Ok(event) => Ok(event),
+            Err(error) => Err((*error).clone()),
+        }
     }
 }
 
 /// Wrap a freshly loaded item into the internal delivery transport.
-pub(crate) fn into_delivery<P>(
-    item: Result<PersistentOutboxEvent<P>, UndecodableEventError>,
-) -> PersistentDelivery<P>
+impl<P> From<Result<PersistentOutboxEvent<P>, UndecodableEventError>> for PersistentDelivery<P>
 where
     P: Serialize + DeserializeOwned + Send,
 {
-    match item {
-        Ok(event) => Ok(Arc::new(event)),
-        Err(error) => Err(Arc::new(error)),
+    fn from(item: Result<PersistentOutboxEvent<P>, UndecodableEventError>) -> Self {
+        Self(match item {
+            Ok(event) => Ok(Arc::new(event)),
+            Err(error) => Err(Arc::new(error)),
+        })
+    }
+}
+
+impl<P> Clone for PersistentDelivery<P>
+where
+    P: Serialize + DeserializeOwned + Send,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
     }
 }
 

--- a/src/out/event.rs
+++ b/src/out/event.rs
@@ -113,6 +113,24 @@ where
     }
 }
 
+/// A stored payload that could not be decoded into the consumer's event type
+/// (e.g. a variant the consumer's enum does not know yet, or a row written by
+/// a different event enum sharing the table).
+///
+/// Carried on [`PersistentOutboxEvent::decode_failure`]: the event is still
+/// delivered — in order, with its sequence — so no consumer ever silently
+/// misses an event. What happens next is consumer policy; see
+/// [`OutboxEventHandler::on_undecodable`](crate::OutboxEventHandler::on_undecodable)
+/// (default: fail the handler job, parking its checkpoint *before* this
+/// event).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DecodeFailure {
+    /// The payload column exactly as stored.
+    pub raw: serde_json::Value,
+    /// The serde error message.
+    pub error: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PersistentOutboxEvent<T>
 where
@@ -122,6 +140,12 @@ where
     pub sequence: EventSequence,
     #[serde(bound = "T: DeserializeOwned")]
     pub payload: Option<T>,
+    /// `Some` iff the stored payload failed to decode into `T` — then
+    /// [`payload`](Self::payload) is `None` *and* this carries the raw JSON
+    /// plus the serde error. A plain sequence placeholder (nothing was ever
+    /// committed at this sequence) has both fields `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decode_failure: Option<DecodeFailure>,
     pub tracing_context: Option<es_entity::context::TracingContext>,
     pub recorded_at: chrono::DateTime<chrono::Utc>,
 }
@@ -135,6 +159,7 @@ where
             id: self.id,
             sequence: self.sequence,
             payload: self.payload.clone(),
+            decode_failure: self.decode_failure.clone(),
             tracing_context: self.tracing_context.clone(),
             recorded_at: self.recorded_at,
         }

--- a/src/out/event.rs
+++ b/src/out/event.rs
@@ -117,14 +117,10 @@ where
 /// (e.g. a variant the consumer's enum does not know yet, or a row written by
 /// a different event enum sharing the table).
 ///
-/// Carried on [`PersistentOutboxEvent::decode_failure`] through the internal
-/// delivery plumbing (the poison event must ride the cache/broadcast
-/// machinery as an ordinary sequenced event, or contiguity would break). At
-/// the consumption boundaries it surfaces as [`UndecodableEventError`]: the
-/// listener streams yield it as their `Err` arm, and the handler-job runner
-/// hands it to
-/// [`OutboxEventHandler::handle_undecodable`](crate::OutboxEventHandler::handle_undecodable)
-/// (default: fail the job, parking its checkpoint *before* the event).
+/// Carried inside [`UndecodableEventError`], which is how such an event
+/// travels everywhere: the `Err` arm of the
+/// [`MailboxTables`](crate::MailboxTables) load results, of the internal
+/// delivery plumbing, and of the listener streams.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DecodeFailure {
     /// The payload column exactly as stored.
@@ -134,17 +130,19 @@ pub struct DecodeFailure {
 }
 
 /// A persistent event whose stored payload could not be decoded into the
-/// consumer's event type, delivered as the `Err` arm of
+/// consumer's event type. Everything undecodable-shaped is this one type,
+/// always in an `Err` arm: the
+/// [`MailboxTables`](crate::MailboxTables) load results, the
 /// [`PersistentOutboxListener`](crate::out::PersistentOutboxListener) /
-/// [`AllOutboxListener`](crate::out::AllOutboxListener).
+/// [`AllOutboxListener`](crate::out::AllOutboxListener) stream items, and
+/// the error the default
+/// [`OutboxEventHandler::handle_undecodable`](crate::OutboxEventHandler::handle_undecodable)
+/// fails the handler job with.
 ///
 /// The `Err` item IS the delivery of that event — in order, in its sequence
 /// position — so no consumer can pass over an undecodable payload without an
 /// explicit decision: `?` (e.g. via `TryStreamExt::try_next`) fails loudly,
-/// and matching the `Err` arm is the visible opt-out. It is also what the
-/// default
-/// [`OutboxEventHandler::handle_undecodable`](crate::OutboxEventHandler::handle_undecodable)
-/// fails the handler job with.
+/// and matching the `Err` arm is the visible opt-out.
 ///
 /// [`Display`](std::fmt::Display) prints the serde error only — the raw
 /// payload is available on [`failure`](Self::failure) but never hits log
@@ -159,19 +157,36 @@ pub struct UndecodableEventError {
     pub failure: DecodeFailure,
 }
 
-impl UndecodableEventError {
-    /// The `Err`-arm view of an event carrying a decode failure; `None` for
-    /// decoded events and plain placeholders.
-    pub(crate) fn try_from_event<T>(event: &PersistentOutboxEvent<T>) -> Option<Self>
-    where
-        T: Serialize + DeserializeOwned + Send,
-    {
-        event.decode_failure.as_ref().map(|failure| Self {
-            id: event.id,
-            sequence: event.sequence,
-            recorded_at: event.recorded_at,
-            failure: failure.clone(),
-        })
+/// Internal transport for the persistent delivery plumbing (cache,
+/// broadcast, backfill): an undecodable event rides it as the `Err` arm so
+/// it still occupies its sequence position — the contiguity machinery treats
+/// both arms alike. `Arc` on both arms keeps broadcast fan-out cheap; the
+/// listeners unwrap to the public owned [`UndecodableEventError`] at their
+/// yield boundary.
+pub(crate) type PersistentDelivery<P> =
+    Result<Arc<PersistentOutboxEvent<P>>, Arc<UndecodableEventError>>;
+
+/// The sequence a delivery occupies, whichever arm it is.
+pub(crate) fn delivery_sequence<P>(delivery: &PersistentDelivery<P>) -> EventSequence
+where
+    P: Serialize + DeserializeOwned + Send,
+{
+    match delivery {
+        Ok(event) => event.sequence,
+        Err(error) => error.sequence,
+    }
+}
+
+/// Wrap a freshly loaded item into the internal delivery transport.
+pub(crate) fn into_delivery<P>(
+    item: Result<PersistentOutboxEvent<P>, UndecodableEventError>,
+) -> PersistentDelivery<P>
+where
+    P: Serialize + DeserializeOwned + Send,
+{
+    match item {
+        Ok(event) => Ok(Arc::new(event)),
+        Err(error) => Err(Arc::new(error)),
     }
 }
 
@@ -182,17 +197,13 @@ where
 {
     pub id: OutboxEventId,
     pub sequence: EventSequence,
+    /// `None` is a sequence placeholder: nothing to process at this
+    /// sequence (a gap from a rolled-back transaction, or a payload
+    /// explicitly NULLed by an operator). An *undecodable* payload never
+    /// appears here — it travels as [`UndecodableEventError`], the `Err`
+    /// arm of the load results and listener streams.
     #[serde(bound = "T: DeserializeOwned")]
     pub payload: Option<T>,
-    /// `Some` iff the stored payload failed to decode into `T` — then
-    /// [`payload`](Self::payload) is `None` *and* this carries the raw JSON
-    /// plus the serde error. A plain sequence placeholder (nothing was ever
-    /// committed at this sequence) has both fields `None`. The listener
-    /// streams never yield an event with this set as an `Ok` item — it is
-    /// translated into their `Err` arm ([`UndecodableEventError`]) at the
-    /// consumption boundary.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub decode_failure: Option<DecodeFailure>,
     pub tracing_context: Option<es_entity::context::TracingContext>,
     pub recorded_at: chrono::DateTime<chrono::Utc>,
 }
@@ -206,7 +217,6 @@ where
             id: self.id,
             sequence: self.sequence,
             payload: self.payload.clone(),
-            decode_failure: self.decode_failure.clone(),
             tracing_context: self.tracing_context.clone(),
             recorded_at: self.recorded_at,
         }

--- a/src/out/event.rs
+++ b/src/out/event.rs
@@ -117,18 +117,62 @@ where
 /// (e.g. a variant the consumer's enum does not know yet, or a row written by
 /// a different event enum sharing the table).
 ///
-/// Carried on [`PersistentOutboxEvent::decode_failure`]: the event is still
-/// delivered — in order, with its sequence — so no consumer ever silently
-/// misses an event. What happens next is consumer policy; see
+/// Carried on [`PersistentOutboxEvent::decode_failure`] through the internal
+/// delivery plumbing (the poison event must ride the cache/broadcast
+/// machinery as an ordinary sequenced event, or contiguity would break). At
+/// the consumption boundaries it surfaces as [`UndecodableEventError`]: the
+/// listener streams yield it as their `Err` arm, and the handler-job runner
+/// hands it to
 /// [`OutboxEventHandler::handle_undecodable`](crate::OutboxEventHandler::handle_undecodable)
-/// (default: fail the handler job, parking its checkpoint *before* this
-/// event).
+/// (default: fail the job, parking its checkpoint *before* the event).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DecodeFailure {
     /// The payload column exactly as stored.
     pub raw: serde_json::Value,
     /// The serde error message.
     pub error: String,
+}
+
+/// A persistent event whose stored payload could not be decoded into the
+/// consumer's event type, delivered as the `Err` arm of
+/// [`PersistentOutboxListener`](crate::out::PersistentOutboxListener) /
+/// [`AllOutboxListener`](crate::out::AllOutboxListener).
+///
+/// The `Err` item IS the delivery of that event — in order, in its sequence
+/// position — so no consumer can pass over an undecodable payload without an
+/// explicit decision: `?` (e.g. via `TryStreamExt::try_next`) fails loudly,
+/// and matching the `Err` arm is the visible opt-out. It is also what the
+/// default
+/// [`OutboxEventHandler::handle_undecodable`](crate::OutboxEventHandler::handle_undecodable)
+/// fails the handler job with.
+///
+/// [`Display`](std::fmt::Display) prints the serde error only — the raw
+/// payload is available on [`failure`](Self::failure) but never hits log
+/// lines by accident.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("undecodable persistent outbox event {id} at sequence {sequence}: {}", failure.error)]
+pub struct UndecodableEventError {
+    pub id: OutboxEventId,
+    pub sequence: EventSequence,
+    pub recorded_at: chrono::DateTime<chrono::Utc>,
+    /// The raw payload and the serde error.
+    pub failure: DecodeFailure,
+}
+
+impl UndecodableEventError {
+    /// The `Err`-arm view of an event carrying a decode failure; `None` for
+    /// decoded events and plain placeholders.
+    pub(crate) fn try_from_event<T>(event: &PersistentOutboxEvent<T>) -> Option<Self>
+    where
+        T: Serialize + DeserializeOwned + Send,
+    {
+        event.decode_failure.as_ref().map(|failure| Self {
+            id: event.id,
+            sequence: event.sequence,
+            recorded_at: event.recorded_at,
+            failure: failure.clone(),
+        })
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -143,7 +187,10 @@ where
     /// `Some` iff the stored payload failed to decode into `T` — then
     /// [`payload`](Self::payload) is `None` *and* this carries the raw JSON
     /// plus the serde error. A plain sequence placeholder (nothing was ever
-    /// committed at this sequence) has both fields `None`.
+    /// committed at this sequence) has both fields `None`. The listener
+    /// streams never yield an event with this set as an `Ok` item — it is
+    /// translated into their `Err` arm ([`UndecodableEventError`]) at the
+    /// consumption boundary.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub decode_failure: Option<DecodeFailure>,
     pub tracing_context: Option<es_entity::context::TracingContext>,

--- a/src/out/event.rs
+++ b/src/out/event.rs
@@ -120,7 +120,7 @@ where
 /// Carried on [`PersistentOutboxEvent::decode_failure`]: the event is still
 /// delivered — in order, with its sequence — so no consumer ever silently
 /// misses an event. What happens next is consumer policy; see
-/// [`OutboxEventHandler::on_undecodable`](crate::OutboxEventHandler::on_undecodable)
+/// [`OutboxEventHandler::handle_undecodable`](crate::OutboxEventHandler::handle_undecodable)
 /// (default: fail the handler job, parking its checkpoint *before* this
 /// event).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -9,7 +9,7 @@ use job::{
 
 use super::ctx::*;
 use super::{EphemeralOutboxListener, Outbox, event::*};
-use crate::{sequence::EventSequence, tables::MailboxTables};
+use crate::tables::MailboxTables;
 
 /// Which delivery streams an event-handler job subscribes to — see
 /// [`OutboxEventHandler::SUBSCRIPTION`].
@@ -26,23 +26,6 @@ pub enum EventSubscription {
     All,
     PersistentOnly,
     EphemeralOnly,
-}
-
-/// The error the default
-/// [`handle_undecodable`](OutboxEventHandler::handle_undecodable) fails
-/// with: a persistent event's stored payload could not be decoded into the
-/// handler's event type. Propagates as the handler job's error; the job's
-/// checkpoint is parked at the sequence *before* the event, so every retry
-/// re-reads it and nothing is ever skipped.
-#[derive(Debug, thiserror::Error)]
-#[error(
-    "undecodable persistent outbox event {id} at sequence {sequence} (checkpoint parked before it): {error}"
-)]
-pub struct UndecodableEventError {
-    pub id: OutboxEventId,
-    pub sequence: EventSequence,
-    /// The serde error message.
-    pub error: String,
 }
 
 /// Handles the events of one outbox listener job.
@@ -114,42 +97,34 @@ where
     }
 
     /// Handle a persistent event whose stored payload could not be decoded
-    /// into `P` (the event arrives with
-    /// [`decode_failure`](PersistentOutboxEvent::decode_failure) set and no
-    /// payload). The runner invokes this *instead of*
-    /// [`handle_persistent`](Self::handle_persistent) — an undecodable event
-    /// never reaches the normal handling path.
+    /// into `P` — delivered as the persistent stream's `Err` arm and never
+    /// as an ordinary event, so it cannot reach
+    /// [`handle_persistent`](Self::handle_persistent). The
+    /// [`UndecodableEventError`] carries the event's identity and the raw
+    /// payload + serde error (`error.failure`).
     ///
-    /// The default fails with [`UndecodableEventError`]: a payload the
-    /// consumer cannot decode is a runtime bug (schema drift, a producer
-    /// ahead of this consumer, foreign rows in the table) that must surface
-    /// loudly, not silently pass by. On any `Err` the runner lands the
-    /// pending batch, parks the checkpoint at the sequence *before* the
-    /// event and fails the job — every retry re-reads the event from the
-    /// database, so deploying a consumer that understands the payload
-    /// resumes the pipeline automatically, in order, with nothing skipped.
+    /// The default fails with the error as-is: a payload the consumer
+    /// cannot decode is a runtime bug (schema drift, a producer ahead of
+    /// this consumer, foreign rows in the table) that must surface loudly,
+    /// not silently pass by. On any `Err` the runner lands the pending
+    /// batch, parks the checkpoint at the sequence *before* the event and
+    /// fails the job — every retry re-reads the event from the database, so
+    /// deploying a consumer that understands the payload resumes the
+    /// pipeline automatically, in order, with nothing skipped.
     ///
     /// Override and return `Ok(())` only when this handler genuinely wants
     /// to move past payloads it cannot decode — an explicit, auditable
-    /// decision (consider recording `event.decode_failure` somewhere
-    /// durable first). The checkpoint then advances over the event exactly
-    /// as for a [`skip`](EventCtx::skip). No transaction is opened on this
-    /// path; like [`handle_ephemeral`](Self::handle_ephemeral), any work
-    /// done here must tolerate replay.
+    /// decision (consider recording `error.failure` somewhere durable
+    /// first). The checkpoint then advances over the event exactly as for a
+    /// [`skip`](EventCtx::skip). No transaction is opened on this path;
+    /// like [`handle_ephemeral`](Self::handle_ephemeral), any work done
+    /// here must tolerate replay.
     fn handle_undecodable(
         &self,
-        event: &PersistentOutboxEvent<P>,
+        error: &UndecodableEventError,
     ) -> impl std::future::Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send
     {
-        let error = UndecodableEventError {
-            id: event.id,
-            sequence: event.sequence,
-            error: event
-                .decode_failure
-                .as_ref()
-                .map(|failure| failure.error.clone())
-                .unwrap_or_default(),
-        };
+        let error = error.clone();
         async move { Err(error.into()) }
     }
 
@@ -214,7 +189,7 @@ enum NextDelivery<P>
 where
     P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
-    Persistent(Option<Arc<PersistentOutboxEvent<P>>>),
+    Persistent(Option<Result<Arc<PersistentOutboxEvent<P>>, UndecodableEventError>>),
     Ephemeral(Arc<EphemeralOutboxEvent<P>>),
 }
 
@@ -442,13 +417,13 @@ where
         };
 
         loop {
-            let event = if op_slot.is_some() || tracker.collected > 0 {
+            let item = if op_slot.is_some() || tracker.collected > 0 {
                 // A batch is pending (an open op, collected items, or both):
                 // only take persistent events that are already buffered —
                 // the batch is never held open waiting on the network. A
                 // pending stream is itself the flush trigger.
                 match persistent.next().now_or_never() {
-                    Some(Some(event)) => event,
+                    Some(Some(item)) => item,
                     Some(None) => {
                         let mut parts = CtxParts {
                             op_slot: &mut op_slot,
@@ -521,7 +496,7 @@ where
                             .map_err(|e| e as Box<dyn std::error::Error>)?;
                         continue;
                     }
-                    NextDelivery::Persistent(Some(event)) => event,
+                    NextDelivery::Persistent(Some(item)) => item,
                     NextDelivery::Persistent(None) => {
                         if tracker.persisted_seq < state.sequence {
                             persist_checkpoint(&mut current_job, &state)
@@ -533,17 +508,18 @@ where
                 }
             };
 
-            // An undecodable payload never reaches the normal handling path:
-            // the handler's handle_undecodable decides its fate. `Ok`
-            // acknowledges the event (the checkpoint advances over it like a
-            // skip); any `Err` — the default — fails the job with the
-            // pending batch landed and the checkpoint parked at the sequence
-            // *before* the event, so every retry re-reads it and nothing is
-            // ever skipped.
-            if event.decode_failure.is_some() {
-                match self.handler.handle_undecodable(&event).await {
+            // An undecodable payload arrives as the stream's `Err` arm and
+            // never reaches handle_persistent: handle_undecodable decides its
+            // fate. `Ok` acknowledges the event (the checkpoint advances over
+            // it like a skip); any `Err` — the default — fails the job with
+            // the pending batch landed and the checkpoint parked at the
+            // sequence *before* the event, so every retry re-reads it and
+            // nothing is ever skipped.
+            let event = match item {
+                Ok(event) => event,
+                Err(undecodable) => match self.handler.handle_undecodable(&undecodable).await {
                     Ok(()) => {
-                        state.sequence = event.sequence;
+                        state.sequence = undecodable.sequence;
                         continue;
                     }
                     Err(error) => {
@@ -563,8 +539,8 @@ where
                         }
                         return Err(error as Box<dyn std::error::Error>);
                     }
-                }
-            }
+                },
+            };
 
             let ctx = EventCtx {
                 parts: CtxParts {

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -28,31 +28,12 @@ pub enum EventSubscription {
     EphemeralOnly,
 }
 
-/// Fate of a persistent event whose stored payload could not be decoded into
-/// the handler's event type, decided by
-/// [`OutboxEventHandler::on_undecodable`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum UndecodableAction {
-    /// The default: treat the undecodable payload as a runtime bug. The
-    /// runner lands the pending batch, persists the checkpoint at the
-    /// sequence *before* this event, and fails the job — the job retry
-    /// machinery (with its configured backoff) re-reads the event from the
-    /// database on every attempt, so the pipeline resumes on its own once a
-    /// consumer that understands the payload is deployed. Nothing is ever
-    /// skipped.
-    Fail,
-    /// Explicitly acknowledge the event and move past it. The checkpoint
-    /// advances over the event exactly as for a
-    /// [`skip`](super::EventCtx::skip) — an unambiguous, per-handler opt-in
-    /// to drop payloads this handler cannot decode.
-    Ack,
-}
-
-/// A persistent event's stored payload could not be decoded into the
-/// handler's event type and the handler's
-/// [`on_undecodable`](OutboxEventHandler::on_undecodable) policy chose
-/// [`Fail`](UndecodableAction::Fail). Propagates as the handler job's error;
-/// the job's checkpoint is parked at the sequence before the event.
+/// The error the default
+/// [`handle_undecodable`](OutboxEventHandler::handle_undecodable) fails
+/// with: a persistent event's stored payload could not be decoded into the
+/// handler's event type. Propagates as the handler job's error; the job's
+/// checkpoint is parked at the sequence *before* the event, so every retry
+/// re-reads it and nothing is ever skipped.
 #[derive(Debug, thiserror::Error)]
 #[error(
     "undecodable persistent outbox event {id} at sequence {sequence} (checkpoint parked before it): {error}"
@@ -132,32 +113,44 @@ where
         async move { Ok(ctx.skip()) }
     }
 
-    /// Policy for a persistent event whose stored payload could not be
-    /// decoded into `P` (the event arrives with
+    /// Handle a persistent event whose stored payload could not be decoded
+    /// into `P` (the event arrives with
     /// [`decode_failure`](PersistentOutboxEvent::decode_failure) set and no
-    /// payload). The runner consults this *instead of*
+    /// payload). The runner invokes this *instead of*
     /// [`handle_persistent`](Self::handle_persistent) — an undecodable event
     /// never reaches the normal handling path.
     ///
-    /// Defaults to [`Fail`](UndecodableAction::Fail): the job lands its
-    /// pending batch, parks its checkpoint before the event and errors — a
-    /// payload the consumer cannot decode is a runtime bug (schema drift, a
-    /// producer ahead of this consumer, foreign rows in the table) that must
-    /// surface loudly, not silently pass by. Because the event is re-read
-    /// from the database on every job retry, deploying a consumer that
-    /// understands the payload resumes the pipeline automatically, in order,
-    /// with nothing skipped.
+    /// The default fails with [`UndecodableEventError`]: a payload the
+    /// consumer cannot decode is a runtime bug (schema drift, a producer
+    /// ahead of this consumer, foreign rows in the table) that must surface
+    /// loudly, not silently pass by. On any `Err` the runner lands the
+    /// pending batch, parks the checkpoint at the sequence *before* the
+    /// event and fails the job — every retry re-reads the event from the
+    /// database, so deploying a consumer that understands the payload
+    /// resumes the pipeline automatically, in order, with nothing skipped.
     ///
-    /// Override to return [`Ack`](UndecodableAction::Ack) only when this
-    /// handler genuinely wants to drop payloads it cannot decode — an
-    /// explicit, auditable decision (consider recording
-    /// `event.decode_failure` somewhere first).
-    fn on_undecodable(
+    /// Override and return `Ok(())` only when this handler genuinely wants
+    /// to move past payloads it cannot decode — an explicit, auditable
+    /// decision (consider recording `event.decode_failure` somewhere
+    /// durable first). The checkpoint then advances over the event exactly
+    /// as for a [`skip`](EventCtx::skip). No transaction is opened on this
+    /// path; like [`handle_ephemeral`](Self::handle_ephemeral), any work
+    /// done here must tolerate replay.
+    fn handle_undecodable(
         &self,
         event: &PersistentOutboxEvent<P>,
-    ) -> impl std::future::Future<Output = UndecodableAction> + Send {
-        let _ = event;
-        async { UndecodableAction::Fail }
+    ) -> impl std::future::Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send
+    {
+        let error = UndecodableEventError {
+            id: event.id,
+            sequence: event.sequence,
+            error: event
+                .decode_failure
+                .as_ref()
+                .map(|failure| failure.error.clone())
+                .unwrap_or_default(),
+        };
+        async move { Err(error.into()) }
     }
 
     /// Apply everything collected since the last flush. Called at most once
@@ -541,17 +534,19 @@ where
             };
 
             // An undecodable payload never reaches the normal handling path:
-            // the handler's on_undecodable policy decides between failing the
-            // job — pending batch landed, checkpoint parked at the sequence
+            // the handler's handle_undecodable decides its fate. `Ok`
+            // acknowledges the event (the checkpoint advances over it like a
+            // skip); any `Err` — the default — fails the job with the
+            // pending batch landed and the checkpoint parked at the sequence
             // *before* the event, so every retry re-reads it and nothing is
-            // ever skipped (the default) — and explicitly acknowledging it.
-            if let Some(failure) = &event.decode_failure {
-                match self.handler.on_undecodable(&event).await {
-                    UndecodableAction::Ack => {
+            // ever skipped.
+            if event.decode_failure.is_some() {
+                match self.handler.handle_undecodable(&event).await {
+                    Ok(()) => {
                         state.sequence = event.sequence;
                         continue;
                     }
-                    UndecodableAction::Fail => {
+                    Err(error) => {
                         let mut parts = CtxParts {
                             op_slot: &mut op_slot,
                             current_job: &mut current_job,
@@ -566,11 +561,7 @@ where
                                 .await
                                 .map_err(|e| e as Box<dyn std::error::Error>)?;
                         }
-                        return Err(Box::new(UndecodableEventError {
-                            id: event.id,
-                            sequence: event.sequence,
-                            error: failure.error.clone(),
-                        }));
+                        return Err(error as Box<dyn std::error::Error>);
                     }
                 }
             }

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -103,22 +103,27 @@ where
     /// [`UndecodableEventError`] carries the event's identity and the raw
     /// payload + serde error (`error.failure`).
     ///
+    /// The runner lands the pending batch *before* invoking this — like
+    /// [`handle_ephemeral`](Self::handle_ephemeral), nothing is pending
+    /// while it runs and no batch transaction spans the await, and work
+    /// completed up to the event is durable regardless of the outcome.
+    ///
     /// The default fails with the error as-is: a payload the consumer
     /// cannot decode is a runtime bug (schema drift, a producer ahead of
     /// this consumer, foreign rows in the table) that must surface loudly,
-    /// not silently pass by. On any `Err` the runner lands the pending
-    /// batch, parks the checkpoint at the sequence *before* the event and
-    /// fails the job — every retry re-reads the event from the database, so
-    /// deploying a consumer that understands the payload resumes the
-    /// pipeline automatically, in order, with nothing skipped.
+    /// not silently pass by. On `Err` the job fails with its checkpoint
+    /// parked at the sequence *before* the event — every retry re-reads the
+    /// event from the database, so deploying a consumer that understands
+    /// the payload resumes the pipeline automatically, in order, with
+    /// nothing skipped.
     ///
     /// Override and return `Ok(())` only when this handler genuinely wants
     /// to move past payloads it cannot decode — an explicit, auditable
     /// decision (consider recording `error.failure` somewhere durable
     /// first). The checkpoint then advances over the event exactly as for a
-    /// [`skip`](EventCtx::skip). No transaction is opened on this path;
-    /// like [`handle_ephemeral`](Self::handle_ephemeral), any work done
-    /// here must tolerate replay.
+    /// [`skip`](EventCtx::skip). Any work done here must tolerate replay
+    /// (the event is redelivered if the acknowledgement's checkpoint was
+    /// not yet persisted at a crash).
     fn handle_undecodable(
         &self,
         error: &UndecodableEventError,
@@ -510,36 +515,41 @@ where
 
             // An undecodable payload arrives as the stream's `Err` arm and
             // never reaches handle_persistent: handle_undecodable decides its
-            // fate. `Ok` acknowledges the event (the checkpoint advances over
-            // it like a skip); any `Err` — the default — fails the job with
-            // the pending batch landed and the checkpoint parked at the
-            // sequence *before* the event, so every retry re-reads it and
-            // nothing is ever skipped.
+            // fate. The pending batch lands FIRST — completed work and its
+            // checkpoint (at the sequence *before* this event) are durable
+            // regardless of the outcome, and no batch transaction spans the
+            // foreign handle_undecodable await (the same fence as
+            // consume_isolated's entry). Then `Ok` acknowledges the event
+            // (the checkpoint advances over it like a skip); any `Err` — the
+            // default — fails the job with the checkpoint parked before the
+            // event, so every retry re-reads it and nothing is ever skipped.
             let event = match item {
                 Ok(event) => event,
-                Err(undecodable) => match self.handler.handle_undecodable(&undecodable).await {
-                    Ok(()) => {
-                        state.sequence = undecodable.sequence;
-                        continue;
-                    }
-                    Err(error) => {
-                        let mut parts = CtxParts {
-                            op_slot: &mut op_slot,
-                            current_job: &mut current_job,
-                            state: &state,
-                            tracker: &mut tracker,
-                        };
-                        flush_batch(&mut parts, &mut batch, &flusher, "undecodable_event")
-                            .await
-                            .map_err(|e| e as Box<dyn std::error::Error>)?;
-                        if tracker.persisted_seq < state.sequence {
-                            persist_checkpoint(&mut current_job, &state)
-                                .await
-                                .map_err(|e| e as Box<dyn std::error::Error>)?;
+                Err(undecodable) => {
+                    let mut parts = CtxParts {
+                        op_slot: &mut op_slot,
+                        current_job: &mut current_job,
+                        state: &state,
+                        tracker: &mut tracker,
+                    };
+                    flush_batch(&mut parts, &mut batch, &flusher, "undecodable_event")
+                        .await
+                        .map_err(|e| e as Box<dyn std::error::Error>)?;
+                    match self.handler.handle_undecodable(&undecodable).await {
+                        Ok(()) => {
+                            state.sequence = undecodable.sequence;
+                            continue;
                         }
-                        return Err(error as Box<dyn std::error::Error>);
+                        Err(error) => {
+                            if tracker.persisted_seq < state.sequence {
+                                persist_checkpoint(&mut current_job, &state)
+                                    .await
+                                    .map_err(|e| e as Box<dyn std::error::Error>)?;
+                            }
+                            return Err(error as Box<dyn std::error::Error>);
+                        }
                     }
-                },
+                }
             };
 
             let ctx = EventCtx {

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -9,7 +9,7 @@ use job::{
 
 use super::ctx::*;
 use super::{EphemeralOutboxListener, Outbox, event::*};
-use crate::tables::MailboxTables;
+use crate::{sequence::EventSequence, tables::MailboxTables};
 
 /// Which delivery streams an event-handler job subscribes to — see
 /// [`OutboxEventHandler::SUBSCRIPTION`].
@@ -26,6 +26,42 @@ pub enum EventSubscription {
     All,
     PersistentOnly,
     EphemeralOnly,
+}
+
+/// Fate of a persistent event whose stored payload could not be decoded into
+/// the handler's event type, decided by
+/// [`OutboxEventHandler::on_undecodable`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UndecodableAction {
+    /// The default: treat the undecodable payload as a runtime bug. The
+    /// runner lands the pending batch, persists the checkpoint at the
+    /// sequence *before* this event, and fails the job — the job retry
+    /// machinery (with its configured backoff) re-reads the event from the
+    /// database on every attempt, so the pipeline resumes on its own once a
+    /// consumer that understands the payload is deployed. Nothing is ever
+    /// skipped.
+    Fail,
+    /// Explicitly acknowledge the event and move past it. The checkpoint
+    /// advances over the event exactly as for a
+    /// [`skip`](super::EventCtx::skip) — an unambiguous, per-handler opt-in
+    /// to drop payloads this handler cannot decode.
+    Ack,
+}
+
+/// A persistent event's stored payload could not be decoded into the
+/// handler's event type and the handler's
+/// [`on_undecodable`](OutboxEventHandler::on_undecodable) policy chose
+/// [`Fail`](UndecodableAction::Fail). Propagates as the handler job's error;
+/// the job's checkpoint is parked at the sequence before the event.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "undecodable persistent outbox event {id} at sequence {sequence} (checkpoint parked before it): {error}"
+)]
+pub struct UndecodableEventError {
+    pub id: OutboxEventId,
+    pub sequence: EventSequence,
+    /// The serde error message.
+    pub error: String,
 }
 
 /// Handles the events of one outbox listener job.
@@ -94,6 +130,34 @@ where
     > + Send {
         let _ = event;
         async move { Ok(ctx.skip()) }
+    }
+
+    /// Policy for a persistent event whose stored payload could not be
+    /// decoded into `P` (the event arrives with
+    /// [`decode_failure`](PersistentOutboxEvent::decode_failure) set and no
+    /// payload). The runner consults this *instead of*
+    /// [`handle_persistent`](Self::handle_persistent) — an undecodable event
+    /// never reaches the normal handling path.
+    ///
+    /// Defaults to [`Fail`](UndecodableAction::Fail): the job lands its
+    /// pending batch, parks its checkpoint before the event and errors — a
+    /// payload the consumer cannot decode is a runtime bug (schema drift, a
+    /// producer ahead of this consumer, foreign rows in the table) that must
+    /// surface loudly, not silently pass by. Because the event is re-read
+    /// from the database on every job retry, deploying a consumer that
+    /// understands the payload resumes the pipeline automatically, in order,
+    /// with nothing skipped.
+    ///
+    /// Override to return [`Ack`](UndecodableAction::Ack) only when this
+    /// handler genuinely wants to drop payloads it cannot decode — an
+    /// explicit, auditable decision (consider recording
+    /// `event.decode_failure` somewhere first).
+    fn on_undecodable(
+        &self,
+        event: &PersistentOutboxEvent<P>,
+    ) -> impl std::future::Future<Output = UndecodableAction> + Send {
+        let _ = event;
+        async { UndecodableAction::Fail }
     }
 
     /// Apply everything collected since the last flush. Called at most once
@@ -475,6 +539,41 @@ where
                     }
                 }
             };
+
+            // An undecodable payload never reaches the normal handling path:
+            // the handler's on_undecodable policy decides between failing the
+            // job — pending batch landed, checkpoint parked at the sequence
+            // *before* the event, so every retry re-reads it and nothing is
+            // ever skipped (the default) — and explicitly acknowledging it.
+            if let Some(failure) = &event.decode_failure {
+                match self.handler.on_undecodable(&event).await {
+                    UndecodableAction::Ack => {
+                        state.sequence = event.sequence;
+                        continue;
+                    }
+                    UndecodableAction::Fail => {
+                        let mut parts = CtxParts {
+                            op_slot: &mut op_slot,
+                            current_job: &mut current_job,
+                            state: &state,
+                            tracker: &mut tracker,
+                        };
+                        flush_batch(&mut parts, &mut batch, &flusher, "undecodable_event")
+                            .await
+                            .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        if tracker.persisted_seq < state.sequence {
+                            persist_checkpoint(&mut current_job, &state)
+                                .await
+                                .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        }
+                        return Err(Box::new(UndecodableEventError {
+                            id: event.id,
+                            sequence: event.sequence,
+                            error: failure.error.clone(),
+                        }));
+                    }
+                }
+            }
 
             let ctx = EventCtx {
                 parts: CtxParts {

--- a/src/out/mod.rs
+++ b/src/out/mod.rs
@@ -16,7 +16,10 @@ use serde::{Serialize, de::DeserializeOwned};
 use std::sync::Arc;
 
 pub use self::ctx::{BatchOp, EventCtx, FlushError, FlushOp, Handled, IsolatedOp};
-pub use self::job::{EventSubscription, OutboxEventHandler, OutboxEventJobConfig};
+pub use self::job::{
+    EventSubscription, OutboxEventHandler, OutboxEventJobConfig, UndecodableAction,
+    UndecodableEventError,
+};
 use crate::{config::*, handle::OwnedTaskHandle, sequence::EventSequence, tables::*};
 pub use all_listener::AllOutboxListener;
 use ephemeral::EphemeralOutboxEventCache;

--- a/src/out/mod.rs
+++ b/src/out/mod.rs
@@ -16,9 +16,7 @@ use serde::{Serialize, de::DeserializeOwned};
 use std::sync::Arc;
 
 pub use self::ctx::{BatchOp, EventCtx, FlushError, FlushOp, Handled, IsolatedOp};
-pub use self::job::{
-    EventSubscription, OutboxEventHandler, OutboxEventJobConfig, UndecodableEventError,
-};
+pub use self::job::{EventSubscription, OutboxEventHandler, OutboxEventJobConfig};
 use crate::{config::*, handle::OwnedTaskHandle, sequence::EventSequence, tables::*};
 pub use all_listener::AllOutboxListener;
 use ephemeral::EphemeralOutboxEventCache;

--- a/src/out/mod.rs
+++ b/src/out/mod.rs
@@ -17,8 +17,7 @@ use std::sync::Arc;
 
 pub use self::ctx::{BatchOp, EventCtx, FlushError, FlushOp, Handled, IsolatedOp};
 pub use self::job::{
-    EventSubscription, OutboxEventHandler, OutboxEventJobConfig, UndecodableAction,
-    UndecodableEventError,
+    EventSubscription, OutboxEventHandler, OutboxEventJobConfig, UndecodableEventError,
 };
 use crate::{config::*, handle::OwnedTaskHandle, sequence::EventSequence, tables::*};
 pub use all_listener::AllOutboxListener;

--- a/src/out/persist_events_hook.rs
+++ b/src/out/persist_events_hook.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, sync::Arc};
+use std::marker::PhantomData;
 
 use es_entity::hooks::{CommitHook, HookOperation, PreCommitRet};
 use serde::{Serialize, de::DeserializeOwned};
@@ -82,7 +82,7 @@ where
 
     fn post_commit(self) {
         for event in self.post_commit_events {
-            let _ = self.sender.send(Ok(Arc::new(event)));
+            let _ = self.sender.send(PersistentDelivery::from(Ok(event)));
         }
     }
 

--- a/src/out/persist_events_hook.rs
+++ b/src/out/persist_events_hook.rs
@@ -4,7 +4,7 @@ use es_entity::hooks::{CommitHook, HookOperation, PreCommitRet};
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::sync::broadcast;
 
-use crate::out::event::PersistentOutboxEvent;
+use crate::out::event::{PersistentDelivery, PersistentOutboxEvent};
 use crate::out::post_persist_hook::PostPersistHooks;
 use crate::tables::MailboxTables;
 
@@ -13,7 +13,7 @@ where
     P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
     Tables: MailboxTables,
 {
-    sender: broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
+    sender: broadcast::Sender<PersistentDelivery<P>>,
     pre_commit_events: Vec<P>,
     post_commit_events: Vec<PersistentOutboxEvent<P>>,
     batch_size: usize,
@@ -30,7 +30,7 @@ where
     Tables: MailboxTables,
 {
     pub fn new(
-        sender: broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
+        sender: broadcast::Sender<PersistentDelivery<P>>,
         events: impl IntoIterator<Item = impl Into<P>>,
         batch_size: usize,
         post_persist_hooks: PostPersistHooks<P>,
@@ -82,7 +82,7 @@ where
 
     fn post_commit(self) {
         for event in self.post_commit_events {
-            let _ = self.sender.send(event.into());
+            let _ = self.sender.send(Ok(Arc::new(event)));
         }
     }
 

--- a/src/out/persistent/cache.rs
+++ b/src/out/persistent/cache.rs
@@ -195,7 +195,7 @@ where
     ) {
         use std::ops::Bound;
 
-        let sequence = delivery_sequence(&event);
+        let sequence = event.sequence();
         let highest_known = highest_known_sequence.load(Ordering::Relaxed);
 
         // Skip events that are too old to be useful, but never let the
@@ -243,7 +243,7 @@ where
     ) {
         if let Ok(events) = Tables::load_next_page::<P>(&pool, from_sequence, buffer_size).await {
             for item in events {
-                let _ = cache_fill_sender.send(into_delivery(item));
+                let _ = cache_fill_sender.send(PersistentDelivery::from(item));
             }
         }
     }
@@ -271,8 +271,8 @@ where
                 Ok(events) if events.is_empty() => break,
                 Ok(events) => {
                     for item in events {
-                        let delivery = into_delivery(item);
-                        let seq = delivery_sequence(&delivery);
+                        let delivery = PersistentDelivery::from(item);
+                        let seq = delivery.sequence();
                         let _ = cache_fill_sender.send(delivery.clone());
                         if sender.send(delivery).await.is_err() {
                             return;
@@ -308,7 +308,7 @@ where
     ) {
         if let Ok(events) = Tables::load_events_in_range::<P>(&pool, after, up_to).await {
             for item in events {
-                let _ = cache_fill_sender.send(into_delivery(item));
+                let _ = cache_fill_sender.send(PersistentDelivery::from(item));
             }
         }
     }

--- a/src/out/persistent/cache.rs
+++ b/src/out/persistent/cache.rs
@@ -19,9 +19,8 @@ where
     P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
     highest_known_sequence: Arc<AtomicU64>,
-    persistent_event_receiver: Option<broadcast::Receiver<Arc<PersistentOutboxEvent<P>>>>,
-    backfill_request:
-        mpsc::UnboundedSender<(EventSequence, mpsc::Sender<Arc<PersistentOutboxEvent<P>>>)>,
+    persistent_event_receiver: Option<broadcast::Receiver<PersistentDelivery<P>>>,
+    backfill_request: mpsc::UnboundedSender<(EventSequence, mpsc::Sender<PersistentDelivery<P>>)>,
     backfill_buffer_size: usize,
 }
 
@@ -33,7 +32,7 @@ where
         EventSequence::from(self.highest_known_sequence.load(Ordering::Relaxed))
     }
 
-    pub fn persistent_event_stream(&mut self) -> BroadcastStream<Arc<PersistentOutboxEvent<P>>> {
+    pub fn persistent_event_stream(&mut self) -> BroadcastStream<PersistentDelivery<P>> {
         BroadcastStream::new(
             self.persistent_event_receiver
                 .take()
@@ -44,7 +43,7 @@ where
     pub fn request_old_persistent_events(
         &self,
         start_after: EventSequence,
-    ) -> ReceiverStream<Arc<PersistentOutboxEvent<P>>> {
+    ) -> ReceiverStream<PersistentDelivery<P>> {
         let (tx, rx) = mpsc::channel(self.backfill_buffer_size);
         let _ = self.backfill_request.send((start_after, tx));
         ReceiverStream::new(rx)
@@ -119,11 +118,11 @@ where
     P: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
     highest_known_sequence: Arc<AtomicU64>,
-    persistent_event_sender: broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
+    persistent_event_sender: broadcast::Sender<PersistentDelivery<P>>,
     backfill_request_send:
-        mpsc::UnboundedSender<(EventSequence, mpsc::Sender<Arc<PersistentOutboxEvent<P>>>)>,
+        mpsc::UnboundedSender<(EventSequence, mpsc::Sender<PersistentDelivery<P>>)>,
     backfill_buffer_size: usize,
-    cache_fill_sender: broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
+    cache_fill_sender: broadcast::Sender<PersistentDelivery<P>>,
     _cache_loop_handle: OwnedTaskHandle,
     _phantom: std::marker::PhantomData<Tables>,
 }
@@ -142,7 +141,7 @@ where
         }
     }
 
-    pub fn cache_fill_sender(&self) -> broadcast::Sender<Arc<PersistentOutboxEvent<P>>> {
+    pub fn cache_fill_sender(&self) -> broadcast::Sender<PersistentDelivery<P>> {
         self.cache_fill_sender.clone()
     }
 
@@ -184,19 +183,19 @@ where
     }
 
     fn insert_into_cache_and_maybe_broadcast(
-        cache: im::OrdMap<EventSequence, Arc<PersistentOutboxEvent<P>>>,
-        event: Arc<PersistentOutboxEvent<P>>,
+        cache: im::OrdMap<EventSequence, PersistentDelivery<P>>,
+        event: PersistentDelivery<P>,
         highest_known_sequence: &AtomicU64,
-        persistent_event_sender: &broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
+        persistent_event_sender: &broadcast::Sender<PersistentDelivery<P>>,
         mut last_broadcast_sequence: EventSequence,
         cache_size: usize,
     ) -> (
-        im::OrdMap<EventSequence, Arc<PersistentOutboxEvent<P>>>,
+        im::OrdMap<EventSequence, PersistentDelivery<P>>,
         EventSequence,
     ) {
         use std::ops::Bound;
 
-        let sequence = event.sequence;
+        let sequence = delivery_sequence(&event);
         let highest_known = highest_known_sequence.load(Ordering::Relaxed);
 
         // Skip events that are too old to be useful, but never let the
@@ -239,12 +238,12 @@ where
     async fn fill_gap(
         pool: sqlx::PgPool,
         from_sequence: EventSequence,
-        cache_fill_sender: broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
+        cache_fill_sender: broadcast::Sender<PersistentDelivery<P>>,
         buffer_size: usize,
     ) {
         if let Ok(events) = Tables::load_next_page::<P>(&pool, from_sequence, buffer_size).await {
-            for event in events {
-                let _ = cache_fill_sender.send(Arc::new(event));
+            for item in events {
+                let _ = cache_fill_sender.send(into_delivery(item));
             }
         }
     }
@@ -252,9 +251,9 @@ where
     async fn handle_backfill_request(
         pool: sqlx::PgPool,
         start_after: EventSequence,
-        sender: mpsc::Sender<Arc<PersistentOutboxEvent<P>>>,
-        cache_snapshot: im::OrdMap<EventSequence, Arc<PersistentOutboxEvent<P>>>,
-        cache_fill_sender: broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
+        sender: mpsc::Sender<PersistentDelivery<P>>,
+        cache_snapshot: im::OrdMap<EventSequence, PersistentDelivery<P>>,
+        cache_fill_sender: broadcast::Sender<PersistentDelivery<P>>,
         highest: EventSequence,
         buffer_size: usize,
     ) {
@@ -271,11 +270,11 @@ where
             match Tables::load_next_page::<P>(&pool, current_sequence, buffer_size).await {
                 Ok(events) if events.is_empty() => break,
                 Ok(events) => {
-                    for event in events {
-                        let seq = event.sequence;
-                        let event = Arc::new(event);
-                        let _ = cache_fill_sender.send(event.clone());
-                        if sender.send(event).await.is_err() {
+                    for item in events {
+                        let delivery = into_delivery(item);
+                        let seq = delivery_sequence(&delivery);
+                        let _ = cache_fill_sender.send(delivery.clone());
+                        if sender.send(delivery).await.is_err() {
                             return;
                         }
                         current_sequence = seq;
@@ -305,11 +304,11 @@ where
         pool: sqlx::PgPool,
         after: EventSequence,
         up_to: EventSequence,
-        cache_fill_sender: broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
+        cache_fill_sender: broadcast::Sender<PersistentDelivery<P>>,
     ) {
         if let Ok(events) = Tables::load_events_in_range::<P>(&pool, after, up_to).await {
-            for event in events {
-                let _ = cache_fill_sender.send(Arc::new(event));
+            for item in events {
+                let _ = cache_fill_sender.send(into_delivery(item));
             }
         }
     }
@@ -319,7 +318,7 @@ where
     /// Returns `None` for unparsable payloads.
     fn handle_notification(
         payload: &str,
-        cache: &im::OrdMap<EventSequence, Arc<PersistentOutboxEvent<P>>>,
+        cache: &im::OrdMap<EventSequence, PersistentDelivery<P>>,
     ) -> Option<NotifiedRange> {
         #[derive(serde::Deserialize)]
         struct NotificationHeader {
@@ -352,14 +351,14 @@ where
     async fn spawn_cache_loop(
         pool: &sqlx::PgPool,
         config: &MailboxConfig,
-        persistent_event_sender: broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
+        persistent_event_sender: broadcast::Sender<PersistentDelivery<P>>,
         highest_known_sequence: Arc<AtomicU64>,
         mut backfill_request: mpsc::UnboundedReceiver<(
             EventSequence,
-            mpsc::Sender<Arc<PersistentOutboxEvent<P>>>,
+            mpsc::Sender<PersistentDelivery<P>>,
         )>,
-        mut cache_fill_receiver: broadcast::Receiver<Arc<PersistentOutboxEvent<P>>>,
-        cache_fill_sender: broadcast::Sender<Arc<PersistentOutboxEvent<P>>>,
+        mut cache_fill_receiver: broadcast::Receiver<PersistentDelivery<P>>,
+        cache_fill_sender: broadcast::Sender<PersistentDelivery<P>>,
         mut notification_receiver: mpsc::Receiver<NotifyMessage>,
     ) -> Result<OwnedTaskHandle, sqlx::Error> {
         let pool = pool.clone();
@@ -372,7 +371,7 @@ where
         let initial_sequence = EventSequence::from(highest_known_sequence.load(Ordering::Relaxed));
 
         let handle = spawn_supervised("obix::persistent_cache_loop", async move {
-            let mut persistent_cache: im::OrdMap<EventSequence, Arc<PersistentOutboxEvent<P>>> =
+            let mut persistent_cache: im::OrdMap<EventSequence, PersistentDelivery<P>> =
                 im::OrdMap::new();
             let mut last_broadcast_sequence = initial_sequence;
             // Bookkeeping for the sequence the broadcast is stalled on.

--- a/src/out/persistent/listener.rs
+++ b/src/out/persistent/listener.rs
@@ -43,7 +43,7 @@ where
     }
 
     fn maybe_add_to_cache(&mut self, delivery: PersistentDelivery<P>) {
-        let sequence = crate::out::event::delivery_sequence(&delivery);
+        let sequence = delivery.sequence();
         self.latest_known = self.latest_known.max(sequence);
         if sequence > self.last_returned_sequence
             && self.local_cache.insert(sequence, delivery).is_none()
@@ -124,10 +124,7 @@ where
             }
             if seq == this.last_returned_sequence.next() {
                 this.last_returned_sequence = seq;
-                return Poll::Ready(Some(match event {
-                    Ok(event) => Ok(event),
-                    Err(error) => Err((*error).clone()),
-                }));
+                return Poll::Ready(Some(event.into_item()));
             }
             this.local_cache.insert(seq, event);
             break;

--- a/src/out/persistent/listener.rs
+++ b/src/out/persistent/listener.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeMap, pin::Pin, sync::Arc, task::Poll};
 use tokio_stream::wrappers::{BroadcastStream, ReceiverStream, errors::BroadcastStreamRecvError};
 
 use super::cache::CacheHandle;
-use crate::out::event::{PersistentOutboxEvent, UndecodableEventError};
+use crate::out::event::{PersistentDelivery, PersistentOutboxEvent, UndecodableEventError};
 use crate::sequence::EventSequence;
 
 pub struct PersistentOutboxListener<P>
@@ -13,11 +13,11 @@ where
 {
     last_returned_sequence: EventSequence,
     latest_known: EventSequence,
-    event_receiver: BroadcastStream<Arc<PersistentOutboxEvent<P>>>,
+    event_receiver: BroadcastStream<PersistentDelivery<P>>,
     buffer_size: usize,
-    local_cache: BTreeMap<EventSequence, Arc<PersistentOutboxEvent<P>>>,
+    local_cache: BTreeMap<EventSequence, PersistentDelivery<P>>,
     cache_handle: CacheHandle<P>,
-    backfill_receiver: Option<ReceiverStream<Arc<PersistentOutboxEvent<P>>>>,
+    backfill_receiver: Option<ReceiverStream<PersistentDelivery<P>>>,
 }
 
 impl<P> PersistentOutboxListener<P>
@@ -42,10 +42,11 @@ where
         }
     }
 
-    fn maybe_add_to_cache(&mut self, event: Arc<PersistentOutboxEvent<P>>) {
-        self.latest_known = self.latest_known.max(event.sequence);
-        if event.sequence > self.last_returned_sequence
-            && self.local_cache.insert(event.sequence, event).is_none()
+    fn maybe_add_to_cache(&mut self, delivery: PersistentDelivery<P>) {
+        let sequence = crate::out::event::delivery_sequence(&delivery);
+        self.latest_known = self.latest_known.max(sequence);
+        if sequence > self.last_returned_sequence
+            && self.local_cache.insert(sequence, delivery).is_none()
             && self.local_cache.len() > self.buffer_size
         {
             self.local_cache.pop_last();
@@ -123,9 +124,9 @@ where
             }
             if seq == this.last_returned_sequence.next() {
                 this.last_returned_sequence = seq;
-                return Poll::Ready(Some(match UndecodableEventError::try_from_event(&event) {
-                    Some(error) => Err(error),
-                    None => Ok(event),
+                return Poll::Ready(Some(match event {
+                    Ok(event) => Ok(event),
+                    Err(error) => Err((*error).clone()),
                 }));
             }
             this.local_cache.insert(seq, event);

--- a/src/out/persistent/listener.rs
+++ b/src/out/persistent/listener.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeMap, pin::Pin, sync::Arc, task::Poll};
 use tokio_stream::wrappers::{BroadcastStream, ReceiverStream, errors::BroadcastStreamRecvError};
 
 use super::cache::CacheHandle;
-use crate::out::event::PersistentOutboxEvent;
+use crate::out::event::{PersistentOutboxEvent, UndecodableEventError};
 use crate::sequence::EventSequence;
 
 pub struct PersistentOutboxListener<P>
@@ -66,7 +66,11 @@ impl<P> Stream for PersistentOutboxListener<P>
 where
     P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
 {
-    type Item = Arc<PersistentOutboxEvent<P>>;
+    /// An undecodable event is yielded as the `Err` arm, in its sequence
+    /// position — the delivery of that event in degraded form. The stream
+    /// continues past it; whether the *consumer* moves past it is the
+    /// consumer's explicit decision (`?` fails loudly).
+    type Item = Result<Arc<PersistentOutboxEvent<P>>, UndecodableEventError>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -119,7 +123,10 @@ where
             }
             if seq == this.last_returned_sequence.next() {
                 this.last_returned_sequence = seq;
-                return Poll::Ready(Some(event));
+                return Poll::Ready(Some(match UndecodableEventError::try_from_event(&event) {
+                    Some(error) => Err(error),
+                    None => Ok(event),
+                }));
             }
             this.local_cache.insert(seq, event);
             break;

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -20,7 +20,7 @@ pub struct DefaultMailboxTables;
 /// previously wedged the whole pipeline in a hot panic/retry loop — nor be
 /// silently dropped: the event is delivered with a [`DecodeFailure`]
 /// attached and its fate is decided by consumer policy (see
-/// [`OutboxEventHandler::on_undecodable`](crate::OutboxEventHandler::on_undecodable)).
+/// [`OutboxEventHandler::handle_undecodable`](crate::OutboxEventHandler::handle_undecodable)).
 #[doc(hidden)]
 pub fn decode_persistent_payload<P: serde::de::DeserializeOwned>(
     raw: serde_json::Value,

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -4,7 +4,10 @@ use es_entity::hooks::HookOperation;
 
 use crate::{
     inbox::{InboxError, InboxEvent, InboxEventId, InboxEventStatus, InboxIdempotencyKey},
-    out::{DecodeFailure, EphemeralEventType, EphemeralOutboxEvent, PersistentOutboxEvent},
+    out::{
+        DecodeFailure, EphemeralEventType, EphemeralOutboxEvent, OutboxEventId,
+        PersistentOutboxEvent, UndecodableEventError,
+    },
     sequence::*,
 };
 
@@ -13,32 +16,53 @@ use crate::{
 #[cfg_attr(feature = "default-tables", obix(crate = "crate"))]
 pub struct DefaultMailboxTables;
 
-/// Decode a stored persistent payload, invoked from `MailboxTables` derive
-/// output. A payload that does not decode into the caller's event type (e.g.
-/// a variant the consumer does not know yet, or a row written by a different
-/// event enum sharing the table) must neither panic — a single poison row
-/// previously wedged the whole pipeline in a hot panic/retry loop — nor be
-/// silently dropped: the event is delivered with a [`DecodeFailure`]
-/// attached and its fate is decided by consumer policy (see
+/// Decode one stored persistent row into a delivery item, invoked from
+/// `MailboxTables` derive output. A `NULL` payload is a plain placeholder
+/// (`Ok` with `payload: None`); a payload that does not decode into the
+/// caller's event type (e.g. a variant the consumer does not know yet, or a
+/// row written by a different event enum sharing the table) must neither
+/// panic — a single poison row previously wedged the whole pipeline in a hot
+/// panic/retry loop — nor be silently dropped: it becomes the `Err` arm
+/// ([`UndecodableEventError`]), still occupying its sequence position, and
+/// its fate is decided by consumer policy (see
 /// [`OutboxEventHandler::handle_undecodable`](crate::OutboxEventHandler::handle_undecodable)).
 #[doc(hidden)]
-pub fn decode_persistent_payload<P: serde::de::DeserializeOwned>(
-    raw: serde_json::Value,
+pub fn decode_persistent_event<P>(
+    id: OutboxEventId,
     sequence: u64,
-) -> (Option<P>, Option<DecodeFailure>) {
-    match P::deserialize(&raw) {
-        Ok(payload) => (Some(payload), None),
-        Err(error) => {
-            record_persistent_payload_undecodable(&error, sequence);
-            (
-                None,
-                Some(DecodeFailure {
-                    error: error.to_string(),
-                    raw,
-                }),
-            )
-        }
-    }
+    recorded_at: chrono::DateTime<chrono::Utc>,
+    tracing_context: Option<es_entity::context::TracingContext>,
+    payload: Option<serde_json::Value>,
+) -> Result<PersistentOutboxEvent<P>, UndecodableEventError>
+where
+    P: Serialize + DeserializeOwned + Send,
+{
+    let sequence = EventSequence::from(sequence);
+    let payload = match payload {
+        None => None,
+        Some(raw) => match P::deserialize(&raw) {
+            Ok(payload) => Some(payload),
+            Err(error) => {
+                record_persistent_payload_undecodable(&error, u64::from(sequence));
+                return Err(UndecodableEventError {
+                    id,
+                    sequence,
+                    recorded_at,
+                    failure: DecodeFailure {
+                        error: error.to_string(),
+                        raw,
+                    },
+                });
+            }
+        },
+    };
+    Ok(PersistentOutboxEvent {
+        id,
+        sequence,
+        payload,
+        tracing_context,
+        recorded_at,
+    })
 }
 
 #[tracing::instrument(
@@ -87,11 +111,17 @@ pub trait MailboxTables: Send + Sync + 'static {
     where
         P: Serialize + DeserializeOwned + Send;
 
+    /// Each item is one sequence position: `Ok` for a decoded event or a
+    /// plain placeholder (`payload: None`), `Err` for a stored payload that
+    /// does not decode into `P` — delivered, not dropped, so the page stays
+    /// contiguous.
     fn load_next_page<P>(
         pool: &sqlx::PgPool,
         from_sequence: EventSequence,
         buffer_size: usize,
-    ) -> impl Future<Output = Result<Vec<PersistentOutboxEvent<P>>, sqlx::Error>> + Send
+    ) -> impl Future<
+        Output = Result<Vec<Result<PersistentOutboxEvent<P>, UndecodableEventError>>, sqlx::Error>,
+    > + Send
     where
         P: Serialize + DeserializeOwned + Send;
 
@@ -99,12 +129,15 @@ pub trait MailboxTables: Send + Sync + 'static {
     /// a plain SELECT. Unlike [`load_next_page`](Self::load_next_page) this
     /// never writes placeholder rows for sequence gaps — sequences absent
     /// from the result belong to in-flight transactions and are left to the
-    /// grace-period gap fill.
+    /// grace-period gap fill. Undecodable payloads are the `Err` items, as
+    /// in [`load_next_page`](Self::load_next_page).
     fn load_events_in_range<P>(
         pool: &sqlx::PgPool,
         after_sequence: EventSequence,
         up_to_sequence: EventSequence,
-    ) -> impl Future<Output = Result<Vec<PersistentOutboxEvent<P>>, sqlx::Error>> + Send
+    ) -> impl Future<
+        Output = Result<Vec<Result<PersistentOutboxEvent<P>, UndecodableEventError>>, sqlx::Error>,
+    > + Send
     where
         P: Serialize + DeserializeOwned + Send;
 

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -4,7 +4,7 @@ use es_entity::hooks::HookOperation;
 
 use crate::{
     inbox::{InboxError, InboxEvent, InboxEventId, InboxEventStatus, InboxIdempotencyKey},
-    out::{EphemeralEventType, EphemeralOutboxEvent, PersistentOutboxEvent},
+    out::{DecodeFailure, EphemeralEventType, EphemeralOutboxEvent, PersistentOutboxEvent},
     sequence::*,
 };
 
@@ -12,6 +12,68 @@ use crate::{
 #[cfg_attr(feature = "default-tables", derive(obix_macros::MailboxTables))]
 #[cfg_attr(feature = "default-tables", obix(crate = "crate"))]
 pub struct DefaultMailboxTables;
+
+/// Decode a stored persistent payload, invoked from `MailboxTables` derive
+/// output. A payload that does not decode into the caller's event type (e.g.
+/// a variant the consumer does not know yet, or a row written by a different
+/// event enum sharing the table) must neither panic — a single poison row
+/// previously wedged the whole pipeline in a hot panic/retry loop — nor be
+/// silently dropped: the event is delivered with a [`DecodeFailure`]
+/// attached and its fate is decided by consumer policy (see
+/// [`OutboxEventHandler::on_undecodable`](crate::OutboxEventHandler::on_undecodable)).
+#[doc(hidden)]
+pub fn decode_persistent_payload<P: serde::de::DeserializeOwned>(
+    raw: serde_json::Value,
+    sequence: u64,
+) -> (Option<P>, Option<DecodeFailure>) {
+    match P::deserialize(&raw) {
+        Ok(payload) => (Some(payload), None),
+        Err(error) => {
+            record_persistent_payload_undecodable(&error, sequence);
+            (
+                None,
+                Some(DecodeFailure {
+                    error: error.to_string(),
+                    raw,
+                }),
+            )
+        }
+    }
+}
+
+#[tracing::instrument(
+    name = "obix.tables.persistent_payload_undecodable",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", error = %error, sequence = sequence)
+)]
+fn record_persistent_payload_undecodable(error: &serde_json::Error, sequence: u64) {}
+
+/// Invoked from `MailboxTables` derive output when a stored ephemeral event
+/// payload cannot be deserialized; the event is dropped from the result.
+/// Unlike the persistent stream (ordered, guaranteed delivery — see
+/// [`decode_persistent_payload`]) the ephemeral stream is best-effort
+/// last-value by design, so dropping is the honest degradation.
+#[doc(hidden)]
+#[tracing::instrument(
+    name = "obix.tables.ephemeral_payload_undecodable",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", error = %error, event_type = %event_type)
+)]
+pub fn record_ephemeral_payload_undecodable(error: &serde_json::Error, event_type: &str) {}
+
+/// Invoked from `MailboxTables` derive output when the tracing-context
+/// envelope cannot be deserialized; the event is kept with no context
+/// attached (the context is delivery metadata, not payload data).
+#[doc(hidden)]
+#[tracing::instrument(
+    name = "obix.tables.tracing_context_undecodable",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", error = %error)
+)]
+pub fn record_tracing_context_undecodable(error: &serde_json::Error) {}
 
 pub trait MailboxTables: Send + Sync + 'static {
     fn highest_known_persistent_sequence<'a>(

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -112,7 +112,11 @@ where
 
     let event = tokio::time::timeout(Duration::from_secs(20), async {
         loop {
-            let event = listener.next().await.expect("stream should not end");
+            let event = listener
+                .next()
+                .await
+                .expect("stream should not end")
+                .expect("undecodable event on outbox stream");
             if let Some(extracted) = event.as_event::<IE>().and_then(|e| matches(&result, e)) {
                 return extracted;
             }

--- a/tests/outbox.rs
+++ b/tests/outbox.rs
@@ -97,6 +97,7 @@ async fn events_via_short_circuit() -> anyhow::Result<()> {
     let Some(event) = listener.next().await else {
         anyhow::bail!("expected event from listener");
     };
+    let event = event?;
     assert!(matches!(event.payload, Some(TestEvent::Ping(0))));
     Ok(())
 }
@@ -125,6 +126,7 @@ async fn events_via_pg_notify() -> anyhow::Result<()> {
     let Some(event) = listener.next().await else {
         anyhow::bail!("expected event from listener");
     };
+    let event = event?;
     assert!(matches!(event.payload, Some(TestEvent::Ping(0))));
     Ok(())
 }
@@ -160,6 +162,7 @@ async fn event_batch_via_pg_notify() -> anyhow::Result<()> {
         else {
             anyhow::bail!("expected event {i} from listener");
         };
+        let event = event?;
         assert!(matches!(event.payload, Some(TestEvent::Ping(n)) if n == i));
     }
     Ok(())
@@ -185,7 +188,11 @@ async fn events_via_cache() -> anyhow::Result<()> {
         .publish_persisted_in_op(&mut op, TestEvent::Ping(0))
         .await?;
     op.commit().await?;
-    pre_listener.next().await.expect("event was cached");
+    pre_listener
+        .next()
+        .await
+        .expect("event was cached")
+        .expect("undecodable event");
 
     let mut listener = outbox.listen_persisted(EventSequence::BEGIN);
 
@@ -194,6 +201,7 @@ async fn events_via_cache() -> anyhow::Result<()> {
     else {
         anyhow::bail!("expected event from listener");
     };
+    let event = event?;
     assert!(matches!(event.payload, Some(TestEvent::Ping(0))));
 
     Ok(())
@@ -234,7 +242,7 @@ async fn events_not_in_cache_backfilled_from_pg() -> anyhow::Result<()> {
         let event = tokio::time::timeout(std::time::Duration::from_secs(1), listener.next())
             .await
             .expect("should receive event via PG backfill")
-            .expect("should have event");
+            .expect("should have event")?;
         events.push(event);
     }
 
@@ -285,7 +293,8 @@ async fn large_payload_via_pg_notify_fetches_from_db() -> anyhow::Result<()> {
         let event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
             .await
             .unwrap_or_else(|_| panic!("timeout waiting for event {}", i))
-            .unwrap_or_else(|| panic!("expected event {} but got None", i));
+            .unwrap_or_else(|| panic!("expected event {} but got None", i))
+            .unwrap_or_else(|e| panic!("undecodable event {}: {}", i, e));
         received_events.push(event);
     }
 
@@ -346,7 +355,8 @@ async fn large_batch_persisted_in_bounded_chunks() -> anyhow::Result<()> {
         let event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
             .await
             .unwrap_or_else(|_| panic!("timeout waiting for event {i}"))
-            .unwrap_or_else(|| panic!("expected event {i} but got None"));
+            .unwrap_or_else(|| panic!("expected event {i} but got None"))
+            .unwrap_or_else(|e| panic!("undecodable event {i}: {e}"));
         events.push(event);
     }
 
@@ -394,7 +404,7 @@ async fn sequence_gap_from_rolled_back_transaction() -> anyhow::Result<()> {
 
     let event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
         .await?
-        .expect("should receive first event");
+        .expect("should receive first event")?;
     assert!(matches!(event.payload, Some(TestEvent::Ping(0))));
 
     // Create a gap by consuming a sequence number without inserting a row
@@ -412,7 +422,7 @@ async fn sequence_gap_from_rolled_back_transaction() -> anyhow::Result<()> {
     // Should receive the gap-filled placeholder (None payload) followed by the real event
     let gap_event = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
         .await?
-        .expect("should receive gap-filled placeholder");
+        .expect("should receive gap-filled placeholder")?;
     assert!(
         gap_event.payload.is_none(),
         "gap-filled event should have None payload"
@@ -420,7 +430,7 @@ async fn sequence_gap_from_rolled_back_transaction() -> anyhow::Result<()> {
 
     let real_event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
         .await?
-        .expect("should receive real event after gap");
+        .expect("should receive real event after gap")?;
     assert!(matches!(real_event.payload, Some(TestEvent::Ping(1))));
 
     Ok(())
@@ -451,7 +461,7 @@ async fn gap_fill_waits_for_grace_period() -> anyhow::Result<()> {
 
     let event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
         .await?
-        .expect("should receive first event");
+        .expect("should receive first event")?;
     assert!(matches!(event.payload, Some(TestEvent::Ping(0))));
 
     // Burn a sequence number (gap at N+1), then publish seq N+2
@@ -478,7 +488,7 @@ async fn gap_fill_waits_for_grace_period() -> anyhow::Result<()> {
     // After the grace period the placeholder arrives, then the real event.
     let gap_event = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
         .await?
-        .expect("should receive gap-filled placeholder after grace period");
+        .expect("should receive gap-filled placeholder after grace period")?;
     assert!(
         gap_event.payload.is_none(),
         "gap-filled event should have None payload"
@@ -486,7 +496,7 @@ async fn gap_fill_waits_for_grace_period() -> anyhow::Result<()> {
 
     let real_event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
         .await?
-        .expect("should receive real event after gap");
+        .expect("should receive real event after gap")?;
     assert!(matches!(real_event.payload, Some(TestEvent::Ping(1))));
 
     Ok(())
@@ -519,7 +529,7 @@ async fn in_flight_transaction_gap_resolves_without_placeholder() -> anyhow::Res
 
     let event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
         .await?
-        .expect("should receive first event");
+        .expect("should receive first event")?;
     assert!(matches!(event.payload, Some(TestEvent::Ping(0))));
 
     // Insert seq N+1 directly in a transaction that stays open…
@@ -551,7 +561,7 @@ async fn in_flight_transaction_gap_resolves_without_placeholder() -> anyhow::Res
 
     let gap_event = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
         .await?
-        .expect("should receive the committed gap event");
+        .expect("should receive the committed gap event")?;
     assert!(
         matches!(gap_event.payload, Some(TestEvent::Ping(7))),
         "gap must resolve with the real committed event, got {:?}",
@@ -560,7 +570,7 @@ async fn in_flight_transaction_gap_resolves_without_placeholder() -> anyhow::Res
 
     let real_event = tokio::time::timeout(std::time::Duration::from_secs(2), listener.next())
         .await?
-        .expect("should receive real event after gap");
+        .expect("should receive real event after gap")?;
     assert!(matches!(real_event.payload, Some(TestEvent::Ping(1))));
 
     Ok(())
@@ -741,7 +751,7 @@ async fn delivers_events_notified_while_listen_connection_down() -> anyhow::Resu
     let event = tokio::time::timeout(std::time::Duration::from_secs(10), listener.next())
         .await
         .map_err(|_| anyhow::anyhow!("baseline pg_notify delivery timed out"))?
-        .ok_or_else(|| anyhow::anyhow!("listener stream ended"))?;
+        .ok_or_else(|| anyhow::anyhow!("listener stream ended"))??;
     assert!(matches!(event.payload, Some(TestEvent::Ping(1))));
 
     // Terminate every LISTEN backend and insert the event in ONE autocommit
@@ -774,7 +784,7 @@ async fn delivers_events_notified_while_listen_connection_down() -> anyhow::Resu
                  (missed notification not resynced)"
             )
         })?
-        .ok_or_else(|| anyhow::anyhow!("listener stream ended"))?;
+        .ok_or_else(|| anyhow::anyhow!("listener stream ended"))??;
     assert!(matches!(event.payload, Some(TestEvent::Ping(2))));
 
     Ok(())
@@ -840,17 +850,22 @@ async fn undecodable_payload_is_delivered_with_decode_failure() -> anyhow::Resul
     assert!(matches!(events[1].payload, Some(TestEvent::Ping(0))));
     assert!(events[1].decode_failure.is_none());
 
-    // Raw listeners receive the poison event too — nothing is dropped from
-    // the stream and later events still arrive, in order.
+    // The raw stream delivers the poison event as its Err arm, in sequence
+    // position — the type forces every raw consumer to decide (`?` would
+    // fail loudly here) — and later events still arrive, in order.
     let first = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
         .await?
-        .ok_or_else(|| anyhow::anyhow!("listener stream ended"))?;
-    assert!(first.payload.is_none());
-    assert!(first.decode_failure.is_some());
+        .ok_or_else(|| anyhow::anyhow!("listener stream closed"))?;
+    let undecodable = first.expect_err("poison event must surface as the stream's Err arm");
+    assert_eq!(u64::from(undecodable.sequence), 1);
+    assert_eq!(
+        undecodable.failure.raw,
+        serde_json::json!({"module": "CoreParty", "id": 1})
+    );
 
     let second = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
         .await?
-        .ok_or_else(|| anyhow::anyhow!("listener stream ended"))?;
+        .ok_or_else(|| anyhow::anyhow!("listener stream closed"))??;
     assert!(matches!(second.payload, Some(TestEvent::Ping(0))));
     assert!(second.decode_failure.is_none());
 

--- a/tests/outbox.rs
+++ b/tests/outbox.rs
@@ -779,3 +779,80 @@ async fn delivers_events_notified_while_listen_connection_down() -> anyhow::Resu
 
     Ok(())
 }
+
+// Rows written into a shared database by a different event enum (e.g.
+// test-only module tags) must neither crash the reader nor be silently
+// dropped: the event is still delivered — in order, with `decode_failure`
+// carrying the raw payload and the serde error — and later events flow.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "module")]
+enum ForeignEvent {
+    CoreParty { id: u64 },
+}
+
+#[tokio::test]
+#[file_serial]
+async fn undecodable_payload_is_delivered_with_decode_failure() -> anyhow::Result<()> {
+    use obix::{MailboxTables as _, out::Outbox};
+
+    let pool = init_pool().await?;
+    helpers::wipeout_outbox_tables(&pool).await?;
+
+    let config = MailboxConfig::builder()
+        .build()
+        .expect("Couldn't build MailboxConfig");
+
+    // Publish via a foreign event enum, like tests sharing the database do.
+    let foreign = Outbox::<ForeignEvent, helpers::TestTables>::init(&pool, config.clone()).await?;
+    let mut op = pool.begin().await?;
+    foreign
+        .publish_persisted_in_op(&mut op, ForeignEvent::CoreParty { id: 1 })
+        .await?;
+    op.commit().await?;
+
+    let outbox = Outbox::<TestEvent, helpers::TestTables>::init(&pool, config).await?;
+    let mut listener = outbox.listen_persisted(Some(EventSequence::from(0)));
+
+    let mut op = pool.begin().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(0))
+        .await?;
+    op.commit().await?;
+
+    // The load path delivers the poison row with the raw JSON and the serde
+    // error attached, and the valid row intact.
+    let events =
+        helpers::TestTables::load_next_page::<TestEvent>(&pool, EventSequence::from(0), 10).await?;
+    assert_eq!(events.len(), 2);
+    assert!(events[0].payload.is_none());
+    let failure = events[0]
+        .decode_failure
+        .as_ref()
+        .expect("undecodable row must carry decode_failure");
+    assert_eq!(
+        failure.raw,
+        serde_json::json!({"module": "CoreParty", "id": 1})
+    );
+    assert!(
+        !failure.error.is_empty(),
+        "decode_failure must carry the serde error"
+    );
+    assert!(matches!(events[1].payload, Some(TestEvent::Ping(0))));
+    assert!(events[1].decode_failure.is_none());
+
+    // Raw listeners receive the poison event too — nothing is dropped from
+    // the stream and later events still arrive, in order.
+    let first = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("listener stream ended"))?;
+    assert!(first.payload.is_none());
+    assert!(first.decode_failure.is_some());
+
+    let second = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("listener stream ended"))?;
+    assert!(matches!(second.payload, Some(TestEvent::Ping(0))));
+    assert!(second.decode_failure.is_none());
+
+    Ok(())
+}

--- a/tests/outbox.rs
+++ b/tests/outbox.rs
@@ -792,7 +792,7 @@ async fn delivers_events_notified_while_listen_connection_down() -> anyhow::Resu
 
 // Rows written into a shared database by a different event enum (e.g.
 // test-only module tags) must neither crash the reader nor be silently
-// dropped: the event is still delivered — in order, with `decode_failure`
+// dropped: the event is still delivered — in order, as the `Err` item
 // carrying the raw payload and the serde error — and later events flow.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "module")]
@@ -802,7 +802,7 @@ enum ForeignEvent {
 
 #[tokio::test]
 #[file_serial]
-async fn undecodable_payload_is_delivered_with_decode_failure() -> anyhow::Result<()> {
+async fn undecodable_payload_is_delivered_as_err_item() -> anyhow::Result<()> {
     use obix::{MailboxTables as _, out::Outbox};
 
     let pool = init_pool().await?;
@@ -829,26 +829,26 @@ async fn undecodable_payload_is_delivered_with_decode_failure() -> anyhow::Resul
         .await?;
     op.commit().await?;
 
-    // The load path delivers the poison row with the raw JSON and the serde
-    // error attached, and the valid row intact.
+    // The load path delivers the poison row as its Err item — raw JSON and
+    // serde error attached, sequence position occupied — and the valid row
+    // intact.
     let events =
         helpers::TestTables::load_next_page::<TestEvent>(&pool, EventSequence::from(0), 10).await?;
     assert_eq!(events.len(), 2);
-    assert!(events[0].payload.is_none());
-    let failure = events[0]
-        .decode_failure
+    let poison = events[0]
         .as_ref()
-        .expect("undecodable row must carry decode_failure");
+        .expect_err("poison row must be the Err item");
+    assert_eq!(u64::from(poison.sequence), 1);
     assert_eq!(
-        failure.raw,
+        poison.failure.raw,
         serde_json::json!({"module": "CoreParty", "id": 1})
     );
     assert!(
-        !failure.error.is_empty(),
-        "decode_failure must carry the serde error"
+        !poison.failure.error.is_empty(),
+        "the Err item must carry the serde error"
     );
-    assert!(matches!(events[1].payload, Some(TestEvent::Ping(0))));
-    assert!(events[1].decode_failure.is_none());
+    let decoded = events[1].as_ref().expect("valid row must be the Ok item");
+    assert!(matches!(decoded.payload, Some(TestEvent::Ping(0))));
 
     // The raw stream delivers the poison event as its Err arm, in sequence
     // position — the type forces every raw consumer to decide (`?` would
@@ -867,7 +867,6 @@ async fn undecodable_payload_is_delivered_with_decode_failure() -> anyhow::Resul
         .await?
         .ok_or_else(|| anyhow::anyhow!("listener stream closed"))??;
     assert!(matches!(second.payload, Some(TestEvent::Ping(0))));
-    assert!(second.decode_failure.is_none());
 
     Ok(())
 }

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use obix::{
     EventCtx, EventSubscription, Handled, MailboxConfig, OutboxEventHandler, OutboxEventJobConfig,
-    out::Outbox,
+    UndecodableAction, out::Outbox,
 };
 use serde::{Deserialize, Serialize};
 use serial_test::file_serial;
@@ -38,6 +38,60 @@ impl OutboxEventHandler<TestEvent> for SkippingObserver {
             self.received.lock().await.push(*n);
         }
         Ok(ctx.skip())
+    }
+}
+
+/// A different event enum sharing the same physical table — publishing
+/// through it plants a row the `TestEvent` consumers cannot decode.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "module")]
+enum ForeignEvent {
+    CoreParty { id: u64 },
+}
+
+async fn publish_foreign_poison(pool: &sqlx::PgPool) -> anyhow::Result<()> {
+    let foreign = Outbox::<ForeignEvent, TestTables>::init(
+        pool,
+        MailboxConfig::builder()
+            .build()
+            .expect("Couldn't build MailboxConfig"),
+    )
+    .await?;
+    let mut op = pool.begin().await?;
+    foreign
+        .publish_persisted_in_op(&mut op, ForeignEvent::CoreParty { id: 1 })
+        .await?;
+    op.commit().await?;
+    Ok(())
+}
+
+/// Overrides `on_undecodable` to explicitly acknowledge undecodable events,
+/// recording their sequences.
+struct AckingObserver {
+    received: Arc<Mutex<Vec<u64>>>,
+    acked: Arc<Mutex<Vec<u64>>>,
+}
+
+impl OutboxEventHandler<TestEvent> for AckingObserver {
+    type Batch = ();
+
+    async fn handle_persistent<'inv>(
+        &self,
+        ctx: EventCtx<'inv>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(TestEvent::Ping(n)) = &event.payload {
+            self.received.lock().await.push(*n);
+        }
+        Ok(ctx.skip())
+    }
+
+    async fn on_undecodable(
+        &self,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> UndecodableAction {
+        self.acked.lock().await.push(u64::from(event.sequence));
+        UndecodableAction::Ack
     }
 }
 
@@ -1684,6 +1738,166 @@ async fn ephemeral_only_handler_skips_checkpoint_machinery() -> anyhow::Result<(
         None,
         "EphemeralOnly job must never write execution state"
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn undecodable_event_fails_job_and_resumes_after_fix() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    // Phase 1: Ping(1) at seq 1, an undecodable foreign event at seq 2,
+    // Ping(2) at seq 3. The default policy treats the poison event as a
+    // runtime bug: the job fails with its checkpoint parked at seq 1 —
+    // Ping(2) must NOT be delivered and nothing is ever skipped.
+    let received = Arc::new(Mutex::new(Vec::new()));
+    {
+        let job_config = job::JobSvcConfig::builder()
+            .pool(pool.clone())
+            .build()
+            .unwrap();
+        let mut jobs = job::Jobs::init(job_config).await?;
+
+        let config = OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE))
+            .with_retry_settings(fast_retry_settings())
+            .with_checkpoint_interval(std::time::Duration::from_millis(100));
+        let outbox = init_outbox_with_handler_config(
+            &pool,
+            &mut jobs,
+            config,
+            SkippingObserver {
+                received: received.clone(),
+            },
+        )
+        .await?;
+
+        let mut op = outbox.begin_op().await?;
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+            .await?;
+        op.commit().await?;
+
+        publish_foreign_poison(&pool).await?;
+
+        let mut op = outbox.begin_op().await?;
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(2))
+            .await?;
+        op.commit().await?;
+
+        jobs.start_poll().await?;
+
+        // The checkpoint is persisted at seq 1 before the job errors, then
+        // every retry re-reads the poison event and fails again: the
+        // checkpoint stays parked and Ping(2) stays undelivered.
+        wait_for_checkpoint(&pool, 1).await?;
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        assert_eq!(*received.lock().await, vec![1]);
+        assert_eq!(checkpoint_sequence(&pool).await?, Some(1));
+
+        jobs.shutdown().await?;
+    }
+
+    // Phase 2: operator remediation — NULL the poison payload (an explicit,
+    // auditable act that turns the row into an ordinary sequence
+    // placeholder) and restart the consumer. The pipeline resumes exactly
+    // where it parked: nothing before the poison event replays, nothing
+    // after it was lost.
+    sqlx::query("UPDATE persistent_outbox_events SET payload = NULL WHERE sequence = 2")
+        .execute(&pool)
+        .await?;
+
+    let received_after = Arc::new(Mutex::new(Vec::new()));
+    {
+        let job_config = job::JobSvcConfig::builder()
+            .pool(pool.clone())
+            .build()
+            .unwrap();
+        let mut jobs = job::Jobs::init(job_config).await?;
+
+        let outbox = Outbox::<TestEvent, TestTables>::init(
+            &pool,
+            MailboxConfig::builder()
+                .build()
+                .expect("Couldn't build MailboxConfig"),
+        )
+        .await?;
+        outbox
+            .register_event_handler(
+                &mut jobs,
+                OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE))
+                    .with_retry_settings(fast_retry_settings())
+                    .with_checkpoint_interval(std::time::Duration::from_millis(100)),
+                SkippingObserver {
+                    received: received_after.clone(),
+                },
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        jobs.start_poll().await?;
+
+        wait_for_n_deliveries(&received_after, 1, std::time::Duration::from_secs(5)).await?;
+        assert_eq!(*received_after.lock().await, vec![2]);
+        wait_for_checkpoint(&pool, 3).await?;
+
+        jobs.shutdown().await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[file_serial]
+async fn on_undecodable_ack_moves_past_poison_event() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    let mut jobs = job::Jobs::init(job_config).await?;
+
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let acked = Arc::new(Mutex::new(Vec::new()));
+    let config = OutboxEventJobConfig::new(job::JobType::new(JOB_TYPE))
+        .with_checkpoint_interval(std::time::Duration::from_millis(100));
+    let outbox = init_outbox_with_handler_config(
+        &pool,
+        &mut jobs,
+        config,
+        AckingObserver {
+            received: received.clone(),
+            acked: acked.clone(),
+        },
+    )
+    .await?;
+
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(1))
+        .await?;
+    op.commit().await?;
+
+    publish_foreign_poison(&pool).await?;
+
+    let mut op = outbox.begin_op().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(2))
+        .await?;
+    op.commit().await?;
+
+    jobs.start_poll().await?;
+
+    // The explicit ack is consulted instead of handle_persistent, and the
+    // pipeline moves past the poison event without failing the job.
+    wait_for_n_deliveries(&received, 2, std::time::Duration::from_secs(5)).await?;
+    assert_eq!(*received.lock().await, vec![1, 2]);
+    assert_eq!(*acked.lock().await, vec![2]);
+    wait_for_checkpoint(&pool, 3).await?;
+
+    jobs.shutdown().await?;
 
     Ok(())
 }

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use obix::{
     EventCtx, EventSubscription, Handled, MailboxConfig, OutboxEventHandler, OutboxEventJobConfig,
-    UndecodableAction, out::Outbox,
+    out::Outbox,
 };
 use serde::{Deserialize, Serialize};
 use serial_test::file_serial;
@@ -65,8 +65,9 @@ async fn publish_foreign_poison(pool: &sqlx::PgPool) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Overrides `on_undecodable` to explicitly acknowledge undecodable events,
-/// recording their sequences.
+/// Overrides `handle_undecodable` to explicitly acknowledge undecodable
+/// events (returning `Ok` instead of the default error), recording their
+/// sequences.
 struct AckingObserver {
     received: Arc<Mutex<Vec<u64>>>,
     acked: Arc<Mutex<Vec<u64>>>,
@@ -86,12 +87,12 @@ impl OutboxEventHandler<TestEvent> for AckingObserver {
         Ok(ctx.skip())
     }
 
-    async fn on_undecodable(
+    async fn handle_undecodable(
         &self,
         event: &obix::out::PersistentOutboxEvent<TestEvent>,
-    ) -> UndecodableAction {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.acked.lock().await.push(u64::from(event.sequence));
-        UndecodableAction::Ack
+        Ok(())
     }
 }
 
@@ -1850,7 +1851,7 @@ async fn undecodable_event_fails_job_and_resumes_after_fix() -> anyhow::Result<(
 
 #[tokio::test]
 #[file_serial]
-async fn on_undecodable_ack_moves_past_poison_event() -> anyhow::Result<()> {
+async fn handle_undecodable_ok_moves_past_poison_event() -> anyhow::Result<()> {
     let pool = init_pool().await?;
 
     let job_config = job::JobSvcConfig::builder()
@@ -1890,8 +1891,8 @@ async fn on_undecodable_ack_moves_past_poison_event() -> anyhow::Result<()> {
 
     jobs.start_poll().await?;
 
-    // The explicit ack is consulted instead of handle_persistent, and the
-    // pipeline moves past the poison event without failing the job.
+    // handle_undecodable is invoked instead of handle_persistent; its Ok
+    // moves the pipeline past the poison event without failing the job.
     wait_for_n_deliveries(&received, 2, std::time::Duration::from_secs(5)).await?;
     assert_eq!(*received.lock().await, vec![1, 2]);
     assert_eq!(*acked.lock().await, vec![2]);

--- a/tests/outbox_event_handler.rs
+++ b/tests/outbox_event_handler.rs
@@ -66,8 +66,8 @@ async fn publish_foreign_poison(pool: &sqlx::PgPool) -> anyhow::Result<()> {
 }
 
 /// Overrides `handle_undecodable` to explicitly acknowledge undecodable
-/// events (returning `Ok` instead of the default error), recording their
-/// sequences.
+/// events (returning `Ok` instead of failing with the error), recording
+/// their sequences.
 struct AckingObserver {
     received: Arc<Mutex<Vec<u64>>>,
     acked: Arc<Mutex<Vec<u64>>>,
@@ -89,9 +89,9 @@ impl OutboxEventHandler<TestEvent> for AckingObserver {
 
     async fn handle_undecodable(
         &self,
-        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+        error: &obix::UndecodableEventError,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        self.acked.lock().await.push(u64::from(event.sequence));
+        self.acked.lock().await.push(u64::from(error.sequence));
         Ok(())
     }
 }

--- a/tests/post_persist_hook.rs
+++ b/tests/post_persist_hook.rs
@@ -567,7 +567,7 @@ async fn reposted_events_reach_destination_listener() -> anyhow::Result<()> {
 
     let deadline = std::time::Duration::from_secs(5);
     let received = tokio::time::timeout(deadline, async {
-        while let Some(event) = listener.next().await {
+        while let Some(Ok(event)) = listener.next().await {
             if event.payload == Some(DestEvent::Mapped(9)) {
                 return true;
             }


### PR DESCRIPTION
Supersedes #103 with the design discussed there: an undecodable payload must not panic (the observed hot panic/retry loop: ~100% CPU, 26 GB of logs in 30 min from one poison row) — but it must not be silently skipped either. Part of the obix contract is that **every listener receives every event, in order**; a payload the consumer cannot decode is a runtime bug that has to surface, not pass by — on **every** consumption path, including raw streams.

## Design: `Result` end-to-end

A decode error is discovered inside shared infrastructure (the cache-fill/backfill tasks), not in any consumer's call stack — so the failure is materialized as the **`Err` arm of one sum type, `UndecodableEventError`, spoken at every layer**. `PersistentOutboxEvent` itself is **unchanged** (`payload: None` still means exactly "placeholder — nothing at this sequence"); an undecodable payload never masquerades as an event:

1. **Load layer (breaking)** — the `MailboxTables` load paths return delivery items instead of `.expect()`-panicking:

   ```rust
   load_next_page / load_events_in_range
       -> Vec<Result<PersistentOutboxEvent<P>, UndecodableEventError>>
   // UndecodableEventError { id, sequence, recorded_at, failure: DecodeFailure { raw, error } }
   ```

   An `Err` item still occupies its sequence position, so pages stay contiguous and the cache/broadcast/gap-fill machinery carries both arms alike (internally as an `Arc`-ed `Result` so broadcast fan-out stays cheap).

2. **Delivery layer (breaking)** — the listener streams yield the same sum:

   ```rust
   PersistentOutboxListener<P>: Stream<Item = Result<Arc<PersistentOutboxEvent<P>>, UndecodableEventError>>
   AllOutboxListener<P>:        Stream<Item = Result<OutboxEvent<P>, UndecodableEventError>>
   ```

   The `Err` item IS the delivery of that event, in order. **No raw consumer can pass over it without an explicit decision**: the natural consumption pattern (`TryStreamExt::try_next` + `?`) fails loudly, and tolerating poison requires a visible `Err` match arm. `UndecodableEventError` is non-generic, `Clone`, implements `Error`; `Display` prints the serde error only (the raw payload never hits log lines by accident). Ephemeral streams are unchanged (best-effort last-value by design). Placeholders (gap rows / NULLed payloads) remain ordinary `Ok` items with `payload: None` — they are legitimately "nothing at this sequence", not errors.

3. **Policy layer** — an undecodable event never reaches `handle_persistent` (now guaranteed by the *type*, not convention). The runner routes the `Err` arm to the new overridable `OutboxEventHandler::handle_undecodable(&UndecodableEventError) -> Result<(), _>`. The default fails with the error as-is: pending batch lands, checkpoint persists at the sequence *before* the event, job errors — the retry machinery (configured `RetrySettings` backoff) re-reads the row on every attempt, so **deploying a consumer that understands the payload resumes the pipeline automatically, in order, with nothing skipped**. Overriding and returning `Ok(())` acknowledges the event explicitly (record `error.failure` durably first); an override can also fail with its own contextual error and keep the park-before-the-event semantics.

**Operator runbook**: `UPDATE persistent_outbox_events SET payload = NULL WHERE sequence = N` turns the poison row into an ordinary placeholder — the pre-existing, contract-sanctioned "nothing to process at this sequence" representation. Quarantine needs no new machinery. (Pair with a consumer restart: the in-process cache holds the loaded event, so a DB-side fix heals a running consumer only after restart.)

Also in the derive (salvaged from #103's uncontroversial parts): an undecodable **ephemeral** payload is dropped with an error span, and a broken **tracing-context** envelope degrades to no context. Each decode failure records an `obix.tables.*_undecodable` error span (`otel.status_code = ERROR`). Serialization-side `expect`s are unchanged (a write failure is the publisher's own bug).

## Versioning

The stream item types and `MailboxTables` load signatures are **breaking** → minor bump (**0.5.0**), marked via `feat!`. That is deliberate: every raw `listen_persisted` / `listen_all` site downstream gets a compiler-forced audit, which is exactly the guarantee this change exists to provide. `PersistentOutboxEvent` and the publish-side APIs are untouched.

Migration for raw consumers:

```rust
// fail-loud (recommended default):
use futures::TryStreamExt;
while let Some(event) = listener.try_next().await? { ... }

// explicit tolerance:
while let Some(item) = listener.next().await {
    match item {
        Ok(event) => { ... }
        Err(undecodable) => { /* visible, deliberate decision */ }
    }
}
```

## Tests

- `undecodable_payload_is_delivered_as_err_item` — `load_next_page` returns the poison row as its `Err` item (raw JSON + serde error, sequence position occupied) and the valid row intact; the raw stream yields the poison event as its `Err` arm in sequence position, then keeps flowing in order.
- `undecodable_event_fails_job_and_resumes_after_fix` — end-to-end of the default policy and the operator runbook: the handler job fails at the poison event with its checkpoint parked at N−1 (events after it stay undelivered — nothing is skipped past); after `payload := NULL` + consumer restart, the pipeline resumes exactly where it parked, replaying nothing and losing nothing.
- `handle_undecodable_ok_moves_past_poison_event` — the override is invoked with the `UndecodableEventError`; its `Ok` advances the checkpoint over the poison event without failing the job.

Full suite green via `cargo nextest run`; `nix flake check` (fmt, clippy `--all-features -D warnings`, audit, deny) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking changes to core outbox load and listener APIs plus checkpoint/job behavior on decode failures affect every persistent consumer and can stall pipelines until remediation or an explicit override.
> 
> **Overview**
> Poison persistent rows no longer **panic** on JSON deserialize during load/cache/backfill. They are delivered **in sequence** as `Err(UndecodableEventError)` (raw payload + serde message), while gap/NULL placeholders stay `Ok` with `payload: None`.
> 
> **Breaking:** `MailboxTables::load_next_page` / `load_events_in_range` and `PersistentOutboxListener` / `AllOutboxListener` streams now use `Result` items end-to-end (via shared `decode_persistent_event` and internal `PersistentDelivery` broadcast plumbing). Raw consumers must use `try_next`/`?` or an explicit `Err` match.
> 
> Handler jobs route decode failures to new **`OutboxEventHandler::handle_undecodable`**: default **fails** the job with checkpoint parked before the bad sequence (retries re-read the row); **`Ok(())`** advances like a skip after flushing any pending batch. Ephemeral bad payloads are dropped with error spans; bad tracing context is cleared instead of panicking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 621af8f5251fec38036b85c11948551acb7ca604. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->