### PR TITLE
fix: stop trusting pg_notify payloads — notifications are hints, not transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Implementation of the outbox pattern backed by PostgreSQL and [sqlx](https://doc
 - Persistent events stored in PostgreSQL with sequential ordering
 - Ephemeral events for transient state updates
 - Real-time event delivery via PostgreSQL NOTIFY/LISTEN
+- Database-verified delivery: notifications carry only hints (sequence ranges / event type + timestamp), never payloads — a forged or snooped `pg_notify` can neither inject events nor leak payloads
 - Event caching for efficient replay and new listener catchup
 - Automatic backfill from database for events not in cache
 - Large payload handling with automatic database fallback

--- a/migrations/20251204130225_obix_setup.sql
+++ b/migrations/20251204130225_obix_setup.sql
@@ -38,23 +38,20 @@ CREATE TABLE ephemeral_outbox_events (
   recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- SECURITY: the ephemeral notification is a hint, not a transport.
+--
+-- PostgreSQL performs no authorization on LISTEN/NOTIFY channels: any role
+-- able to connect to the database could LISTEN and harvest payloads with no
+-- table grant, or pg_notify a forged event consumers would accept. The
+-- notification therefore carries only {event_type, recorded_at}; listeners
+-- always fetch the payload from the table with their own credentials
+-- (recorded_at lets them skip the fetch when their cache is already current).
 CREATE FUNCTION notify_ephemeral_outbox_events() RETURNS TRIGGER AS $$
-DECLARE
-  payload TEXT;
-  payload_size INTEGER;
 BEGIN
-  payload := row_to_json(NEW);
-  payload_size := octet_length(payload);
-  IF payload_size > 8000 THEN
-    payload := json_build_object(
-      'event_type', NEW.event_type,
-      'payload', NULL,
-      'payload_omitted', true,
-      'tracing_context', NEW.tracing_context,
-      'recorded_at', NEW.recorded_at
-    )::TEXT;
-  END IF;
-  PERFORM pg_notify('ephemeral_outbox_events', payload);
+  PERFORM pg_notify(
+    'ephemeral_outbox_events',
+    json_build_object('event_type', NEW.event_type, 'recorded_at', NEW.recorded_at)::TEXT
+  );
   RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;

--- a/obix-macros/src/tables.rs
+++ b/obix-macros/src/tables.rs
@@ -18,7 +18,41 @@ fn default_crate_name() -> syn::LitStr {
 
 pub fn derive(ast: syn::DeriveInput) -> darling::Result<proc_macro2::TokenStream> {
     let tables = MailboxTables::from_derive_input(&ast)?;
+    tables.validate_prefix()?;
     Ok(quote!(#tables))
+}
+
+impl MailboxTables {
+    /// The prefix is interpolated verbatim into SQL identifiers (table,
+    /// sequence and channel names) and into the `pg_notify('<channel>', ...)`
+    /// string literal of the generated persist query. Restricting it to a
+    /// plain identifier charset makes SQL injection through the derive
+    /// attribute unrepresentable; the length bound keeps the longest derived
+    /// name — `{prefix}_persistent_outbox_events_sequence_seq`, i.e.
+    /// prefix + 38 bytes — inside PostgreSQL's 63-byte identifier limit.
+    fn validate_prefix(&self) -> darling::Result<()> {
+        let Some(prefix) = &self.prefix else {
+            return Ok(());
+        };
+        let value = prefix.value();
+        let valid = !value.is_empty()
+            && value.len() <= 25
+            && value
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+            && value.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+        if valid {
+            Ok(())
+        } else {
+            Err(darling::Error::custom(format!(
+                "invalid obix tbl_prefix `{value}`: must be 1-25 characters, start with an \
+                 ASCII letter or underscore, and contain only ASCII letters, digits and \
+                 underscores (it is interpolated into generated SQL identifiers)"
+            ))
+            .with_span(prefix))
+        }
+    }
 }
 
 impl ToTokens for MailboxTables {
@@ -530,9 +564,15 @@ FROM {}persistent_outbox_events_sequence_seq",
                                         return None;
                                     }
                                 };
-                                let event_type = #crate_name::prelude::serde_json::from_value(
-                                    #crate_name::prelude::serde_json::Value::String(event_type_str)
-                                ).expect("Couldn't deserialize event_type");
+                                let event_type = match #crate_name::prelude::serde_json::from_value(
+                                    #crate_name::prelude::serde_json::Value::String(event_type_str.clone())
+                                ) {
+                                    Ok(event_type) => event_type,
+                                    Err(error) => {
+                                        #crate_name::record_ephemeral_event_type_undecodable(&error, &event_type_str);
+                                        return None;
+                                    }
+                                };
 
                                 let row = {
                                     struct TempRow {
@@ -606,7 +646,7 @@ FROM {}persistent_outbox_events_sequence_seq",
                         .ok_or(#crate_name::inbox::InboxError::NotFound(id))?;
 
                         let status: #crate_name::inbox::InboxEventStatus = row.status.parse()
-                            .expect("Invalid inbox event status in database");
+                            .map_err(#crate_name::inbox::InboxError::InvalidStatus)?;
 
                         Ok(#crate_name::inbox::InboxEvent {
                             id: #crate_name::inbox::InboxEventId::from(row.id),
@@ -641,9 +681,9 @@ FROM {}persistent_outbox_events_sequence_seq",
                             .into_iter()
                             .map(|row| {
                                 let status: #crate_name::inbox::InboxEventStatus = row.status.parse()
-                                    .expect("Invalid inbox event status in database");
+                                    .map_err(#crate_name::inbox::InboxError::InvalidStatus)?;
 
-                                #crate_name::inbox::InboxEvent {
+                                Ok(#crate_name::inbox::InboxEvent {
                                     id: #crate_name::inbox::InboxEventId::from(row.id),
                                     idempotency_key: row.idempotency_key,
                                     payload: row.payload,
@@ -651,9 +691,9 @@ FROM {}persistent_outbox_events_sequence_seq",
                                     error: row.error,
                                     recorded_at: row.recorded_at,
                                     processed_at: row.processed_at,
-                                }
+                                })
                             })
-                            .collect();
+                            .collect::<Result<Vec<_>, #crate_name::inbox::InboxError>>()?;
 
                         Ok(events)
                     }

--- a/src/inbox/error.rs
+++ b/src/inbox/error.rs
@@ -8,6 +8,8 @@ pub enum InboxError {
     Job(#[from] job::error::JobError),
     #[error("InboxError - NotFound: {0}")]
     NotFound(super::InboxEventId),
+    #[error("InboxError - InvalidStatus: {0}")]
+    InvalidStatus(String),
     #[error("InboxError - Deserialization: {0}")]
     Deserialization(#[from] serde_json::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,6 @@ pub use sequence::EventSequence;
 pub use tables::MailboxTables;
 #[doc(hidden)]
 pub use tables::{
-    decode_persistent_event, record_ephemeral_payload_undecodable,
-    record_tracing_context_undecodable,
+    decode_persistent_event, record_ephemeral_event_type_undecodable,
+    record_ephemeral_payload_undecodable, record_tracing_context_undecodable,
 };

--- a/src/out/ephemeral/cache.rs
+++ b/src/out/ephemeral/cache.rs
@@ -103,6 +103,14 @@ where
         event: Arc<EphemeralOutboxEvent<P>>,
         ephemeral_event_sender: &broadcast::Sender<Arc<EphemeralOutboxEvent<P>>>,
     ) -> im::HashMap<EphemeralEventType, Arc<EphemeralOutboxEvent<P>>> {
+        // Last-write-wins by recorded_at: notification-triggered fetches for
+        // the same event type can complete out of order — a strictly older
+        // event must never overwrite (or be broadcast after) a newer one.
+        if let Some(cached) = cache.get(&event.event_type)
+            && cached.recorded_at > event.recorded_at
+        {
+            return cache;
+        }
         let event_type = event.event_type.clone();
         let cache = cache.update(event_type, event.clone());
         let _ = ephemeral_event_sender.send(event);
@@ -121,51 +129,50 @@ where
         }
     }
 
+    /// Handle a `{event_type, recorded_at}` notification hint.
+    ///
+    /// The payload is NEVER taken from the notification body. PostgreSQL
+    /// performs no authorization on LISTEN/NOTIFY channels — any role able
+    /// to connect to this database can signal any channel — so a
+    /// notification is only ever a hint that something changed; the event
+    /// itself is always (re-)fetched from the table with this process's own
+    /// credentials. `recorded_at` bounds that fetch: when the in-process
+    /// cache already holds an event at least as recent (the publisher's
+    /// post-commit broadcast beat the NOTIFY), the hint is a no-op.
     fn handle_ephemeral_notification(
-        pool: &sqlx::PgPool,
         payload: &str,
         cache: &im::HashMap<EphemeralEventType, Arc<EphemeralOutboxEvent<P>>>,
-        cache_fill_sender: &broadcast::Sender<Arc<EphemeralOutboxEvent<P>>>,
-    ) -> Option<EphemeralOutboxEvent<P>> {
+    ) -> Option<EphemeralEventType> {
         #[derive(serde::Deserialize)]
         struct NotificationHeader {
-            event_type: String,
-            #[serde(default)]
-            payload_omitted: bool,
+            event_type: EphemeralEventType,
+            recorded_at: chrono::DateTime<chrono::Utc>,
         }
 
-        let header: NotificationHeader = serde_json::from_str(payload).ok()?;
-        let event_type = serde_json::from_value(serde_json::Value::String(header.event_type))
-            .expect("Couldn't deserialize event_type");
-
-        if header.payload_omitted {
-            if cache.contains_key(&event_type) {
+        let header: NotificationHeader = match serde_json::from_str(payload) {
+            Ok(header) => header,
+            Err(error) => {
+                record_notification_undecodable(&error);
                 return None;
             }
-            tokio::spawn(Self::fetch_event_by_type(
-                pool.clone(),
-                event_type,
-                cache_fill_sender.clone(),
-            ));
+        };
+
+        let cache_is_current = cache
+            .get(&header.event_type)
+            .is_some_and(|cached| cached.recorded_at >= header.recorded_at);
+        if cache_is_current {
             None
         } else {
-            serde_json::from_str(payload).ok()
+            Some(header.event_type)
         }
     }
 
     fn process_notification(
         notification: sqlx::postgres::PgNotification,
-        pool: &sqlx::PgPool,
         cache: &im::HashMap<EphemeralEventType, Arc<EphemeralOutboxEvent<P>>>,
-        cache_fill_sender: &broadcast::Sender<Arc<EphemeralOutboxEvent<P>>>,
-    ) -> Option<EphemeralOutboxEvent<P>> {
+    ) -> Option<EphemeralEventType> {
         if notification.channel() == Tables::ephemeral_outbox_events_channel() {
-            Self::handle_ephemeral_notification(
-                pool,
-                notification.payload(),
-                cache,
-                cache_fill_sender,
-            )
+            Self::handle_ephemeral_notification(notification.payload(), cache)
         } else {
             None
         }
@@ -242,26 +249,39 @@ where
                                 while let Ok(message) = ephemeral_notification_rx.try_recv() {
                                     messages.push(message);
                                 }
+                                // Collect the unique event types that need a
+                                // fetch. A burst of N notifications for the
+                                // same type is drained against one cache
+                                // snapshot (fetches are async, the cache is
+                                // unchanged during the drain), so deduping
+                                // here collapses them into a single fetch
+                                // rather than N redundant broadcasts of the
+                                // same latest event.
+                                let mut types_to_fetch =
+                                    std::collections::HashSet::<EphemeralEventType>::new();
                                 for message in messages {
                                     match message {
                                         NotifyMessage::Notification(notification) => {
-                                            if let Some(event) = Self::process_notification(
-                                                notification,
-                                                &pool,
-                                                &ephemeral_cache,
-                                                &cache_fill_sender,
-                                            ) {
-                                                ephemeral_cache = Self::insert_into_cache_and_broadcast(
-                                                    ephemeral_cache,
-                                                    Arc::new(event),
-                                                    &ephemeral_event_sender,
-                                                );
+                                            if let Some(event_type) =
+                                                Self::process_notification(
+                                                    notification,
+                                                    &ephemeral_cache,
+                                                )
+                                            {
+                                                types_to_fetch.insert(event_type);
                                             }
                                         }
                                         NotifyMessage::Resync => {
                                             resync_needed = true;
                                         }
                                     }
+                                }
+                                for event_type in types_to_fetch {
+                                    tokio::spawn(Self::fetch_event_by_type(
+                                        pool.clone(),
+                                        event_type,
+                                        cache_fill_sender.clone(),
+                                    ));
                                 }
 
                                 if resync_needed {
@@ -335,3 +355,11 @@ fn record_notification_channel_closed() {}
     fields(otel.status_code = "ERROR", error = %error),
 )]
 fn record_resync_failed(error: &sqlx::Error) {}
+
+#[tracing::instrument(
+    name = "obix.ephemeral_cache.notification_undecodable",
+    level = "warn",
+    skip_all,
+    fields(error = %error),
+)]
+fn record_notification_undecodable(error: &serde_json::Error) {}

--- a/src/out/persistent/cache.rs
+++ b/src/out/persistent/cache.rs
@@ -458,6 +458,7 @@ where
                             Some(message) => {
                                 let mut resync_needed = false;
                                 let mut fetch_range: Option<(EventSequence, EventSequence)> = None;
+                                let mut claimed_head: Option<EventSequence> = None;
                                 let mut messages = vec![message];
                                 while let Ok(message) = notification_receiver.try_recv() {
                                     messages.push(message);
@@ -469,10 +470,13 @@ where
                                                 notification.payload(),
                                                 &persistent_cache,
                                             ) {
-                                                highest_known_sequence.fetch_max(
-                                                    u64::from(notified.max_sequence),
-                                                    Ordering::AcqRel,
-                                                );
+                                                // NOT applied to
+                                                // highest_known_sequence yet —
+                                                // see the clamp below.
+                                                claimed_head = Some(match claimed_head {
+                                                    Some(max) => max.max(notified.max_sequence),
+                                                    None => notified.max_sequence,
+                                                });
                                                 if let Some((after, up_to)) = notified.missing {
                                                     fetch_range = Some(match fetch_range {
                                                         Some((lo, hi)) => {
@@ -489,22 +493,66 @@ where
                                     }
                                 }
 
-                                if let Some((after, up_to)) = fetch_range {
-                                    tokio::spawn(Self::fetch_notified_range(
-                                        pool.clone(),
-                                        after,
-                                        up_to,
-                                        cache_fill_sender.clone(),
-                                    ));
-                                }
-
-                                if resync_needed {
+                                // A NOTIFY payload is unauthenticated: any role able to
+                                // connect to this database can signal any channel. A
+                                // forged {min, max} claiming a huge max_sequence must
+                                // neither advance highest_known_sequence to a phantom
+                                // value (which would pin the gap-fill loop below,
+                                // grinding a fill query every second forever) NOR drive
+                                // an unbounded range scan — the same forged
+                                // {min:1, max:i64::MAX} would otherwise spawn a
+                                // fetch_notified_range(0, i64::MAX) streaming the
+                                // entire table tail through cache_fill on every forgery.
+                                //
+                                // Both the head advance and the fetch up_to are clamped
+                                // to the sequence's authoritative last_value, which is
+                                // >= any legitimately notified sequence (so free for
+                                // real notifications, protective for forged ones).
+                                //
+                                // last_value advances at nextval (pre-commit), so a
+                                // forged claim inside (committed_head, last_value]
+                                // still passes the clamp and can trigger a grace-period
+                                // gap-fill against in-flight sequences — but that work
+                                // is bounded by last_value and self-heals via the
+                                // ON CONFLICT speculative-insert block, so it never
+                                // stalls. On a transient head-read failure the fetch is
+                                // skipped (rather than fired unclamped); a subsequent
+                                // notification or resync retries.
+                                let current_head =
+                                    highest_known_sequence.load(Ordering::Relaxed);
+                                let claim_advances = claimed_head
+                                    .is_some_and(|claimed| u64::from(claimed) > current_head);
+                                if claim_advances || resync_needed || fetch_range.is_some() {
                                     match Tables::highest_known_persistent_sequence(&pool).await {
                                         Ok(head) => {
+                                            let confirmed_head = claimed_head
+                                                .map(|claimed| {
+                                                    EventSequence::from(
+                                                        u64::from(claimed)
+                                                            .min(u64::from(head)),
+                                                    )
+                                                })
+                                                .unwrap_or(head);
                                             highest_known_sequence.fetch_max(
-                                                u64::from(head),
+                                                u64::from(confirmed_head),
                                                 Ordering::AcqRel,
                                             );
+                                            if let Some((after, up_to)) = fetch_range {
+                                                let clamped_up_to = EventSequence::from(
+                                                    u64::from(up_to)
+                                                        .min(u64::from(confirmed_head)),
+                                                );
+                                                if u64::from(after)
+                                                    < u64::from(clamped_up_to)
+                                                {
+                                                    tokio::spawn(Self::fetch_notified_range(
+                                                        pool.clone(),
+                                                        after,
+                                                        clamped_up_to,
+                                                        cache_fill_sender.clone(),
+                                                    ));
+                                                }
+                                            }
                                         }
                                         Err(e) => record_resync_failed(&e),
                                     }

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -87,6 +87,18 @@ fn record_persistent_payload_undecodable(error: &serde_json::Error, sequence: u6
 )]
 pub fn record_ephemeral_payload_undecodable(error: &serde_json::Error, event_type: &str) {}
 
+/// Invoked from `MailboxTables` derive output when a stored ephemeral row's
+/// `event_type` cannot be deserialized (schema drift or foreign rows); the
+/// event is dropped from the result, like an undecodable payload.
+#[doc(hidden)]
+#[tracing::instrument(
+    name = "obix.tables.ephemeral_event_type_undecodable",
+    level = "error",
+    skip_all,
+    fields(otel.status_code = "ERROR", error = %error, event_type = %event_type)
+)]
+pub fn record_ephemeral_event_type_undecodable(error: &serde_json::Error, event_type: &str) {}
+
 /// Invoked from `MailboxTables` derive output when the tracing-context
 /// envelope cannot be deserialized; the event is kept with no context
 /// attached (the context is delivery metadata, not payload data).

--- a/tests/outbox.rs
+++ b/tests/outbox.rs
@@ -708,6 +708,171 @@ async fn ephemeral_events_replace_same_type() -> anyhow::Result<()> {
     Ok(())
 }
 
+// SECURITY regression: a forged pg_notify on the ephemeral channel must not
+// inject events. LISTEN/NOTIFY has no per-channel authorization in
+// PostgreSQL — any role able to connect can signal any channel — so the
+// notification is only a hint; the event must come from the table (and a
+// forged hint with no matching row must yield nothing).
+#[tokio::test]
+#[file_serial]
+async fn forged_ephemeral_notification_is_not_delivered() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let outbox = init_outbox::<TestEvent>(
+        &pool,
+        MailboxConfig::builder()
+            .build()
+            .expect("Couldn't build MailboxConfig"),
+    )
+    .await?;
+
+    let mut listener = outbox.listen_ephemeral();
+
+    // Fully-formed forged event, as the pre-fix listener would have accepted
+    // and broadcast directly from the notification body.
+    sqlx::query("SELECT pg_notify('ephemeral_outbox_events', $1)")
+        .bind(
+            serde_json::json!({
+                "event_type": "forged_type",
+                "payload": {"Ping": 999},
+                "tracing_context": null,
+                "recorded_at": chrono::Utc::now(),
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await?;
+
+    // Nothing may arrive: the hint references no row in the table.
+    let forged = tokio::time::timeout(std::time::Duration::from_millis(500), listener.next()).await;
+    assert!(
+        forged.is_err(),
+        "forged ephemeral notification must not be delivered, got {forged:?}"
+    );
+
+    // The listener is still alive: a legitimately published event arrives.
+    let event_type = obix::out::EphemeralEventType::new("legit_type");
+    outbox
+        .publish_ephemeral(event_type.clone(), TestEvent::Ping(1))
+        .await?;
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
+        .await?
+        .expect("listener must still deliver legitimate events");
+    assert_eq!(event.event_type, event_type);
+    assert!(matches!(event.payload, TestEvent::Ping(1)));
+
+    Ok(())
+}
+
+// An ephemeral event written by another process (straight SQL insert,
+// bypassing this process's in-process publish broadcast) must still reach
+// listeners: the trigger's {event_type, recorded_at} hint triggers a
+// fetch from the table with the listener's own credentials.
+#[tokio::test]
+#[file_serial]
+async fn ephemeral_event_written_externally_is_fetched_from_db() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let outbox = init_outbox::<TestEvent>(
+        &pool,
+        MailboxConfig::builder()
+            .build()
+            .expect("Couldn't build MailboxConfig"),
+    )
+    .await?;
+
+    let mut listener = outbox.listen_ephemeral();
+
+    sqlx::query("INSERT INTO ephemeral_outbox_events (event_type, payload) VALUES ($1, $2)")
+        .bind("external_type")
+        .bind(serde_json::json!({"Ping": 7}))
+        .execute(&pool)
+        .await?;
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
+        .await?
+        .expect("externally written ephemeral event must be delivered via the hint + fetch path");
+    assert_eq!(event.event_type.as_str(), "external_type");
+    assert!(matches!(event.payload, TestEvent::Ping(7)));
+
+    Ok(())
+}
+
+// SECURITY regression: a forged {min_sequence, max_sequence} notification
+// on the persistent channel must not (a) advance the cache head past the
+// database's actual sequence, (b) synthesize phantom events, (c) drive an
+// unbounded range scan over a populated table, or (d) stall real delivery.
+// Unlike the ephemeral forgery test this runs against a POPULATED table, so
+// the range-fetch amplification (fetch_notified_range(0, i64::MAX) streaming
+// the whole tail) is actually exercised and the clamp is tested.
+#[tokio::test]
+#[file_serial]
+async fn forged_persistent_notification_does_not_stall_listener() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+
+    let outbox = init_outbox::<TestEvent>(
+        &pool,
+        MailboxConfig::builder()
+            .build()
+            .expect("Couldn't build MailboxConfig"),
+    )
+    .await?;
+
+    // Populate the table so the forged range fetch has real rows to amplify
+    // over if the clamp were absent.
+    let mut op = pool.begin().await?;
+    outbox
+        .publish_all_persisted(&mut op, (0..5).map(TestEvent::Ping))
+        .await?;
+    op.commit().await?;
+
+    let mut listener = outbox.listen_persisted(None);
+
+    sqlx::query("SELECT pg_notify('persistent_outbox_events', $1)")
+        .bind(
+            serde_json::json!({
+                "min_sequence": 1,
+                "max_sequence": i64::MAX,
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await?;
+
+    // The forged claim is clamped to the real head, so no phantom events
+    // beyond the committed 5 are synthesized. (The 5 real events may arrive
+    // from the clamped fetch — that's correct, not a forgery.)
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    while let Ok(Some(item)) =
+        tokio::time::timeout(std::time::Duration::from_millis(300), listener.next()).await
+    {
+        let event = item?;
+        let n = event.payload.as_ref().and_then(|p| match p {
+            TestEvent::Ping(n) => Some(*n),
+            _ => None,
+        });
+        assert!(
+            n.is_some_and(|n| n < 5),
+            "forged persistent notification must not deliver events beyond the real head, got {event:?}"
+        );
+    }
+
+    // Real delivery still works, promptly (the forged head must not wedge
+    // the contiguity machinery).
+    let mut op = pool.begin().await?;
+    outbox
+        .publish_persisted_in_op(&mut op, TestEvent::Ping(99))
+        .await?;
+    op.commit().await?;
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), listener.next())
+        .await?
+        .expect("listener must still deliver after a forged notification")?;
+    assert!(matches!(event.payload, Some(TestEvent::Ping(99))));
+
+    Ok(())
+}
+
 /// Regression: an event whose NOTIFY fires while the LISTEN connection is
 /// down must still reach consumers.
 ///


### PR DESCRIPTION
## Summary

PostgreSQL performs **no authorization on LISTEN/NOTIFY channels** — any role able to connect to the database can signal (and listen to) any channel. obix treated notification bodies as trusted transport, which this PR fixes. Notifications are now strictly *hints*; event data is always read from the tables with the consumer's own credentials.

> **⚠️ Breaking change** — the setup migration `20251204130225_obix_setup.sql` is modified in place (the ephemeral trigger now sends only `{event_type, recorded_at}` instead of `row_to_json(NEW)`). Existing deployments must recreate the schema; there is no in-place upgrade migration. Marked `fix!` per conventional commits.

### 🔴 Ephemeral event forgery & eavesdropping

- **Before:** the trigger sent the full payload over `pg_notify`, and listeners deserialized and broadcast it **without touching the table**. Any DB role (or SQL injection in any application sharing the database) could inject forged ephemeral events into all consumers, and could `LISTEN` to harvest every ephemeral payload with no table grant.
- **After:** the trigger sends only `{event_type, recorded_at}`. Listeners always fetch the payload from the table; `recorded_at` lets them skip the fetch when the in-process cache is already current. A burst of N notifications for the same type collapses into a single fetch (deduped in the drain loop).

### 🟠 Forged persistent notifications — phantom head + unbounded range fetch

- **Before:** a forged `{min_sequence, max_sequence}` with a huge `max_sequence` was applied directly to `highest_known_sequence` (pinning the gap-fill loop against a phantom head — a fill query every second, forever) **and** drove an unbounded `fetch_notified_range` scanning the entire table tail on every forgery.
- **After:** both the head advance and the fetch `up_to` are clamped to the sequence's authoritative `last_value` before being applied. `last_value` advances at `nextval` (pre-commit), so a forged claim inside `(committed_head, last_value]` can still trigger a bounded grace-period gap-fill that self-heals via `ON CONFLICT` — it never stalls.

### 🟡 Minor hardening

- **`tbl_prefix` validation** — restricted to 1–25 chars of `[A-Za-z0-9_]` (no leading digit) at derive time; it is interpolated into generated SQL identifiers and the `pg_notify` channel literal.
- **No panics on DB-derived data** — unparseable inbox status → `InboxError::InvalidStatus`; undeserializable ephemeral `event_type` → row dropped with an error span.

## Test plan

- [x] `forged_ephemeral_notification_is_not_delivered` — **fails on pre-fix code** (forged event was broadcast verbatim), passes with the fix
- [x] `ephemeral_event_written_externally_is_fetched_from_db` — cross-instance delivery via hint + DB fetch
- [x] `forged_persistent_notification_does_not_stall_listener` — **now runs against a populated table** (5 events), so the range-fetch amplification is exercised; forged `i64::MAX` head neither synthesizes phantom events beyond the real head nor stalls delivery
- [x] Full suite green: `cargo test --all-features` (63 tests), `cargo clippy --all-targets` clean, `cargo fmt --check` clean
