### PR TITLE
chore: pin nix dev postgres to 18

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
         cargo-deny
         mdbook
         bacon
-        postgresql
+        postgresql_18
         process-compose
         ytt
         curl
@@ -108,7 +108,7 @@
       pg-start = pkgs.writeShellApplication {
         name = "pg-start";
         runtimeInputs =
-          [pkgs.postgresql pkgs.coreutils]
+          [pkgs.postgresql_18 pkgs.coreutils]
           ++ pkgs.lib.optionals pkgs.stdenv.isLinux [pkgs.util-linux];
         text = ''
           NAME="$1" PORT="$2" PGUSER="$3" DB="$4"
@@ -210,7 +210,7 @@
           exec.command = "${
             pkgs.writeShellApplication {
               name = "ready-${name}";
-              runtimeInputs = [pkgs.postgresql];
+              runtimeInputs = [pkgs.postgresql_18];
               text = ''
                 exec psql -p "''${PGPORT:-${toString port}}" -U ${user} -h 127.0.0.1 -d ${db} -c 'SELECT 1' -t -q
               '';


### PR DESCRIPTION
## Why

`pkgs.postgresql` follows the nixpkgs default version (currently 17.8). lana-bank runs PostgreSQL **18** in every environment (local nix, staging 18.3, QA 18.4). PG18 ships the built-in `uuidv7()` function, which upcoming outbox work (v4 → v7 ID migration for `persistent_outbox_events.id` / `ephemeral_outbox_events.id`) will rely on — so obix's dev/test database needs to be 18 first.

## What

Pin `postgresql` → `postgresql_18` in `flake.nix`:
- dev shell `buildInputs`
- `pg-start` runtime inputs
- readiness-probe runtime inputs

## Verification

- `nix eval .#devShells.<system>.default.drvPath` — evaluates
- `nix develop -c psql --version` → `psql (PostgreSQL) 18.2`