### PR TITLE
feat(outbox): handler groups — N event handlers on one resident job

### DIFF
--- a/.sqlx/query-c552a35fae8044fcb2edbc84ae98c8816ec16f07dc65b8fcd17c9366ced80667.json
+++ b/.sqlx/query-c552a35fae8044fcb2edbc84ae98c8816ec16f07dc65b8fcd17c9366ced80667.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM job_executions WHERE job_type = $1 RETURNING execution_state_json",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "execution_state_json",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "c552a35fae8044fcb2edbc84ae98c8816ec16f07dc65b8fcd17c9366ced80667"
+}

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,11 @@ reset-deps: clean-deps start-deps
 check-code:
 	nix flake check
 
+# `--all-targets` is required: without it, prepare only sees lib/bin queries and
+# silently DELETES the .sqlx entries for queries that live in tests/, breaking
+# the offline build of the test suite.
 sqlx-prepare:
-	cargo sqlx prepare --workspace
+	cargo sqlx prepare --workspace -- --all-targets
 
 # Coverage-guided fuzzing via the shared vendored script
 # (ci/vendor/tasks/fuzz.sh, from galoy-concourse-shared), also used by

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,9 @@ pub use inbox::{
 pub use obix_macros::{MailboxTables, OutboxEvent};
 pub use out::{
     BatchOp, CursorError, DecodeFailure, EventCtx, EventSubscription, FlushError, FlushOp, Handled,
-    IsolatedOp, OpCursor, Outbox, OutboxEventHandler, OutboxEventJobConfig,
-    PartitionMaintainerConfig, Partitions, PostPersistHook, UndecodableEventError,
+    HandlerGroupError, HandlerGroupName, IsolatedOp, OpCursor, Outbox, OutboxEventHandler,
+    OutboxEventJobConfig, PartitionMaintainerConfig, Partitions, PostPersistHook,
+    UndecodableEventError,
 };
 pub use sequence::EventSequence;
 pub use tables::MailboxTables;

--- a/src/out/ctx.rs
+++ b/src/out/ctx.rs
@@ -57,6 +57,96 @@ pub(crate) struct OutboxEventJobState {
     pub(crate) sequence: EventSequence,
 }
 
+/// The checkpoint a landing commits, abstracted over the job's shape.
+///
+/// A solo handler job writes [`OutboxEventJobState`] — one sequence. A handler
+/// group writes one row carrying *every* member's sequence, so the landing
+/// transaction that applies N members' flushes also commits N checkpoints. The
+/// erasure keeps that difference out of [`EventCtx`], whose public signature
+/// must not gain a state type parameter.
+pub(crate) trait CheckpointState: Send + Sync {
+    /// The last fully handled sequence — the batch's upper bound, used for
+    /// tracing and [`FlushError`] attribution. For a group this is the
+    /// batch-end sequence, not any single member's checkpoint.
+    fn sequence(&self) -> EventSequence;
+
+    /// Write the checkpoint onto the landing op. Called inside the batch
+    /// transaction, after every flush, immediately before commit.
+    fn persist<'a>(
+        &'a self,
+        current_job: &'a mut CurrentJob,
+        op: &'a mut es_entity::DbOp<'static>,
+    ) -> BoxFuture<'a, Result<(), HandlerError>>;
+}
+
+impl CheckpointState for OutboxEventJobState {
+    fn sequence(&self) -> EventSequence {
+        self.sequence
+    }
+
+    fn persist<'a>(
+        &'a self,
+        current_job: &'a mut CurrentJob,
+        op: &'a mut es_entity::DbOp<'static>,
+    ) -> BoxFuture<'a, Result<(), HandlerError>> {
+        Box::pin(async move {
+            current_job.update_execution_state_in_op(op, self).await?;
+            Ok(())
+        })
+    }
+}
+
+/// The *other* members sharing a group's landing.
+///
+/// A member's [`consume_isolated`](EventCtx::consume_isolated) fence must land
+/// the whole pending group batch — not just its own accumulator — or a sibling's
+/// collected items would outlive the transaction that was supposed to carry
+/// them. The dispatching member's own accumulator is already reachable through
+/// [`EventCtx`]'s `batch`/`flusher`, so this covers exactly the peers, split
+/// around it to preserve registration order: `flush_before` (registered earlier)
+/// → the dispatching member → `flush_after` (registered later).
+///
+/// A solo job passes [`NoPeers`].
+pub(crate) trait PeerFlush: Send {
+    /// Whether any peer holds collected items — a pending batch that must land
+    /// even when the dispatching member has nothing of its own.
+    fn any_dirty(&self) -> bool;
+
+    fn flush_before<'a>(
+        &'a mut self,
+        op: &'a mut es_entity::DbOp<'static>,
+    ) -> BoxFuture<'a, Result<(), HandlerError>>;
+
+    fn flush_after<'a>(
+        &'a mut self,
+        op: &'a mut es_entity::DbOp<'static>,
+    ) -> BoxFuture<'a, Result<(), HandlerError>>;
+}
+
+/// A solo handler job has no peers: every hook is a no-op, so the solo landing
+/// path is byte-for-byte the pre-group one.
+pub(crate) struct NoPeers;
+
+impl PeerFlush for NoPeers {
+    fn any_dirty(&self) -> bool {
+        false
+    }
+
+    fn flush_before<'a>(
+        &'a mut self,
+        _op: &'a mut es_entity::DbOp<'static>,
+    ) -> BoxFuture<'a, Result<(), HandlerError>> {
+        Box::pin(std::future::ready(Ok(())))
+    }
+
+    fn flush_after<'a>(
+        &'a mut self,
+        _op: &'a mut es_entity::DbOp<'static>,
+    ) -> BoxFuture<'a, Result<(), HandlerError>> {
+        Box::pin(std::future::ready(Ok(())))
+    }
+}
+
 /// Book-keeping the runner shares with [`EventCtx`].
 pub(crate) struct BatchTracker {
     /// Number of events contributing to the pending batch (consumed into the
@@ -75,8 +165,18 @@ pub(crate) struct BatchTracker {
 pub(crate) struct CtxParts<'inv> {
     pub(crate) op_slot: &'inv mut Option<es_entity::DbOp<'static>>,
     pub(crate) current_job: &'inv mut CurrentJob,
-    pub(crate) state: &'inv OutboxEventJobState,
+    pub(crate) checkpoint: &'inv dyn CheckpointState,
     pub(crate) tracker: &'inv mut BatchTracker,
+    pub(crate) peers: &'inv mut dyn PeerFlush,
+    /// Whether the accumulator travelling alongside these parts holds collected
+    /// items.
+    ///
+    /// Solo: identical to `tracker.collected > 0`, which counts this handler's
+    /// collects and nothing else. Grouped: the *dispatching member's* own dirty
+    /// flag — the shared counter only says that some member collected, and
+    /// flushing on that would hand a sibling's trigger to this member's
+    /// [`flush`](super::OutboxEventHandler::flush) as an empty accumulator.
+    pub(crate) own_dirty: bool,
 }
 
 /// Proof that a persistent event was resolved in one of the legal ways.
@@ -518,6 +618,11 @@ impl std::error::Error for FlushError {
 /// flush (inside the batch transaction, opening one if only items are
 /// pending) → checkpoint at the last fully handled sequence → commit. No-op
 /// when nothing is pending.
+///
+/// In a handler group the same call also flushes every peer holding collected
+/// items, in registration order around the dispatching member, so one landing
+/// is one transaction carrying every member's work *and* every member's
+/// checkpoint.
 #[tracing::instrument(
     name = "outbox.flush_batch",
     skip_all,
@@ -525,7 +630,7 @@ impl std::error::Error for FlushError {
         reason = reason,
         batch_size = parts.tracker.events_in_op,
         collected = parts.tracker.collected,
-        checkpoint_seq = u64::from(parts.state.sequence),
+        checkpoint_seq = u64::from(parts.checkpoint.sequence()),
     ),
     err
 )]
@@ -535,44 +640,55 @@ pub(crate) async fn flush_batch<B: Default>(
     flusher: &dyn ItemFlush<B>,
     reason: &'static str,
 ) -> Result<(), HandlerError> {
-    if parts.op_slot.is_none() && parts.tracker.collected == 0 {
+    let own_items = parts.own_dirty;
+    if parts.op_slot.is_none() && parts.tracker.collected == 0 && !parts.peers.any_dirty() {
         return Ok(());
     }
-    if parts.tracker.collected > 0 {
-        if parts.op_slot.is_none() {
-            *parts.op_slot = Some(
-                es_entity::DbOp::init_with_clock(
-                    parts.current_job.pool(),
-                    parts.current_job.clock(),
-                )
-                .await?,
-            );
+    // Take the op out for the whole landing: on any error below it is dropped
+    // here and rolls back, and the slot is already empty — a failed landing can
+    // never leave a half-applied op behind for the next event to join.
+    let mut op = match parts.op_slot.take() {
+        Some(op) => op,
+        None => {
+            es_entity::DbOp::init_with_clock(parts.current_job.pool(), parts.current_job.clock())
+                .await?
         }
+    };
+    // Hoisted so failure attribution does not borrow `parts` while the flush
+    // hooks below need it mutably. Neither value moves during a landing.
+    let (after, through) = (parts.tracker.persisted_seq, parts.checkpoint.sequence());
+    let attribute = |source| {
+        Box::new(FlushError {
+            reason,
+            after,
+            through,
+            source,
+        })
+    };
+
+    // Every accumulator in scope is drained by this landing, so the shared
+    // counter clears unconditionally — including when only peers were dirty.
+    parts.tracker.collected = 0;
+
+    if let Err(source) = parts.peers.flush_before(&mut op).await {
+        return Err(attribute(source));
+    }
+    if own_items {
         // Drain before the call: on error the items are dropped with the op,
         // and the replayed events re-collect them — the accumulator never
         // leaks stale state into a retry.
         let items = std::mem::take(batch);
-        parts.tracker.collected = 0;
-        let op = parts.op_slot.as_mut().expect("op was materialized above");
-        if let Err(source) = flusher.flush_items(op, items).await {
-            return Err(Box::new(FlushError {
-                reason,
-                after: parts.tracker.persisted_seq,
-                through: parts.state.sequence,
-                source,
-            }));
+        if let Err(source) = flusher.flush_items(&mut op, items).await {
+            return Err(attribute(source));
         }
     }
-    let mut op = parts
-        .op_slot
-        .take()
-        .expect("a pending batch always has an op by now");
-    parts
-        .current_job
-        .update_execution_state_in_op(&mut op, parts.state)
-        .await?;
+    if let Err(source) = parts.peers.flush_after(&mut op).await {
+        return Err(attribute(source));
+    }
+
+    parts.checkpoint.persist(parts.current_job, &mut op).await?;
     op.commit().await?;
-    parts.tracker.persisted_seq = parts.state.sequence;
+    parts.tracker.persisted_seq = parts.checkpoint.sequence();
     parts.tracker.last_persist = tokio::time::Instant::now();
     parts.tracker.events_in_op = 0;
     Ok(())
@@ -583,17 +699,15 @@ pub(crate) async fn flush_batch<B: Default>(
 #[tracing::instrument(
     name = "outbox.persist_checkpoint",
     skip_all,
-    fields(checkpoint_seq = u64::from(state.sequence)),
+    fields(checkpoint_seq = u64::from(checkpoint.sequence())),
     err
 )]
 pub(crate) async fn persist_checkpoint(
     current_job: &mut CurrentJob,
-    state: &OutboxEventJobState,
+    checkpoint: &dyn CheckpointState,
 ) -> Result<(), HandlerError> {
     let mut op = es_entity::DbOp::init_with_clock(current_job.pool(), current_job.clock()).await?;
-    current_job
-        .update_execution_state_in_op(&mut op, state)
-        .await?;
+    checkpoint.persist(current_job, &mut op).await?;
     op.commit().await?;
     Ok(())
 }

--- a/src/out/group.rs
+++ b/src/out/group.rs
@@ -1,0 +1,1156 @@
+//! Handler groups: N registered [`OutboxEventHandler`]s multiplexed onto one
+//! resident job.
+//!
+//! A solo handler job costs one permanently-running job slot, one outbox
+//! subscription and one checkpoint-write transaction per landing. Those costs
+//! are per *handler*, so a consumer with dozens of listeners pays them dozens
+//! of times over — enough to starve the job runner's slot budget and to make
+//! `job_executions` the busiest table in the system.
+//!
+//! A group collapses that to one of each. Members keep their own handler, their
+//! own [`Batch`](OutboxEventHandler::Batch) accumulator, their own checkpoint
+//! and their own failure domain; what they share is the stream read, the
+//! landing transaction and the execution-state row.
+//!
+//! Grouping is a deployment decision made at registration —
+//! [`OutboxEventJobConfig::in_group`](super::OutboxEventJobConfig::in_group),
+//! one line per call site. The [`OutboxEventHandler`] trait and the
+//! [`EventCtx`] consume DSL are unchanged: a handler cannot tell whether it is
+//! running solo or grouped, and does not need to.
+//!
+//! # Delivery
+//!
+//! One listener per group, positioned at the *minimum* member checkpoint. Each
+//! event is dispatched to a member iff `event.sequence > member.checkpoint` —
+//! the per-member delivery filter. A lagging member catches up through the
+//! shared stream while members already past that point filter cheaply in
+//! memory, with no handler call. Once every member has seen an event the filter
+//! is a no-op, so convergence is structural rather than a special catch-up
+//! phase.
+//!
+//! Per-member delivery guarantees are exactly the solo ones: gapless, in order,
+//! and the checkpoint trails applied state.
+//!
+//! # Landing
+//!
+//! The group batch lands under the union of the solo triggers — backlog
+//! drained, `max_batch_size` reached, any member committing or isolating, an
+//! undecodable event, or shutdown. A landing is ONE transaction: every dirty
+//! member's [`flush`](OutboxEventHandler::flush) in registration order, then a
+//! single state write carrying every member's checkpoint, then commit.
+//!
+//! [`consume_isolated`](EventCtx::consume_isolated) keeps its fence semantics
+//! for the requesting member: the pending group batch lands first — including
+//! its siblings' collected items — then the isolated op runs and commits alone.
+//! Other members merely observe a batch boundary, which was never part of the
+//! delivery contract.
+//!
+//! # Failure isolation
+//!
+//! The unit of failure stays the handler. When a member errors, the landing
+//! transaction rolls back and the member is *ejected*: its checkpoint is parked
+//! at its last committed sequence (before the poison event) and it is never
+//! dispatched to again. The batch then replays without it — replay tolerance is
+//! already the DSL's contract — so its siblings advance past an event it could
+//! not handle. The parked checkpoint keeps being written verbatim on every
+//! subsequent landing, so a restart resumes the member exactly where it stopped
+//! and nothing is skipped.
+//!
+//! Ejection is loud (an `ERROR`-level event) and, in this version, terminal for
+//! the process: re-joining happens at the next restart. If every member ejects,
+//! the group job fails so the job runner's own retry/backoff applies, which is
+//! precisely the solo behaviour at group granularity.
+
+use futures::{FutureExt, StreamExt};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use job::{CurrentJob, Job, JobCompletion, JobInitializer, JobRunner, JobSpawner, JobType};
+
+use super::ctx::*;
+use super::job::{EventSubscription, OutboxEventHandler};
+use super::{EphemeralOutboxListener, Outbox, event::*};
+use crate::{sequence::EventSequence, tables::MailboxTables};
+
+/// Name of a handler group — and the [`JobType`] of the resident job hosting
+/// it.
+///
+/// Takes a `&'static str` because that is all [`JobType`] can be built from: a
+/// group name is a deployment constant, exactly like a job type.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HandlerGroupName(JobType);
+
+impl HandlerGroupName {
+    pub const fn new(name: &'static str) -> Self {
+        Self(JobType::new(name))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub(crate) fn job_type(&self) -> JobType {
+        self.0.clone()
+    }
+}
+
+impl std::fmt::Display for HandlerGroupName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A handler could not be registered into its group.
+///
+/// Every variant is a startup-time programming error, surfaced loudly rather
+/// than degraded into a handler that silently receives nothing.
+#[derive(Debug, thiserror::Error)]
+pub enum HandlerGroupError {
+    /// Membership is snapshotted when the group's job starts, so a member
+    /// registered afterwards would never be dispatched to. Register every
+    /// member before `Jobs::start_poll`.
+    #[error(
+        "handler group '{group}': member '{member}' registered after the group job started — \
+         register all members before starting the job poller"
+    )]
+    GroupAlreadyStarted {
+        group: HandlerGroupName,
+        member: JobType,
+    },
+    /// The member key doubles as checkpoint identity, so it must be unique
+    /// within a group.
+    #[error("handler group '{group}': duplicate member '{member}'")]
+    DuplicateMember {
+        group: HandlerGroupName,
+        member: JobType,
+    },
+    /// Batch size and checkpoint interval govern the shared landing, so they
+    /// belong to the group. The first registration sets them; a later member
+    /// disagreeing is an explicit error rather than a silently folded min/max.
+    #[error(
+        "handler group '{group}': member '{member}' sets {setting}={member_value}, conflicting \
+         with the group's {group_value} (taken from the first registration)"
+    )]
+    ConflictingGroupSetting {
+        group: HandlerGroupName,
+        member: JobType,
+        setting: &'static str,
+        group_value: String,
+        member_value: String,
+    },
+}
+
+/// Persisted execution state of a group job: every member's committed
+/// checkpoint, in one row.
+///
+/// `BTreeMap` so the serialized form is deterministic (stable diffs when
+/// inspecting `job_executions` by hand).
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub(crate) struct HandlerGroupJobState {
+    pub(crate) members: BTreeMap<String, EventSequence>,
+}
+
+// ── member erasure ──────────────────────────────────────────────────────────
+
+/// Registration-time description of a member: everything needed to build a
+/// fresh per-run instance, with the handler type erased.
+pub(crate) trait MemberSpec<P>: Send + Sync + 'static
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+{
+    fn key(&self) -> &JobType;
+    fn subscription(&self) -> EventSubscription;
+    fn instantiate(&self) -> Box<dyn MemberInstance<P>>;
+}
+
+struct TypedMemberSpec<H, P> {
+    key: JobType,
+    handler: Arc<H>,
+    _payload: std::marker::PhantomData<fn() -> P>,
+}
+
+impl<H, P> MemberSpec<P> for TypedMemberSpec<H, P>
+where
+    H: OutboxEventHandler<P>,
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+{
+    fn key(&self) -> &JobType {
+        &self.key
+    }
+
+    fn subscription(&self) -> EventSubscription {
+        H::SUBSCRIPTION
+    }
+
+    fn instantiate(&self) -> Box<dyn MemberInstance<P>> {
+        Box::new(TypedMember::<H, P> {
+            key: self.key.clone(),
+            handler: self.handler.clone(),
+            batch: H::Batch::default(),
+            dirty: false,
+            flusher: super::job::HandlerFlusher::new(self.handler.clone()),
+        })
+    }
+}
+
+pub(crate) fn member_spec<H, P>(key: JobType, handler: H) -> Arc<dyn MemberSpec<P>>
+where
+    H: OutboxEventHandler<P>,
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+{
+    Arc::new(TypedMemberSpec::<H, P> {
+        key,
+        handler: Arc::new(handler),
+        _payload: std::marker::PhantomData,
+    })
+}
+
+/// One member's live state within a running group: its handler plus its private
+/// accumulator. Type-erased over the handler's
+/// [`Batch`](OutboxEventHandler::Batch) so the runner can hold a heterogeneous
+/// `Vec` of them.
+///
+/// Deliberately only `Send`, not `Sync`: a handler's
+/// [`Batch`](OutboxEventHandler::Batch) accumulator is only required to be
+/// `Send`, so a member cannot be shared across threads. That is why the two
+/// methods wrapping a foreign await take `&mut self` — a shared borrow held
+/// across an await would demand `Sync` and exclude perfectly good accumulators.
+pub(crate) trait MemberInstance<P>: Send
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+{
+    fn key(&self) -> &JobType;
+    fn subscription(&self) -> EventSubscription;
+
+    /// Whether this member holds collected items awaiting a flush.
+    fn dirty(&self) -> bool;
+
+    /// Resolve one persistent event through this member's handler, against the
+    /// group's shared batch state.
+    fn dispatch<'a>(
+        &'a mut self,
+        parts: CtxParts<'a>,
+        event: &'a PersistentOutboxEvent<P>,
+    ) -> BoxFuture<'a, Result<Outcome, HandlerError>>;
+
+    /// Apply this member's accumulator onto the landing op. No-op when clean.
+    fn flush_into<'a>(
+        &'a mut self,
+        op: &'a mut es_entity::DbOp<'static>,
+    ) -> BoxFuture<'a, Result<(), HandlerError>>;
+
+    /// Drop collected items without applying them — used when a landing rolls
+    /// back, so the replay re-collects from scratch rather than double-applying.
+    fn discard(&mut self);
+
+    fn handle_undecodable<'a>(
+        &'a mut self,
+        error: &'a UndecodableEventError,
+    ) -> BoxFuture<'a, Result<(), HandlerError>>;
+
+    fn handle_ephemeral<'a>(
+        &'a mut self,
+        event: &'a EphemeralOutboxEvent<P>,
+    ) -> BoxFuture<'a, Result<(), HandlerError>>;
+}
+
+struct TypedMember<H, P>
+where
+    H: OutboxEventHandler<P>,
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+{
+    key: JobType,
+    handler: Arc<H>,
+    batch: H::Batch,
+    dirty: bool,
+    flusher: super::job::HandlerFlusher<H, P>,
+}
+
+impl<H, P> MemberInstance<P> for TypedMember<H, P>
+where
+    H: OutboxEventHandler<P>,
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+{
+    fn key(&self) -> &JobType {
+        &self.key
+    }
+
+    fn subscription(&self) -> EventSubscription {
+        H::SUBSCRIPTION
+    }
+
+    fn dirty(&self) -> bool {
+        self.dirty
+    }
+
+    fn dispatch<'a>(
+        &'a mut self,
+        parts: CtxParts<'a>,
+        event: &'a PersistentOutboxEvent<P>,
+    ) -> BoxFuture<'a, Result<Outcome, HandlerError>> {
+        Box::pin(async move {
+            let ctx = EventCtx {
+                parts,
+                batch: &mut self.batch,
+                flusher: &self.flusher,
+            };
+            let outcome = self.handler.handle_persistent(ctx, event).await?.outcome;
+            if outcome == Outcome::Collect {
+                self.dirty = true;
+            }
+            Ok(outcome)
+        })
+    }
+
+    fn flush_into<'a>(
+        &'a mut self,
+        op: &'a mut es_entity::DbOp<'static>,
+    ) -> BoxFuture<'a, Result<(), HandlerError>> {
+        Box::pin(async move {
+            if !self.dirty {
+                return Ok(());
+            }
+            // Drain before the call, mirroring the solo path: on error the items
+            // go with the rolled-back op and the replay re-collects them.
+            let items = std::mem::take(&mut self.batch);
+            self.dirty = false;
+            let mut flush_op = FlushOp::new(op);
+            self.handler.flush(&mut flush_op, items).await
+        })
+    }
+
+    fn discard(&mut self) {
+        self.batch = H::Batch::default();
+        self.dirty = false;
+    }
+
+    fn handle_undecodable<'a>(
+        &'a mut self,
+        error: &'a UndecodableEventError,
+    ) -> BoxFuture<'a, Result<(), HandlerError>> {
+        Box::pin(self.handler.handle_undecodable(error))
+    }
+
+    fn handle_ephemeral<'a>(
+        &'a mut self,
+        event: &'a EphemeralOutboxEvent<P>,
+    ) -> BoxFuture<'a, Result<(), HandlerError>> {
+        Box::pin(self.handler.handle_ephemeral(event))
+    }
+}
+
+/// The members *other than* the one currently dispatching, split around it so a
+/// landing preserves registration order: `left` registered earlier, `right`
+/// later. Also used with an empty `right` for runner-initiated landings, where
+/// there is no dispatching member and `left` is the whole membership.
+struct GroupPeers<'a, P>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+{
+    left: &'a mut [Box<dyn MemberInstance<P>>],
+    right: &'a mut [Box<dyn MemberInstance<P>>],
+    /// Absolute membership index of `right[0]`, so a failure in the right half
+    /// can be attributed to the right member.
+    right_offset: usize,
+    /// Set when a peer's flush errors. A flush failure surfaces as a plain
+    /// `Err` out of the landing, which on its own says nothing about *whose*
+    /// work failed — and ejecting the wrong member would park a healthy handler
+    /// while leaving the poisoned one running.
+    failed: Option<usize>,
+}
+
+impl<P> PeerFlush for GroupPeers<'_, P>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+{
+    fn any_dirty(&self) -> bool {
+        self.left.iter().any(|m| m.dirty()) || self.right.iter().any(|m| m.dirty())
+    }
+
+    fn flush_before<'b>(
+        &'b mut self,
+        op: &'b mut es_entity::DbOp<'static>,
+    ) -> BoxFuture<'b, Result<(), HandlerError>> {
+        Box::pin(async move {
+            for (idx, member) in self.left.iter_mut().enumerate() {
+                if let Err(error) = member.flush_into(&mut *op).await {
+                    self.failed = Some(idx);
+                    return Err(error);
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn flush_after<'b>(
+        &'b mut self,
+        op: &'b mut es_entity::DbOp<'static>,
+    ) -> BoxFuture<'b, Result<(), HandlerError>> {
+        Box::pin(async move {
+            let offset = self.right_offset;
+            for (idx, member) in self.right.iter_mut().enumerate() {
+                if let Err(error) = member.flush_into(&mut *op).await {
+                    self.failed = Some(offset + idx);
+                    return Err(error);
+                }
+            }
+            Ok(())
+        })
+    }
+}
+
+/// A no-op [`ItemFlush`] for runner-initiated landings, which have no
+/// dispatching member and therefore no accumulator of their own — every
+/// member's items travel through [`GroupPeers`].
+struct NoItems;
+
+impl ItemFlush<()> for NoItems {
+    fn flush_items<'a>(
+        &'a self,
+        _op: &'a mut es_entity::DbOp<'static>,
+        _items: (),
+    ) -> BoxFuture<'a, Result<(), HandlerError>> {
+        Box::pin(std::future::ready(Ok(())))
+    }
+}
+
+// ── checkpoint ──────────────────────────────────────────────────────────────
+
+/// Every member's checkpoint, written as one execution-state row.
+pub(crate) struct GroupCheckpoint {
+    keys: Vec<String>,
+    seqs: Vec<EventSequence>,
+    /// Keys found in the persisted state but absent from the registered
+    /// membership — a handler that was temporarily unregistered. Kept verbatim
+    /// so re-registering it later resumes from where it stopped rather than
+    /// replaying from the beginning.
+    retained: BTreeMap<String, EventSequence>,
+    /// The batch's upper bound: the last sequence dispatched to anyone.
+    batch_end: EventSequence,
+}
+
+impl GroupCheckpoint {
+    fn sequence_of(&self, idx: usize) -> EventSequence {
+        self.seqs[idx]
+    }
+
+    /// Advance one member, monotonically: a member that started ahead of the
+    /// shared cursor is never dragged backwards.
+    fn advance(&mut self, idx: usize, sequence: EventSequence) {
+        if sequence > self.seqs[idx] {
+            self.seqs[idx] = sequence;
+        }
+        if sequence > self.batch_end {
+            self.batch_end = sequence;
+        }
+    }
+
+    /// Roll every member back to its last durable position after a failed
+    /// landing.
+    fn rewind_to(&mut self, committed: &[EventSequence]) {
+        self.seqs.copy_from_slice(committed);
+        self.batch_end = committed
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(EventSequence::BEGIN);
+    }
+
+    fn snapshot(&self) -> Vec<EventSequence> {
+        self.seqs.clone()
+    }
+}
+
+impl CheckpointState for GroupCheckpoint {
+    fn sequence(&self) -> EventSequence {
+        self.batch_end
+    }
+
+    fn persist<'a>(
+        &'a self,
+        current_job: &'a mut CurrentJob,
+        op: &'a mut es_entity::DbOp<'static>,
+    ) -> BoxFuture<'a, Result<(), HandlerError>> {
+        Box::pin(async move {
+            let mut members = self.retained.clone();
+            for (key, sequence) in self.keys.iter().zip(self.seqs.iter()) {
+                members.insert(key.clone(), *sequence);
+            }
+            current_job
+                .update_execution_state_in_op(op, &HandlerGroupJobState { members })
+                .await?;
+            Ok(())
+        })
+    }
+}
+
+// ── adoption ────────────────────────────────────────────────────────────────
+
+/// Take over a legacy solo handler job's checkpoint, if one exists.
+///
+/// Reads the solo job's persisted sequence and removes its execution row in one
+/// statement, so a handler that moves from solo to grouped resumes exactly where
+/// it left off instead of replaying the outbox from the beginning.
+///
+/// Deleting the execution row is what retires the legacy job: the job poller
+/// only ever fetches job types that have a registered initializer, and a grouped
+/// member no longer registers one — so the row is already inert. Removing it
+/// keeps a stale checkpoint from being resurrected if the handler is later moved
+/// back out of the group. The `jobs` / `job_events` rows are left as history.
+///
+/// This reaches into the job crate's schema, which obix already vendors
+/// (`migrations/20250904065521_job_setup.sql`). It exists only because the job
+/// crate has no public way to read the state of a job this process did not
+/// spawn and holds no handle to. Given `Jobs::unique_handle(&JobType) ->
+/// Option<JobHandle>`, the whole body collapses to
+/// `handle.load().await?.execution_state::<OutboxEventJobState>()?`.
+#[tracing::instrument(name = "obix.handler_group.adopt_solo_checkpoint", skip_all, fields(member = %member), err)]
+async fn adopt_solo_checkpoint(
+    pool: &sqlx::PgPool,
+    member: &JobType,
+) -> Result<Option<EventSequence>, sqlx::Error> {
+    let row = sqlx::query!(
+        "DELETE FROM job_executions WHERE job_type = $1 RETURNING execution_state_json",
+        member.as_str()
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row
+        .and_then(|row| row.execution_state_json)
+        .and_then(|json| serde_json::from_value::<OutboxEventJobState>(json).ok())
+        .map(|state| state.sequence))
+}
+
+// ── registry ────────────────────────────────────────────────────────────────
+
+/// One group's registered membership, shared between registration and the
+/// group job's initializer.
+pub(crate) struct GroupEntry<P> {
+    pub(crate) members: Vec<Arc<dyn MemberSpec<P>>>,
+    pub(crate) max_batch_size: usize,
+    pub(crate) checkpoint_interval: std::time::Duration,
+    /// Set when the group job snapshots its membership. Registrations after
+    /// this point are rejected rather than silently ignored.
+    pub(crate) started: bool,
+}
+
+pub(crate) type GroupRegistry<P> =
+    Arc<std::sync::RwLock<std::collections::HashMap<HandlerGroupName, GroupEntry<P>>>>;
+
+// ── job wiring ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub(crate) struct HandlerGroupJobData {}
+
+pub(crate) struct HandlerGroupJobInitializer<P, Tables>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+    Tables: MailboxTables,
+{
+    outbox: Outbox<P, Tables>,
+    registry: GroupRegistry<P>,
+    group: HandlerGroupName,
+    retry_settings: job::RetrySettings,
+}
+
+impl<P, Tables> HandlerGroupJobInitializer<P, Tables>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+    Tables: MailboxTables,
+{
+    pub(crate) fn new(
+        outbox: Outbox<P, Tables>,
+        registry: GroupRegistry<P>,
+        group: HandlerGroupName,
+        retry_settings: job::RetrySettings,
+    ) -> Self {
+        Self {
+            outbox,
+            registry,
+            group,
+            retry_settings,
+        }
+    }
+}
+
+impl<P, Tables> JobInitializer for HandlerGroupJobInitializer<P, Tables>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+    Tables: MailboxTables,
+{
+    type Config = HandlerGroupJobData;
+
+    fn job_type(&self) -> JobType {
+        self.group.job_type()
+    }
+
+    fn retry_on_error_settings(&self) -> job::RetrySettings {
+        self.retry_settings.clone()
+    }
+
+    fn init(
+        &self,
+        _job: &Job,
+        _: JobSpawner<Self::Config>,
+    ) -> Result<Box<dyn JobRunner>, Box<dyn std::error::Error>> {
+        // Snapshot membership: from here on the group is closed, and a late
+        // registration is an error rather than a handler that never runs.
+        let (specs, max_batch_size, checkpoint_interval) = {
+            let mut registry = self.registry.write().expect("group registry poisoned");
+            let entry = registry
+                .get_mut(&self.group)
+                .expect("group entry exists for a spawned group job");
+            entry.started = true;
+            (
+                entry.members.clone(),
+                entry.max_batch_size,
+                entry.checkpoint_interval,
+            )
+        };
+
+        Ok(Box::new(HandlerGroupJobRunner::<P, Tables> {
+            outbox: self.outbox.clone(),
+            group: self.group.clone(),
+            specs,
+            max_batch_size,
+            checkpoint_interval,
+        }))
+    }
+}
+
+/// The mutable state of one group run: the live members and everything that
+/// must move as a unit when a batch lands, rolls back, or ejects a member.
+///
+/// Held apart from the loop's stream handles so the landing/recovery logic can
+/// live in methods instead of being repeated at each of the batch's flush
+/// triggers.
+struct GroupBatch<P>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+{
+    members: Vec<Box<dyn MemberInstance<P>>>,
+    /// An ejected member is never dispatched to again; its parked checkpoint is
+    /// still written on every landing so a restart resumes it in place.
+    ejected: Vec<bool>,
+    persistent_member: Vec<bool>,
+    ephemeral_member: Vec<bool>,
+    checkpoint: GroupCheckpoint,
+    /// Every member's last durable position — where a failed landing rewinds to.
+    committed: Vec<EventSequence>,
+    tracker: BatchTracker,
+    op_slot: Option<es_entity::DbOp<'static>>,
+}
+
+/// Outcome of a landing that did not commit.
+enum LandFailure {
+    /// Attributable to one member's flush: eject it and replay the batch.
+    Member(usize, HandlerError),
+    /// Not attributable to a member (checkpoint write, commit) — the group job
+    /// fails and the runner's own retry re-attaches everyone.
+    Fatal(HandlerError),
+}
+
+impl<P> GroupBatch<P>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+{
+    fn new(members: Vec<Box<dyn MemberInstance<P>>>, checkpoint: GroupCheckpoint) -> Self {
+        let persistent_member = members
+            .iter()
+            .map(|m| m.subscription() != EventSubscription::EphemeralOnly)
+            .collect();
+        let ephemeral_member = members
+            .iter()
+            .map(|m| m.subscription() != EventSubscription::PersistentOnly)
+            .collect();
+        let committed = checkpoint.snapshot();
+        let tracker = BatchTracker {
+            events_in_op: 0,
+            collected: 0,
+            persisted_seq: checkpoint.sequence(),
+            last_persist: tokio::time::Instant::now(),
+        };
+        Self {
+            ejected: vec![false; members.len()],
+            members,
+            persistent_member,
+            ephemeral_member,
+            checkpoint,
+            committed,
+            tracker,
+            op_slot: None,
+        }
+    }
+
+    fn pending(&self) -> bool {
+        self.op_slot.is_some() || self.tracker.collected > 0
+    }
+
+    fn all_ejected(&self) -> bool {
+        self.ejected.iter().all(|e| *e)
+    }
+
+    fn wants_ephemeral(&self) -> bool {
+        self.ephemeral_member.iter().any(|w| *w)
+    }
+
+    /// Where the shared listener must sit: the minimum checkpoint across the
+    /// members still being delivered to.
+    fn cursor(&self) -> EventSequence {
+        self.checkpoint
+            .seqs
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| !self.ejected[*idx] && self.persistent_member[*idx])
+            .map(|(_, sequence)| *sequence)
+            .min()
+            .unwrap_or_else(|| self.checkpoint.sequence())
+    }
+
+    /// Should this member see this event? False once it is already past it —
+    /// the per-member delivery filter, which is what lets one shared stream
+    /// serve members at different positions.
+    fn deliver_to(&self, idx: usize, sequence: EventSequence) -> bool {
+        !self.ejected[idx]
+            && self.persistent_member[idx]
+            && sequence > self.checkpoint.sequence_of(idx)
+    }
+
+    /// Discard the pending batch without applying it: the op rolls back with
+    /// the drop, accumulators are cleared so the replay re-collects, and every
+    /// member returns to its last durable checkpoint.
+    fn roll_back(&mut self) {
+        self.op_slot = None;
+        for member in self.members.iter_mut() {
+            member.discard();
+        }
+        self.tracker.collected = 0;
+        self.tracker.events_in_op = 0;
+        self.checkpoint.rewind_to(&self.committed);
+    }
+
+    /// Land the pending batch: every dirty member's flush in registration
+    /// order, one state write carrying every member's checkpoint, then commit —
+    /// one transaction.
+    async fn land(
+        &mut self,
+        current_job: &mut CurrentJob,
+        reason: &'static str,
+    ) -> Result<(), LandFailure> {
+        let mut peers = GroupPeers {
+            left: &mut self.members,
+            right: &mut [],
+            right_offset: 0,
+            failed: None,
+        };
+        // Scoped so the borrows of `peers` and of `self`'s fields end before the
+        // failure attribution below reads them back.
+        let result = {
+            let mut parts = CtxParts {
+                op_slot: &mut self.op_slot,
+                current_job,
+                checkpoint: &self.checkpoint,
+                tracker: &mut self.tracker,
+                peers: &mut peers,
+                own_dirty: false,
+            };
+            flush_batch(&mut parts, &mut (), &NoItems, reason).await
+        };
+        let failed = peers.failed;
+
+        match result {
+            Ok(()) => {
+                self.committed = self.checkpoint.snapshot();
+                Ok(())
+            }
+            Err(error) => Err(match failed {
+                Some(idx) => LandFailure::Member(idx, error),
+                None => LandFailure::Fatal(error),
+            }),
+        }
+    }
+
+    /// Park a member at its last committed sequence and stop delivering to it.
+    fn eject(&mut self, group: &HandlerGroupName, idx: usize, error: &HandlerError, stage: &str) {
+        self.ejected[idx] = true;
+        record_ejection(group, self.members[idx].key(), stage, error);
+    }
+}
+
+struct HandlerGroupJobRunner<P, Tables>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+    Tables: MailboxTables,
+{
+    outbox: Outbox<P, Tables>,
+    group: HandlerGroupName,
+    specs: Vec<Arc<dyn MemberSpec<P>>>,
+    max_batch_size: usize,
+    checkpoint_interval: std::time::Duration,
+}
+
+#[async_trait]
+impl<P, Tables> JobRunner for HandlerGroupJobRunner<P, Tables>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+    Tables: MailboxTables,
+{
+    async fn run(
+        &self,
+        current_job: CurrentJob,
+    ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        if self
+            .specs
+            .iter()
+            .any(|s| s.subscription() != EventSubscription::EphemeralOnly)
+        {
+            self.run_with_persistent(current_job).await
+        } else {
+            self.run_ephemeral_only(current_job).await
+        }
+    }
+}
+
+impl<P, Tables> HandlerGroupJobRunner<P, Tables>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+    Tables: MailboxTables,
+{
+    /// Every member is [`EphemeralOnly`](EventSubscription::EphemeralOnly): a
+    /// bare fan-out loop, with none of the checkpoint or batch machinery.
+    async fn run_ephemeral_only(
+        &self,
+        mut current_job: CurrentJob,
+    ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        let mut members: Vec<Box<dyn MemberInstance<P>>> =
+            self.specs.iter().map(|spec| spec.instantiate()).collect();
+        let mut ephemeral = self.outbox.listen_ephemeral();
+        loop {
+            tokio::select! {
+                biased;
+                _ = current_job.shutdown_requested() => {
+                    return Ok(JobCompletion::RescheduleNow);
+                }
+                event = ephemeral.next() => match event {
+                    Some(event) => {
+                        for member in members.iter_mut() {
+                            member
+                                .handle_ephemeral(&event)
+                                .await
+                                .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        }
+                    }
+                    None => return Ok(JobCompletion::RescheduleNow),
+                },
+            }
+        }
+    }
+
+    async fn run_with_persistent(
+        &self,
+        mut current_job: CurrentJob,
+    ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        let members: Vec<Box<dyn MemberInstance<P>>> =
+            self.specs.iter().map(|spec| spec.instantiate()).collect();
+        // Keys are lifted out before the first await: a member is only `Send`,
+        // so no borrow of the membership may span one.
+        let member_keys: Vec<JobType> = members.iter().map(|m| m.key().clone()).collect();
+        let checkpoint = self.init_checkpoint(&member_keys, &current_job).await?;
+        let mut batch = GroupBatch::new(members, checkpoint);
+
+        let mut persistent = self.outbox.listen_persisted(Some(batch.cursor()));
+        let mut ephemeral = batch
+            .wants_ephemeral()
+            .then(|| self.outbox.listen_ephemeral());
+
+        loop {
+            let item = if batch.pending() {
+                // A batch is pending: take only already-buffered events, never
+                // holding the batch open across the network.
+                match persistent.next().now_or_never() {
+                    Some(Some(item)) => item,
+                    Some(None) => {
+                        self.land(
+                            &mut batch,
+                            &mut current_job,
+                            &mut persistent,
+                            "stream_closed",
+                        )
+                        .await?;
+                        return Ok(JobCompletion::RescheduleNow);
+                    }
+                    None => {
+                        self.land(
+                            &mut batch,
+                            &mut current_job,
+                            &mut persistent,
+                            "backlog_drained",
+                        )
+                        .await?;
+                        continue;
+                    }
+                }
+            } else {
+                let next = tokio::select! {
+                    biased;
+                    _ = current_job.shutdown_requested() => {
+                        if batch.tracker.persisted_seq < batch.checkpoint.sequence() {
+                            persist_checkpoint(&mut current_job, &batch.checkpoint)
+                                .await
+                                .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        }
+                        return Ok(JobCompletion::RescheduleNow);
+                    }
+                    _ = tokio::time::sleep_until(
+                        batch.tracker.last_persist + self.checkpoint_interval,
+                    ), if batch.tracker.persisted_seq < batch.checkpoint.sequence() => {
+                        persist_checkpoint(&mut current_job, &batch.checkpoint)
+                            .await
+                            .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        batch.tracker.persisted_seq = batch.checkpoint.sequence();
+                        batch.tracker.last_persist = tokio::time::Instant::now();
+                        batch.committed = batch.checkpoint.snapshot();
+                        continue;
+                    }
+                    next = async {
+                        tokio::select! {
+                            Some(event) = next_ephemeral(&mut ephemeral) => {
+                                Delivery::Ephemeral(event)
+                            }
+                            event = persistent.next() => Delivery::Persistent(event),
+                        }
+                    } => next,
+                };
+                match next {
+                    Delivery::Ephemeral(event) => {
+                        // Nothing is pending here by construction, so no
+                        // transaction spans these foreign awaits.
+                        for idx in 0..batch.members.len() {
+                            if batch.ejected[idx] || !batch.ephemeral_member[idx] {
+                                continue;
+                            }
+                            if let Err(error) = batch.members[idx].handle_ephemeral(&event).await {
+                                batch.eject(&self.group, idx, &error, "ephemeral");
+                            }
+                        }
+                        if batch.all_ejected() {
+                            return Err(all_ejected(&self.group));
+                        }
+                        continue;
+                    }
+                    Delivery::Persistent(Some(item)) => item,
+                    Delivery::Persistent(None) => {
+                        if batch.tracker.persisted_seq < batch.checkpoint.sequence() {
+                            persist_checkpoint(&mut current_job, &batch.checkpoint)
+                                .await
+                                .map_err(|e| e as Box<dyn std::error::Error>)?;
+                        }
+                        return Ok(JobCompletion::RescheduleNow);
+                    }
+                }
+            };
+
+            // An undecodable payload lands the batch first, then each member
+            // decides its own fate: `Ok` advances that member past the event,
+            // `Err` parks it before the event while its siblings continue.
+            let event = match item {
+                Ok(event) => event,
+                Err(undecodable) => {
+                    self.land(
+                        &mut batch,
+                        &mut current_job,
+                        &mut persistent,
+                        "undecodable_event",
+                    )
+                    .await?;
+                    for idx in 0..batch.members.len() {
+                        if !batch.deliver_to(idx, undecodable.sequence) {
+                            continue;
+                        }
+                        match batch.members[idx].handle_undecodable(&undecodable).await {
+                            Ok(()) => batch.checkpoint.advance(idx, undecodable.sequence),
+                            Err(error) => batch.eject(&self.group, idx, &error, "undecodable"),
+                        }
+                    }
+                    if batch.all_ejected() {
+                        return Err(all_ejected(&self.group));
+                    }
+                    continue;
+                }
+            };
+
+            let mut close_batch = false;
+            let mut member_failed = false;
+            for idx in 0..batch.members.len() {
+                if !batch.deliver_to(idx, event.sequence) {
+                    continue;
+                }
+
+                let (left, rest) = batch.members.split_at_mut(idx);
+                let (member, right) = rest.split_first_mut().expect("idx is in bounds");
+                let mut peers = GroupPeers {
+                    left,
+                    right,
+                    right_offset: idx + 1,
+                    failed: None,
+                };
+                let own_dirty = member.dirty();
+                let parts = CtxParts {
+                    op_slot: &mut batch.op_slot,
+                    current_job: &mut current_job,
+                    checkpoint: &batch.checkpoint,
+                    tracker: &mut batch.tracker,
+                    peers: &mut peers,
+                    own_dirty,
+                };
+
+                let outcome = member.dispatch(parts, &event).await;
+                // A peer's flush can fail inside this member's `consume_isolated`
+                // fence — then the fault is the peer's, not the dispatcher's.
+                let culprit = peers.failed.unwrap_or(idx);
+
+                match outcome {
+                    Ok(outcome) => {
+                        batch.checkpoint.advance(idx, event.sequence);
+                        if outcome == Outcome::Commit {
+                            close_batch = true;
+                        }
+                    }
+                    Err(error) => {
+                        batch.roll_back();
+                        batch.eject(&self.group, culprit, &error, "persistent");
+                        member_failed = true;
+                        break;
+                    }
+                }
+            }
+
+            if member_failed {
+                if batch.all_ejected() {
+                    return Err(all_ejected(&self.group));
+                }
+                // Replay the batch from the last durable position, without the
+                // member that could not handle it.
+                persistent = self.outbox.listen_persisted(Some(batch.cursor()));
+                continue;
+            }
+
+            if close_batch {
+                self.land(&mut batch, &mut current_job, &mut persistent, "commit")
+                    .await?;
+            } else if batch.tracker.events_in_op >= self.max_batch_size {
+                self.land(&mut batch, &mut current_job, &mut persistent, "batch_full")
+                    .await?;
+            }
+        }
+    }
+
+    /// Land the batch, ejecting and replaying instead of failing when the
+    /// fault belongs to one member's flush.
+    async fn land(
+        &self,
+        batch: &mut GroupBatch<P>,
+        current_job: &mut CurrentJob,
+        persistent: &mut super::PersistentOutboxListener<P>,
+        reason: &'static str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match batch.land(current_job, reason).await {
+            Ok(()) => Ok(()),
+            Err(LandFailure::Fatal(error)) => Err(error as Box<dyn std::error::Error>),
+            Err(LandFailure::Member(idx, error)) => {
+                batch.roll_back();
+                batch.eject(&self.group, idx, &error, "flush");
+                if batch.all_ejected() {
+                    return Err(all_ejected(&self.group));
+                }
+                *persistent = self.outbox.listen_persisted(Some(batch.cursor()));
+                Ok(())
+            }
+        }
+    }
+
+    /// Seed each member's checkpoint: a legacy solo job's position if one
+    /// exists, else the group's own persisted state, else the beginning.
+    async fn init_checkpoint(
+        &self,
+        member_keys: &[JobType],
+        current_job: &CurrentJob,
+    ) -> Result<GroupCheckpoint, Box<dyn std::error::Error>> {
+        let persisted = current_job
+            .execution_state::<HandlerGroupJobState>()?
+            .unwrap_or_default();
+
+        let mut keys = Vec::with_capacity(member_keys.len());
+        let mut seqs = Vec::with_capacity(member_keys.len());
+        for member_key in member_keys {
+            let key = member_key.as_str().to_string();
+            let sequence = match adopt_solo_checkpoint(current_job.pool(), member_key).await? {
+                Some(adopted) => {
+                    tracing::info!(
+                        group = %self.group,
+                        member = %member_key,
+                        sequence = %adopted,
+                        "adopted solo handler checkpoint into handler group"
+                    );
+                    adopted
+                }
+                None => persisted.members.get(&key).copied().unwrap_or_default(),
+            };
+            keys.push(key);
+            seqs.push(sequence);
+        }
+
+        // Anything persisted for a key we no longer register is kept as-is.
+        let retained = persisted
+            .members
+            .iter()
+            .filter(|(key, _)| !keys.contains(key))
+            .map(|(key, sequence)| (key.clone(), *sequence))
+            .collect::<BTreeMap<_, _>>();
+        for key in retained.keys() {
+            tracing::info!(
+                group = %self.group,
+                member = %key,
+                "retaining checkpoint for a member that is not currently registered"
+            );
+        }
+
+        let batch_end = seqs.iter().copied().max().unwrap_or(EventSequence::BEGIN);
+        Ok(GroupCheckpoint {
+            keys,
+            seqs,
+            retained,
+            batch_end,
+        })
+    }
+}
+
+fn all_ejected(group: &HandlerGroupName) -> Box<dyn std::error::Error> {
+    format!("handler group '{group}': every member ejected").into()
+}
+
+#[tracing::instrument(name = "obix.handler_group.member_ejected", level = "error", skip(error), fields(error = %error))]
+fn record_ejection(group: &HandlerGroupName, member: &JobType, stage: &str, error: &HandlerError) {}
+
+enum Delivery<P>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    Persistent(Option<Result<Arc<PersistentOutboxEvent<P>>, UndecodableEventError>>),
+    Ephemeral(Arc<EphemeralOutboxEvent<P>>),
+}
+
+async fn next_ephemeral<P>(
+    listener: &mut Option<EphemeralOutboxListener<P>>,
+) -> Option<Arc<EphemeralOutboxEvent<P>>>
+where
+    P: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+{
+    match listener {
+        Some(listener) => listener.next().await,
+        None => std::future::pending().await,
+    }
+}

--- a/src/out/job.rs
+++ b/src/out/job.rs
@@ -8,6 +8,7 @@ use job::{
 };
 
 use super::ctx::*;
+use super::group::HandlerGroupName;
 use super::{EphemeralOutboxListener, Outbox, event::*};
 use crate::tables::MailboxTables;
 
@@ -167,9 +168,18 @@ where
 /// handler type erased.
 ///
 /// [`flush`]: OutboxEventHandler::flush
-struct HandlerFlusher<H, P> {
+pub(super) struct HandlerFlusher<H, P> {
     handler: Arc<H>,
     _payload: std::marker::PhantomData<fn() -> P>,
+}
+
+impl<H, P> HandlerFlusher<H, P> {
+    pub(super) fn new(handler: Arc<H>) -> Self {
+        Self {
+            handler,
+            _payload: std::marker::PhantomData,
+        }
+    }
 }
 
 impl<H, P> ItemFlush<H::Batch> for HandlerFlusher<H, P>
@@ -222,6 +232,7 @@ pub struct OutboxEventJobConfig {
     pub retry_settings: RetrySettings,
     pub max_batch_size: usize,
     pub checkpoint_interval: std::time::Duration,
+    pub group: Option<HandlerGroupName>,
 }
 
 impl OutboxEventJobConfig {
@@ -231,7 +242,27 @@ impl OutboxEventJobConfig {
             retry_settings: RetrySettings::repeat_indefinitely(),
             max_batch_size: DEFAULT_MAX_BATCH_SIZE,
             checkpoint_interval: DEFAULT_CHECKPOINT_INTERVAL,
+            group: None,
         }
+    }
+
+    /// Host this handler on the named group's shared job instead of a job of
+    /// its own — see the [group module docs](super::group).
+    ///
+    /// The first handler registered into a group creates it; later ones join.
+    /// Members keep their own checkpoint, their own accumulator and their own
+    /// failure domain, but share one job slot, one outbox subscription and one
+    /// landing transaction. The handler itself is unchanged: `job_type` remains
+    /// its stable identity for checkpointing, adoption and tracing.
+    ///
+    /// Every member must be registered before the job poller starts, since the
+    /// group snapshots its membership when its job begins. `max_batch_size` and
+    /// `checkpoint_interval` govern the shared landing and so are taken from the
+    /// first registration; a later member setting them differently is a
+    /// registration error rather than a silent fold.
+    pub fn in_group(mut self, group: &HandlerGroupName) -> Self {
+        self.group = Some(group.clone());
+        self
     }
 
     pub fn with_retry_settings(mut self, settings: RetrySettings) -> Self {
@@ -430,11 +461,14 @@ where
                 match persistent.next().now_or_never() {
                     Some(Some(item)) => item,
                     Some(None) => {
+                        let own_dirty = tracker.collected > 0;
                         let mut parts = CtxParts {
                             op_slot: &mut op_slot,
                             current_job: &mut current_job,
-                            state: &state,
+                            checkpoint: &state,
                             tracker: &mut tracker,
+                            peers: &mut NoPeers,
+                            own_dirty,
                         };
                         flush_batch(&mut parts, &mut batch, &flusher, "stream_closed")
                             .await
@@ -442,11 +476,14 @@ where
                         return Ok(JobCompletion::RescheduleNow);
                     }
                     None => {
+                        let own_dirty = tracker.collected > 0;
                         let mut parts = CtxParts {
                             op_slot: &mut op_slot,
                             current_job: &mut current_job,
-                            state: &state,
+                            checkpoint: &state,
                             tracker: &mut tracker,
+                            peers: &mut NoPeers,
+                            own_dirty,
                         };
                         flush_batch(&mut parts, &mut batch, &flusher, "backlog_drained")
                             .await
@@ -526,11 +563,14 @@ where
             let event = match item {
                 Ok(event) => event,
                 Err(undecodable) => {
+                    let own_dirty = tracker.collected > 0;
                     let mut parts = CtxParts {
                         op_slot: &mut op_slot,
                         current_job: &mut current_job,
-                        state: &state,
+                        checkpoint: &state,
                         tracker: &mut tracker,
+                        peers: &mut NoPeers,
+                        own_dirty,
                     };
                     flush_batch(&mut parts, &mut batch, &flusher, "undecodable_event")
                         .await
@@ -552,12 +592,15 @@ where
                 }
             };
 
+            let own_dirty = tracker.collected > 0;
             let ctx = EventCtx {
                 parts: CtxParts {
                     op_slot: &mut op_slot,
                     current_job: &mut current_job,
-                    state: &state,
+                    checkpoint: &state,
                     tracker: &mut tracker,
+                    peers: &mut NoPeers,
+                    own_dirty,
                 },
                 batch: &mut batch,
                 flusher: &flusher,
@@ -577,11 +620,14 @@ where
             match outcome {
                 Outcome::Skip => {}
                 Outcome::Commit => {
+                    let own_dirty = tracker.collected > 0;
                     let mut parts = CtxParts {
                         op_slot: &mut op_slot,
                         current_job: &mut current_job,
-                        state: &state,
+                        checkpoint: &state,
                         tracker: &mut tracker,
+                        peers: &mut NoPeers,
+                        own_dirty,
                     };
                     flush_batch(&mut parts, &mut batch, &flusher, "commit")
                         .await
@@ -589,11 +635,14 @@ where
                 }
                 Outcome::Defer | Outcome::Collect => {
                     if tracker.events_in_op >= self.max_batch_size {
+                        let own_dirty = tracker.collected > 0;
                         let mut parts = CtxParts {
                             op_slot: &mut op_slot,
                             current_job: &mut current_job,
-                            state: &state,
+                            checkpoint: &state,
                             tracker: &mut tracker,
+                            peers: &mut NoPeers,
+                            own_dirty,
                         };
                         flush_batch(&mut parts, &mut batch, &flusher, "batch_full")
                             .await

--- a/src/out/mod.rs
+++ b/src/out/mod.rs
@@ -4,6 +4,7 @@ mod ephemeral;
 mod ephemeral_events_hook;
 mod event;
 mod gap_fill;
+pub mod group;
 mod job;
 mod notifier;
 mod op_cursor;
@@ -19,6 +20,7 @@ use serde::{Serialize, de::DeserializeOwned};
 use std::sync::Arc;
 
 pub use self::ctx::{BatchOp, EventCtx, FlushError, FlushOp, Handled, IsolatedOp};
+pub use self::group::{HandlerGroupError, HandlerGroupName};
 pub use self::job::{EventSubscription, OutboxEventHandler, OutboxEventJobConfig};
 use crate::{config::*, handle::OwnedTaskHandle, sequence::EventSequence, tables::*};
 pub use all_listener::AllOutboxListener;
@@ -56,6 +58,11 @@ where
     /// registration swaps in a rebuilt slice, publishes snapshot it with a
     /// single `Arc` clone.
     post_persist_hooks: Arc<std::sync::RwLock<post_persist_hook::PostPersistHooks<P>>>,
+    /// Handler groups declared via
+    /// [`OutboxEventJobConfig::in_group`](OutboxEventJobConfig::in_group),
+    /// shared across clones. Registration appends members; the group job's
+    /// initializer snapshots the membership when the job starts.
+    handler_groups: group::GroupRegistry<P>,
 }
 
 impl<P, Tables> std::fmt::Debug for Outbox<P, Tables>
@@ -89,6 +96,7 @@ where
             gap_filler: self.gap_filler.clone(),
             clock: self.clock.clone(),
             post_persist_hooks: self.post_persist_hooks.clone(),
+            handler_groups: self.handler_groups.clone(),
         }
     }
 }
@@ -151,6 +159,7 @@ where
             gap_filler,
             clock: config.clock.clone(),
             post_persist_hooks: Arc::new(std::sync::RwLock::new(Vec::new().into())),
+            handler_groups: Arc::new(std::sync::RwLock::new(Default::default())),
         })
     }
 
@@ -358,6 +367,13 @@ where
         )
     }
 
+    /// Register `handler` against this outbox.
+    ///
+    /// By default the handler gets a resident job of its own, keyed by
+    /// `config.job_type`. When the config names a group via
+    /// [`in_group`](OutboxEventJobConfig::in_group) the handler instead joins
+    /// that group's shared job — see the [group module docs](group) for what is
+    /// shared and what stays per-handler.
     pub async fn register_event_handler<H>(
         &self,
         jobs: &mut ::job::Jobs,
@@ -367,12 +383,103 @@ where
     where
         H: OutboxEventHandler<P>,
     {
+        if let Some(group) = config.group.clone() {
+            return self
+                .register_group_member(jobs, group, config, handler)
+                .await;
+        }
         let initializer =
             job::OutboxEventJobInitializer::<H, P, Tables>::new(self.clone(), handler, &config);
         let spawner = jobs.add_initializer(initializer);
         spawner
             .spawn_unique(::job::JobId::new(), job::OutboxEventJobData::default())
             .await?;
+        Ok(())
+    }
+
+    /// Add `handler` to `group`, creating the group (and spawning its single
+    /// resident job) on the first member.
+    async fn register_group_member<H>(
+        &self,
+        jobs: &mut ::job::Jobs,
+        group: HandlerGroupName,
+        config: OutboxEventJobConfig,
+        handler: H,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+    where
+        H: OutboxEventHandler<P>,
+    {
+        let spec = group::member_spec::<H, P>(config.job_type.clone(), handler);
+
+        let is_first = {
+            let mut registry = self
+                .handler_groups
+                .write()
+                .expect("handler group registry poisoned");
+            match registry.get_mut(&group) {
+                Some(entry) => {
+                    if entry.started {
+                        return Err(Box::new(HandlerGroupError::GroupAlreadyStarted {
+                            group,
+                            member: config.job_type,
+                        }));
+                    }
+                    if entry.members.iter().any(|m| m.key() == &config.job_type) {
+                        return Err(Box::new(HandlerGroupError::DuplicateMember {
+                            group,
+                            member: config.job_type,
+                        }));
+                    }
+                    // These govern the shared landing, so they belong to the
+                    // group as a whole — disagreement is an error, not a fold.
+                    if entry.max_batch_size != config.max_batch_size {
+                        return Err(Box::new(HandlerGroupError::ConflictingGroupSetting {
+                            group,
+                            member: config.job_type,
+                            setting: "max_batch_size",
+                            group_value: entry.max_batch_size.to_string(),
+                            member_value: config.max_batch_size.to_string(),
+                        }));
+                    }
+                    if entry.checkpoint_interval != config.checkpoint_interval {
+                        return Err(Box::new(HandlerGroupError::ConflictingGroupSetting {
+                            group,
+                            member: config.job_type,
+                            setting: "checkpoint_interval",
+                            group_value: format!("{:?}", entry.checkpoint_interval),
+                            member_value: format!("{:?}", config.checkpoint_interval),
+                        }));
+                    }
+                    entry.members.push(spec);
+                    false
+                }
+                None => {
+                    registry.insert(
+                        group.clone(),
+                        group::GroupEntry {
+                            members: vec![spec],
+                            max_batch_size: config.max_batch_size,
+                            checkpoint_interval: config.checkpoint_interval,
+                            started: false,
+                        },
+                    );
+                    true
+                }
+            }
+        };
+
+        if is_first {
+            let initializer = group::HandlerGroupJobInitializer::<P, Tables>::new(
+                self.clone(),
+                self.handler_groups.clone(),
+                group,
+                config.retry_settings,
+            );
+            let spawner = jobs.add_initializer(initializer);
+            spawner
+                .spawn_unique(::job::JobId::new(), group::HandlerGroupJobData::default())
+                .await?;
+        }
         Ok(())
     }
 

--- a/tests/handler_groups.rs
+++ b/tests/handler_groups.rs
@@ -1,0 +1,625 @@
+mod helpers;
+
+use std::sync::Arc;
+
+use obix::{
+    EventCtx, FlushOp, Handled, HandlerGroupName, MailboxConfig, OutboxEventHandler,
+    OutboxEventJobConfig, out::Outbox,
+};
+use serde::{Deserialize, Serialize};
+use serial_test::file_serial;
+use tokio::sync::Mutex;
+
+use helpers::{TestTables, init_pool, wipeout_outbox_job_tables, wipeout_outbox_tables};
+
+const GROUP: HandlerGroupName = HandlerGroupName::new("test-handler-group");
+const MEMBER_A: &str = "test-group-member-a";
+const MEMBER_B: &str = "test-group-member-b";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+enum TestEvent {
+    Ping(u64),
+}
+
+/// Records what it saw and skips — no transaction on its behalf.
+struct Observer {
+    received: Arc<Mutex<Vec<u64>>>,
+}
+
+impl OutboxEventHandler<TestEvent> for Observer {
+    type Batch = ();
+
+    async fn handle_persistent<'inv>(
+        &self,
+        ctx: EventCtx<'inv>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(TestEvent::Ping(n)) = &event.payload {
+            self.received.lock().await.push(*n);
+        }
+        Ok(ctx.skip())
+    }
+}
+
+/// Collects into a `Vec` and flushes the whole accumulator into a table inside
+/// the landing transaction — so its rows are durable exactly when the group's
+/// checkpoint is.
+struct Collector {
+    tag: &'static str,
+    fail_flush_at: Option<u64>,
+}
+
+impl OutboxEventHandler<TestEvent> for Collector {
+    type Batch = Vec<u64>;
+
+    async fn handle_persistent<'inv>(
+        &self,
+        ctx: EventCtx<'inv, Vec<u64>>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
+        match &event.payload {
+            Some(TestEvent::Ping(n)) => Ok(ctx.collect(*n)),
+            None => Ok(ctx.skip()),
+        }
+    }
+
+    async fn flush(
+        &self,
+        op: &mut FlushOp<'_>,
+        items: Vec<u64>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(poison) = self.fail_flush_at
+            && items.contains(&poison)
+        {
+            return Err("collector flush failed".into());
+        }
+        use es_entity::AtomicOperation;
+        for n in items {
+            sqlx::query(
+                "INSERT INTO test_group_effects (tag, n) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+            )
+            .bind(self.tag)
+            .bind(n as i64)
+            .execute(op.as_executor())
+            .await?;
+        }
+        Ok(())
+    }
+}
+
+/// Fails on one specific event, so the group must eject it and keep going.
+struct Poisoned {
+    poison: u64,
+    received: Arc<Mutex<Vec<u64>>>,
+}
+
+impl OutboxEventHandler<TestEvent> for Poisoned {
+    type Batch = ();
+
+    async fn handle_persistent<'inv>(
+        &self,
+        ctx: EventCtx<'inv>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(TestEvent::Ping(n)) = &event.payload {
+            if *n == self.poison {
+                return Err("poisoned event".into());
+            }
+            self.received.lock().await.push(*n);
+        }
+        Ok(ctx.skip())
+    }
+}
+
+/// Isolates one specific event, fencing it from the pending group batch.
+struct Isolator {
+    isolate_at: u64,
+}
+
+impl OutboxEventHandler<TestEvent> for Isolator {
+    type Batch = ();
+
+    async fn handle_persistent<'inv>(
+        &self,
+        ctx: EventCtx<'inv>,
+        event: &obix::out::PersistentOutboxEvent<TestEvent>,
+    ) -> Result<Handled<'inv>, Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(TestEvent::Ping(n)) = &event.payload
+            && *n == self.isolate_at
+        {
+            let op = ctx.consume_isolated().await?;
+            return Ok(op.commit());
+        }
+        Ok(ctx.skip())
+    }
+}
+
+// ── harness ─────────────────────────────────────────────────────────────────
+
+async fn reset(pool: &sqlx::PgPool) -> anyhow::Result<()> {
+    wipeout_outbox_tables(pool).await?;
+    for job_type in [GROUP.as_str(), MEMBER_A, MEMBER_B] {
+        wipeout_outbox_job_tables(pool, job_type).await?;
+    }
+    sqlx::query("DROP TABLE IF EXISTS test_group_effects")
+        .execute(pool)
+        .await?;
+    sqlx::query("CREATE TABLE test_group_effects (tag TEXT NOT NULL, n BIGINT NOT NULL, PRIMARY KEY (tag, n))")
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+async fn init_outbox(pool: &sqlx::PgPool) -> anyhow::Result<Outbox<TestEvent, TestTables>> {
+    Ok(Outbox::<TestEvent, TestTables>::init(
+        pool,
+        MailboxConfig::builder()
+            .build()
+            .expect("Couldn't build MailboxConfig"),
+    )
+    .await?)
+}
+
+fn member(job_type: &'static str) -> OutboxEventJobConfig {
+    OutboxEventJobConfig::new(job::JobType::new(job_type)).in_group(&GROUP)
+}
+
+async fn jobs_for(pool: &sqlx::PgPool) -> anyhow::Result<job::Jobs> {
+    let config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .unwrap();
+    Ok(job::Jobs::init(config).await?)
+}
+
+async fn publish(outbox: &Outbox<TestEvent, TestTables>, ns: &[u64]) -> anyhow::Result<()> {
+    let mut op = outbox.begin_op().await?;
+    for n in ns {
+        outbox
+            .publish_persisted_in_op(&mut op, TestEvent::Ping(*n))
+            .await?;
+    }
+    op.commit().await?;
+    Ok(())
+}
+
+async fn wait_for(
+    received: &Mutex<Vec<u64>>,
+    n: usize,
+    timeout: std::time::Duration,
+) -> anyhow::Result<()> {
+    let start = std::time::Instant::now();
+    loop {
+        if received.lock().await.len() >= n {
+            return Ok(());
+        }
+        if start.elapsed() > timeout {
+            anyhow::bail!(
+                "timeout waiting for {n} deliveries, got {:?}",
+                received.lock().await
+            );
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+}
+
+/// The group's persisted per-member checkpoint map.
+async fn group_state(
+    pool: &sqlx::PgPool,
+) -> anyhow::Result<Option<std::collections::BTreeMap<String, i64>>> {
+    let row: Option<(Option<serde_json::Value>,)> = sqlx::query_as(
+        "SELECT je.execution_state_json FROM job_executions je \
+         JOIN jobs j ON j.id = je.id WHERE j.job_type = $1",
+    )
+    .bind(GROUP.as_str())
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.and_then(|(json,)| json).and_then(|json| {
+        json.get("members")
+            .and_then(|m| serde_json::from_value(m.clone()).ok())
+    }))
+}
+
+async fn wait_for_member_checkpoint(
+    pool: &sqlx::PgPool,
+    member: &str,
+    expected: i64,
+) -> anyhow::Result<()> {
+    let start = std::time::Instant::now();
+    loop {
+        if let Some(members) = group_state(pool).await?
+            && members.get(member) == Some(&expected)
+        {
+            return Ok(());
+        }
+        if start.elapsed() > std::time::Duration::from_secs(10) {
+            anyhow::bail!(
+                "timeout waiting for {member} checkpoint {expected}, at {:?}",
+                group_state(pool).await?
+            );
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+}
+
+async fn effect_rows(pool: &sqlx::PgPool, tag: &str) -> anyhow::Result<Vec<i64>> {
+    let rows: Vec<(i64,)> =
+        sqlx::query_as("SELECT n FROM test_group_effects WHERE tag = $1 ORDER BY n")
+            .bind(tag)
+            .fetch_all(pool)
+            .await?;
+    Ok(rows.into_iter().map(|(n,)| n).collect())
+}
+
+async fn running_jobs(pool: &sqlx::PgPool, job_types: &[&str]) -> anyhow::Result<i64> {
+    let (count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM job_executions je JOIN jobs j ON j.id = je.id \
+         WHERE j.job_type = ANY($1)",
+    )
+    .bind(job_types)
+    .fetch_one(pool)
+    .await?;
+    Ok(count)
+}
+
+// ── contracts ───────────────────────────────────────────────────────────────
+
+/// Two members, one job row: the whole point of grouping.
+#[tokio::test]
+#[file_serial]
+async fn group_members_share_one_job() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset(&pool).await?;
+    let mut jobs = jobs_for(&pool).await?;
+    let outbox = init_outbox(&pool).await?;
+
+    let a = Arc::new(Mutex::new(Vec::new()));
+    let b = Arc::new(Mutex::new(Vec::new()));
+    outbox
+        .register_event_handler(
+            &mut jobs,
+            member(MEMBER_A),
+            Observer {
+                received: a.clone(),
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    outbox
+        .register_event_handler(
+            &mut jobs,
+            member(MEMBER_B),
+            Observer {
+                received: b.clone(),
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    jobs.start_poll().await?;
+
+    publish(&outbox, &[1, 2, 3]).await?;
+    wait_for(&a, 3, std::time::Duration::from_secs(10)).await?;
+    wait_for(&b, 3, std::time::Duration::from_secs(10)).await?;
+
+    // Both members saw every event, in order...
+    assert_eq!(*a.lock().await, vec![1, 2, 3]);
+    assert_eq!(*b.lock().await, vec![1, 2, 3]);
+    // ...through exactly one job, and none of their own.
+    assert_eq!(running_jobs(&pool, &[GROUP.as_str()]).await?, 1);
+    assert_eq!(running_jobs(&pool, &[MEMBER_A, MEMBER_B]).await?, 0);
+
+    Ok(())
+}
+
+/// One landing carries every member's flush and every member's checkpoint.
+#[tokio::test]
+#[file_serial]
+async fn one_landing_carries_every_members_work_and_checkpoint() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset(&pool).await?;
+    let mut jobs = jobs_for(&pool).await?;
+    let outbox = init_outbox(&pool).await?;
+
+    for (job_type, tag) in [(MEMBER_A, "a"), (MEMBER_B, "b")] {
+        outbox
+            .register_event_handler(
+                &mut jobs,
+                member(job_type),
+                Collector {
+                    tag,
+                    fail_flush_at: None,
+                },
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    jobs.start_poll().await?;
+
+    publish(&outbox, &[1, 2, 3]).await?;
+    wait_for_member_checkpoint(&pool, MEMBER_A, 3).await?;
+
+    // Both members' collected items landed, and both checkpoints advanced —
+    // out of a single execution-state row.
+    assert_eq!(effect_rows(&pool, "a").await?, vec![1, 2, 3]);
+    assert_eq!(effect_rows(&pool, "b").await?, vec![1, 2, 3]);
+    let members = group_state(&pool).await?.expect("group state written");
+    assert_eq!(members.get(MEMBER_A), Some(&3));
+    assert_eq!(members.get(MEMBER_B), Some(&3));
+
+    Ok(())
+}
+
+/// A member's `consume_isolated` fence must land the *whole* pending group
+/// batch first — including a sibling's collected items — not just its own.
+#[tokio::test]
+#[file_serial]
+async fn isolation_fence_lands_siblings_collected_items() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset(&pool).await?;
+    let mut jobs = jobs_for(&pool).await?;
+    let outbox = init_outbox(&pool).await?;
+
+    // A collects everything; B isolates on 3. A's items for 1..=3 must be
+    // durable before B's isolated op runs.
+    outbox
+        .register_event_handler(
+            &mut jobs,
+            member(MEMBER_A),
+            Collector {
+                tag: "a",
+                fail_flush_at: None,
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    outbox
+        .register_event_handler(&mut jobs, member(MEMBER_B), Isolator { isolate_at: 3 })
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    jobs.start_poll().await?;
+
+    publish(&outbox, &[1, 2, 3, 4]).await?;
+    wait_for_member_checkpoint(&pool, MEMBER_B, 4).await?;
+
+    assert_eq!(effect_rows(&pool, "a").await?, vec![1, 2, 3, 4]);
+    Ok(())
+}
+
+/// A member that cannot handle an event is parked before it; its siblings
+/// advance past it rather than stalling behind it.
+#[tokio::test]
+#[file_serial]
+async fn failing_member_is_ejected_and_siblings_advance() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset(&pool).await?;
+    let mut jobs = jobs_for(&pool).await?;
+    let outbox = init_outbox(&pool).await?;
+
+    let healthy = Arc::new(Mutex::new(Vec::new()));
+    let poisoned = Arc::new(Mutex::new(Vec::new()));
+    outbox
+        .register_event_handler(
+            &mut jobs,
+            member(MEMBER_A),
+            Poisoned {
+                poison: 3,
+                received: poisoned.clone(),
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    outbox
+        .register_event_handler(
+            &mut jobs,
+            member(MEMBER_B),
+            Observer {
+                received: healthy.clone(),
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    jobs.start_poll().await?;
+
+    publish(&outbox, &[1, 2, 3, 4, 5]).await?;
+
+    // The checkpoint is the deterministic signal; the delivery vector is only
+    // stable once it lands.
+    wait_for_member_checkpoint(&pool, MEMBER_B, 5).await?;
+
+    // The healthy sibling gets everything, including events past the poison.
+    // Ejection rewinds the in-flight batch and replays it without the offender,
+    // so the sibling legitimately re-sees the events it had already handled in
+    // memory but not yet committed — whole-batch replay is the DSL's contract.
+    // What must hold is that it sees every event, in order, with none skipped.
+    let seen = healthy.lock().await.clone();
+    let mut first_seen = Vec::new();
+    for n in &seen {
+        if !first_seen.contains(n) {
+            first_seen.push(*n);
+        }
+    }
+    assert_eq!(
+        first_seen,
+        vec![1, 2, 3, 4, 5],
+        "actual deliveries: {seen:?}"
+    );
+
+    // The ejected member's key is retained, parked at its last *committed*
+    // sequence — which here is BEGIN, since it had only skipped and the lazy
+    // checkpoint had not yet fired. What matters is that the park is strictly
+    // before the poison event, so a restart re-reads it and nothing is skipped.
+    let members = group_state(&pool).await?.expect("group state written");
+    let parked = *members
+        .get(MEMBER_A)
+        .expect("ejected member's checkpoint is retained, not dropped");
+    assert!(parked < 3, "parked at {parked}, must be before the poison");
+
+    // And it stops there: no delivery past the event it could not handle.
+    assert!(
+        !poisoned.lock().await.iter().any(|n| *n >= 3),
+        "ejected member must not receive events past its parked checkpoint: {:?}",
+        poisoned.lock().await
+    );
+
+    Ok(())
+}
+
+/// Moving a handler from solo to grouped keeps its position: it must not
+/// replay the outbox from the beginning.
+#[tokio::test]
+#[file_serial]
+async fn grouping_adopts_the_solo_checkpoint() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset(&pool).await?;
+
+    // Phase 1: run MEMBER_A as an ordinary solo handler and let it checkpoint.
+    let seen_solo = Arc::new(Mutex::new(Vec::new()));
+    {
+        let mut jobs = jobs_for(&pool).await?;
+        let outbox = init_outbox(&pool).await?;
+        outbox
+            .register_event_handler(
+                &mut jobs,
+                OutboxEventJobConfig::new(job::JobType::new(MEMBER_A)),
+                Observer {
+                    received: seen_solo.clone(),
+                },
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        jobs.start_poll().await?;
+        publish(&outbox, &[1, 2, 3]).await?;
+        wait_for(&seen_solo, 3, std::time::Duration::from_secs(10)).await?;
+        // Let the lazy skip-only checkpoint reach the database.
+        let start = std::time::Instant::now();
+        loop {
+            let row: Option<(Option<serde_json::Value>,)> = sqlx::query_as(
+                "SELECT je.execution_state_json FROM job_executions je \
+                 JOIN jobs j ON j.id = je.id WHERE j.job_type = $1",
+            )
+            .bind(MEMBER_A)
+            .fetch_optional(&pool)
+            .await?;
+            let seq = row
+                .and_then(|(json,)| json)
+                .and_then(|json| json.get("sequence").and_then(|s| s.as_i64()));
+            if seq == Some(3) {
+                break;
+            }
+            if start.elapsed() > std::time::Duration::from_secs(10) {
+                anyhow::bail!("solo handler never checkpointed at 3 (at {seq:?})");
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        jobs.shutdown().await?;
+    }
+
+    // Phase 2: same handler, now grouped. It must resume at 3.
+    let seen_grouped = Arc::new(Mutex::new(Vec::new()));
+    let mut jobs = jobs_for(&pool).await?;
+    let outbox = init_outbox(&pool).await?;
+    outbox
+        .register_event_handler(
+            &mut jobs,
+            member(MEMBER_A),
+            Observer {
+                received: seen_grouped.clone(),
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    jobs.start_poll().await?;
+
+    publish(&outbox, &[4, 5]).await?;
+    wait_for(&seen_grouped, 2, std::time::Duration::from_secs(10)).await?;
+
+    // Only the new events — the first three were not replayed.
+    assert_eq!(*seen_grouped.lock().await, vec![4, 5]);
+    // And the legacy solo execution row is gone, so it can never resurrect.
+    assert_eq!(running_jobs(&pool, &[MEMBER_A]).await?, 0);
+
+    Ok(())
+}
+
+/// Registering into a group after its job started would silently deliver
+/// nothing — it must be an error instead.
+#[tokio::test]
+#[file_serial]
+async fn late_registration_is_rejected() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset(&pool).await?;
+    let mut jobs = jobs_for(&pool).await?;
+    let outbox = init_outbox(&pool).await?;
+
+    let a = Arc::new(Mutex::new(Vec::new()));
+    outbox
+        .register_event_handler(
+            &mut jobs,
+            member(MEMBER_A),
+            Observer {
+                received: a.clone(),
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    jobs.start_poll().await?;
+    // Wait until the group job has actually started and snapshotted membership.
+    publish(&outbox, &[1]).await?;
+    wait_for(&a, 1, std::time::Duration::from_secs(10)).await?;
+
+    let err = outbox
+        .register_event_handler(
+            &mut jobs,
+            member(MEMBER_B),
+            Observer {
+                received: Arc::new(Mutex::new(Vec::new())),
+            },
+        )
+        .await
+        .expect_err("registering into a started group must fail");
+    assert!(
+        err.to_string().contains("after the group job started"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
+/// Batch size governs the shared landing, so members disagreeing about it is
+/// an error rather than a silently folded value.
+#[tokio::test]
+#[file_serial]
+async fn conflicting_group_settings_are_rejected() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    reset(&pool).await?;
+    let mut jobs = jobs_for(&pool).await?;
+    let outbox = init_outbox(&pool).await?;
+
+    outbox
+        .register_event_handler(
+            &mut jobs,
+            member(MEMBER_A).with_max_batch_size(10),
+            Observer {
+                received: Arc::new(Mutex::new(Vec::new())),
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let err = outbox
+        .register_event_handler(
+            &mut jobs,
+            member(MEMBER_B).with_max_batch_size(99),
+            Observer {
+                received: Arc::new(Mutex::new(Vec::new())),
+            },
+        )
+        .await
+        .expect_err("conflicting max_batch_size must fail");
+    assert!(
+        err.to_string().contains("max_batch_size"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Implements [`drua://obix-dev/design-handler-groups.md`](https://raw.githubusercontent.com/GaloyMoney/drua-library/main/spaces/obix-dev/design-handler-groups.md) (proposed rev 1).

One resident job hosting N registered `OutboxEventHandler`s: one stream read, one batch transaction, one checkpoint write per landing instead of N of each. Opt in per call site:

```rust
const GROUP: HandlerGroupName = HandlerGroupName::new("lana-core");

outbox.register_event_handler(
    &mut jobs,
    OutboxEventJobConfig::new(JOB_TYPE).in_group(&GROUP),
    MyHandler { .. },
).await?;
```

Members keep their own handler, `Batch` accumulator, checkpoint and failure domain. They share the job slot, the outbox subscription and the landing transaction.

## Composition with recent work

**PR #86 (EventCtx consume DSL) — composes, does not override.** The trait and all four entry verbs are untouched; a handler cannot tell whether it runs solo or grouped. Each member resolves its own `EventCtx` with its own accumulator. What changes is only *who lands the op*.

**PR #86 (handler-controlled tx scoping) — a group lands as ONE tx across members.** That is the point: 34 state-write transactions become 1. `consume_isolated` keeps its fence for the *requesting* member, and now also lands siblings' collected items first — otherwise a sibling's collected work would outlive the transaction meant to carry it. Other members merely observe a batch boundary, which was never part of the delivery contract.

**PR #114 (debounced notifier) / PR #116 (two-tier gap-fill) — no interaction, strictly less pressure.** A group is one more `listen_persisted` subscriber positioned at `min(member checkpoints)`. Grouping *reduces* the number of subscriptions and backfill requests; it shares no checkpoint semantics with either mechanism.

**PR #106 (partitioning) — no interaction** (read path only).

**PR #96 (OpCursor) / #97 / #104 (Result-streaming undecodable)** — undecodable events keep their per-handler semantics: the batch lands first, then *each member* decides for itself. `Ok` advances that member past the event; `Err` parks it while siblings continue.

## Internal refactor (no public API change)

`CtxParts` gains two erased hooks so the group path can reuse the landing machinery instead of forking it:

- `CheckpointState` — solo writes `OutboxEventJobState` (one sequence), a group writes the whole per-member map in one row.
- `PeerFlush` — a member's isolation fence lands *all* dirty members, split around the dispatching member to preserve registration order. Solo passes `NoPeers`, so the solo landing path is unchanged.

Public signatures of `EventCtx`, `BatchOp`, `IsolatedOp`, `FlushOp`, `Handled` and `FlushError` are identical.

## Semver / downstream ripple

**Additive.** `register_event_handler`'s signature is unchanged; consumers that never call `in_group` are unaffected. No migration required in **cala** or **lana** (not touched here). Adopting groups later is a one-line diff per registration site — for lana, ~33 sites across 3–5 groups per the design's deployment note, with `cala.ec_balance_rollup` staying solo.

New public surface: `HandlerGroupName`, `HandlerGroupError`, `OutboxEventJobConfig::in_group`, and the `obix::out::group` module docs.

## Deliberately not in this PR

- **`HandlerHandle::Grouped`** — the design sequences groups after the HandlerHandle PR, but only because both touch `register_event_handler`'s return type. Nothing in the group runner needs it, so this PR leaves the signature alone and stays additive. When HandlerHandle lands, a grouped member's `checkpoint()` decodes the group state — one enum variant and one match arm.
- **Eject-to-solo runtime spawn** (design Open Q #1) — v1 takes the design's own fallback: park the member at its last committed sequence, log at ERROR, let siblings advance. Re-joining happens at the next restart. Live rejoin (Open Q #3) is likewise deferred.

## Verification

- `nix develop -c sh -c 'cargo fmt && git add -A && nix flake check'` → **all checks passed** (fmt / clippy `-D warnings` / audit / deny).
- Full live-PG suite **89/89**, including the pre-existing tx-scoping, Result-streaming undecodable, partition, trust-boundary and two-tier gap-fill regressions.
- 7 new contract tests in `tests/handler_groups.rs`: shared job slot, one-tx landing across members, isolation fence over siblings' items, eject-and-advance, solo→grouped checkpoint adoption, late registration rejected, conflicting group settings rejected.
- `.sqlx` regenerated for the one new query.

## Notes for review

Two behaviours are worth confirming against intent, since both surfaced as test failures that turned out to be the spec rather than bugs:

1. **Ejection replays the in-flight batch to healthy members.** The rewind is wholesale, so a sibling legitimately re-sees events it had handled in memory but not committed. That is the design's "the batch replays without it", and replay tolerance is already the DSL's contract — but it means grouped handlers see replays in a case solo handlers would not.
2. **An ejected member parks at its last *committed* sequence, which may be well behind the poison event** (BEGIN, for a skip-only member whose lazy checkpoint had not yet fired). Safe — nothing is skipped — but the park is not always "the event before the poison".

Also included: a one-line `Makefile` fix — `sqlx-prepare` was missing `-- --all-targets`, so running it silently deleted the `.sqlx` entries for queries in `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
