### PR TITLE
chore(outbox)!: default outbox and inbox ids to uuidv7()

### DIFF
--- a/migrations/20251204130225_obix_setup.sql
+++ b/migrations/20251204130225_obix_setup.sql
@@ -1,6 +1,6 @@
 -- Persistent outbox events
 CREATE TABLE persistent_outbox_events (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  id UUID PRIMARY KEY DEFAULT uuidv7(),
   sequence BIGSERIAL UNIQUE,
   payload JSONB,
   tracing_context JSONB,
@@ -49,7 +49,7 @@ EXCEPTION
 END $$;
 
 CREATE TABLE inbox_events (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  id UUID PRIMARY KEY DEFAULT uuidv7(),
   idempotency_key VARCHAR UNIQUE,
   payload JSONB NOT NULL,
   status InboxEventStatus NOT NULL DEFAULT 'pending',


### PR DESCRIPTION
> [!NOTE]
> Stacked on #109 (Postgres 18 pin) — `uuidv7()` requires PG18, so this must land after it. Base will auto-retarget to `main` when #109 merges.

## Why

Consumers (lana-bank via `es-entity`, the `job` crate) already generate **v7** UUIDs app-side. The outbox/inbox tables were the remaining v4 source (`gen_random_uuid()` column defaults). Postgres 18 ships a built-in `uuidv7()`, so the DB can generate time-ordered, index-friendly IDs directly.

## What

`migrations/20251204130225_obix_setup.sql` — `gen_random_uuid()` → `uuidv7()` for:
- `persistent_outbox_events.id`
- `inbox_events.id`

`ephemeral_outbox_events` has no `id` column — untouched.

Marked `chore(outbox)!:` — same schema-reset convention as the partitioning change: no in-place data migration, existing installs recreate the table (or manually `ALTER COLUMN id SET DEFAULT uuidv7()`; harmless either way since `id` is a RETURNING-only identifier, not an ordering key).

## Interaction with #106 (partitioning)

Composes cleanly: #106 keeps `id UUID NOT NULL DEFAULT gen_random_uuid()` — whichever lands second, the same one-line default change applies. Happy to rebase either direction.

## Verification

- `nix run .#nextest` against PG 18.2: **58/58 passed**
- `.sqlx` unchanged (column defaults are not part of cached query metadata)

Downstream: lana-bank vendors this migration — its vendored copies are updated in GaloyMoney/lana-bank#7867.