### PR TITLE
chore(deps): bump es-entity 0.12.0, job 0.7.0, serial_test 4.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
 dependencies = [
  "fslock",
  "futures-executor",
@@ -1783,13 +1783,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,9 +480,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.11.9"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b77820b8cd056d9f3831d49f00bb01fe80216e7c8e04f6e39be29c11d2d1fcd2"
+checksum = "5eaffadefdf3b88dc6b00398313b2689bed1517bd0ed9cb2fa64761e8d7f2d70"
 dependencies = [
  "async-stream",
  "chrono",
@@ -507,17 +507,18 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.11.9"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d894eda6b6c6bf66bce9b984af814e51c65366261fdd131c509c23849980914b"
+checksum = "c58fe4c10966dffe8e62a4fd7def3806bdae30abf8cfdda5dde9f9918073a620"
 dependencies = [
  "convert_case",
- "darling 0.23.0",
+ "darling 0.24.0",
  "pluralizer",
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.119",
+ "sqlparser",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -991,9 +992,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.35"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39448f226d50f033db27ed58401ce4b7e2414a5fff95b3a956e36e451b00bbc6"
+checksum = "26d220979c9eaed27c3862d42b0a1cb26b6a0ce6dfea03c5504554a666924ca0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1891,6 +1892,15 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-serial_test = { version = "3", features = ["file_locks"] }
+serial_test = { version = "4", features = ["file_locks"] }
 
 [workspace]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ obix-macros = { path = "obix-macros", version = "0.6.1-dev" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-es-entity = "0.11.9"
+es-entity = "0.12.0"
 anyhow = "1.0"
 tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
@@ -64,7 +64,7 @@ chrono = { version = "0.4", features = ["clock", "serde"], default-features = fa
 tracing = { version = "0.1" }
 futures = "0.3"
 im = { version = "15.1", features = ["serde"] }
-job = "0.6.35"
+job = "0.7.0"
 thiserror = "2.0"
 async-trait = "0.1"
 derive_builder = "0.20"


### PR DESCRIPTION
Supersedes #108 — includes that PR's serial_test bump plus the manifest fix it was missing.

## What

Batches the pending dependency updates onto one branch:

| Crate | From | To | Notes |
|-------|------|----|-------|
| `serial_test` (dev) | 3.5.0 | 4.0.1 | Dependabot #108 — also aligns the `Cargo.toml` requirement (`"3"` → `"4"`), which #108 left stale and broke `cargo check --locked`. |
| `es-entity` | 0.11.9 | 0.12.0 | Breaking release (cursor unification #178, panic-path removal #172). |
| `es-entity-macros` | 0.11.9 | 0.12.0 | Transitive with es-entity. |
| `job` | 0.6.35 | 0.7.0 | Depends on es-entity 0.12.0 — bumped in lockstep. |

## es-entity 0.12.0 breaking changes — impact on obix

The 0.12.0 breaking changes are confined to the `EsRepo` derive macro surface:

- **#178** — unified `list_for_filters` cursor + derive specialization & migration-index errors.
- **#172** — removed panic paths from `EsRepo`-generated event persistence and `EntityEvents::last_persisted`.

**No obix code changes were required.** obix does not derive `EsRepo`/`EsEntity` or use
`list_for_filters`/`es_query!`/cursor queries — it consumes only the stable lower-level API
(`AtomicOperation`, `DbOp`, `hooks`, `clock`, `context::TracingContext`, `Idempotent`,
`entity_id!`). obix's `Tables::persist_events` is its own method, unrelated to the es-entity
macro path that #172 touched.

## Verification

- `cargo clippy --all-features -- --deny warnings` (offline) — clean, mirrors CI `check-code`.
- Full `nix run .#nextest` suite (live Postgres) — nextest + doc tests + `cargo doc`.
- `job` v0.7.0 resolves against `es-entity` v0.12.0 with a single unified version (no duplicate es-entity in the tree).
- `.sqlx` offline cache unchanged — obix writes its sqlx queries directly, so the es-entity bump changes no generated SQL.