### PR TITLE
fix(flake): set SQLX_OFFLINE in the dev shell (unbreak CI fuzz build)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -436,6 +436,11 @@
 
         devShells.default = mkShell {
           inherit nativeBuildInputs;
+          # obix uses compile-time sqlx::query! macros (via the MailboxTables
+          # derive) backed by the committed .sqlx/ cache. Without this, `cargo
+          # build` / `cargo fuzz build` in `nix develop` (incl. the CI fuzz task)
+          # tries to hit a live Postgres and fails — e.g. the fuzz job has no DB.
+          SQLX_OFFLINE = "true";
           shellHook = ''
             eval "$(${devEnv}/bin/obix-dev-env)"
           '';


### PR DESCRIPTION
The merged fuzz job (#115) builds the fuzz crate via `nix develop -c bash ci/vendor/tasks/fuzz.sh` with no Postgres. obix's `MailboxTables` derive expands to compile-time `sqlx::query!` macros backed by the committed `.sqlx/` cache; without `SQLX_OFFLINE=true` they try to connect to a DB and fail (`Connection refused`), cascading into E0282 errors. Verified failing on CI (build `obix/fuzz/3`).

One-liner: set `SQLX_OFFLINE = "true"` in the dev shell (crane's `commonArgs` already sets it for nix builds). Harmless to the tests job (runs outside the dev shell against live Postgres). es-entity's fuzz doesn't hit this — its lib has no direct compile-time sqlx queries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Environment-only change for local/CI dev shells; aligns dev behavior with existing crane offline sqlx settings and does not alter runtime or test database wiring.
> 
> **Overview**
> Sets **`SQLX_OFFLINE = "true"`** on the default **`nix develop`** shell so compile-time **`sqlx::query!`** (from the **`MailboxTables`** derive, using the committed **`.sqlx/`** cache) does not require a live Postgres during **`cargo build`** or **`cargo fuzz build`**.
> 
> Crane **`commonArgs`** already had this for Nix package builds; dev-shell **`cargo`** invocations (including the Concourse fuzz job via **`nix develop -c`**, which has no DB) were missing it and failed with connection errors. The tests job is unaffected when it runs outside this shell against live Postgres.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 460a2ca22c2d5828e2cfa9ab4e306aa8573b3b6a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->