### PR TITLE
chore(ci): bump vendir to galoy-concourse-shared 26b38b4 (fuzz corpus-restore fix)

### DIFF
--- a/ci/vendir.lock.yml
+++ b/ci/vendir.lock.yml
@@ -2,14 +2,14 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: 'Merge pull request #21 from GaloyMoney/fix/fuzz-script-path...'
-      sha: 4c9071ebc13e88282dc8c8924a52bc1c9d8b05cc
+      commitTitle: 'Merge pull request #22 from GaloyMoney/fix/fuzz-corpus-restore-portable...'
+      sha: 26b38b457e1e638fd168a0d4f4c5db49c1bcb47e
     path: .
   path: ../.github/workflows/vendor
 - contents:
   - git:
-      commitTitle: 'Merge pull request #21 from GaloyMoney/fix/fuzz-script-path...'
-      sha: 4c9071ebc13e88282dc8c8924a52bc1c9d8b05cc
+      commitTitle: 'Merge pull request #22 from GaloyMoney/fix/fuzz-corpus-restore-portable...'
+      sha: 26b38b457e1e638fd168a0d4f4c5db49c1bcb47e
     path: .
   path: vendor
 kind: LockConfig

--- a/ci/vendir.yml
+++ b/ci/vendir.yml
@@ -8,7 +8,7 @@ directories:
   - path: . # Copy this folder out to ..
     git:
       url: https://github.com/GaloyMoney/galoy-concourse-shared.git
-      ref: 4c9071e
+      ref: 26b38b4
     includePaths:
     - shared/actions/*
     excludePaths:
@@ -22,7 +22,7 @@ directories:
   - path: .
     git:
       url: https://github.com/GaloyMoney/galoy-concourse-shared.git
-      ref: 4c9071e
+      ref: 26b38b4
     includePaths:
     - shared/ci/**/*
     excludePaths:

--- a/ci/vendor/tasks/fuzz.sh
+++ b/ci/vendor/tasks/fuzz.sh
@@ -34,7 +34,7 @@ FUZZ_SECONDS="${FUZZ_SECONDS:-60}"
 
 #! Restore the corpus (no-op unless CORPUS_TARBALL_IN is set and matches a file).
 mkdir -p fuzz/corpus
-if [ -n "${CORPUS_TARBALL_IN:-}" ] && compgen -G "$CORPUS_TARBALL_IN" >/dev/null; then
+if [ -n "${CORPUS_TARBALL_IN:-}" ] && ls -d $CORPUS_TARBALL_IN >/dev/null 2>&1; then
   echo "restoring corpus from $CORPUS_TARBALL_IN"
   tar -xzf $CORPUS_TARBALL_IN -C fuzz/
 fi


### PR DESCRIPTION
chore(ci): bump vendir to galoy-concourse-shared 26b38b4

Pulls in galoy-concourse-shared#22: the shared fuzz.sh corpus-restore used
`compgen -G` (a bash builtin unavailable in the fuzz task's shell), so the
restored tarball was downloaded but never extracted and every run fuzzed from
scratch. Now `ls -d <glob>` (POSIX), so the corpus actually loads and coverage
accumulates across runs.

Refresh touches only ci/vendor/tasks/fuzz.sh (the one-line fix) plus the
vendir ref/lock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only vendir refresh and a one-line POSIX shell change in fuzz corpus restore; no application runtime or security-sensitive logic.
> 
> **Overview**
> Bumps **galoy-concourse-shared** vendir pins from `4c9071e` to **`26b38b4`** in `ci/vendir.yml` and `ci/vendir.lock.yml`, pulling in the shared **`fuzz.sh`** corpus-restore fix.
> 
> The vendored script now checks whether `CORPUS_TARBALL_IN` matches a path with **`ls -d`** instead of **`compgen -G`**, so corpus tarball restore works in the fuzz task’s shell (where `compgen` wasn’t available). CI fuzz runs can load the restored corpus and accumulate coverage across runs instead of always starting from scratch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 104325e17ee8fdc85ae3f876d7e469958bf97909. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->