### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+Only the latest release and `main` receive security fixes.
+
+Please report security vulnerabilities by email to **security@galoy.io** —
+do not report them through public GitHub issues, discussions, or pull requests.


### PR DESCRIPTION
Adds a minimal `SECURITY.md` so GitHub surfaces a security policy for this
repo, pointing reporters at **security@galoy.io**.

Part of an effort to add a consistent security policy across Galoy's open
source repositories (obix, job, es-entity, cala, bria, drua).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security logic, or data-handling impact.
> 
> **Overview**
> Adds a new **`SECURITY.md`** so GitHub can show a repository security policy for this repo.
> 
> The policy states that only the latest release and **`main`** get security fixes, and directs vulnerability reports to **security@galoy.io** instead of public GitHub issues, discussions, or pull requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca5eb2e5d268efc15b7567b188fcb6f85d675fbb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->