### PR TITLE
feat(deps): bump es-entity to 0.12.9 for re-entrant hook registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,9 +480,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.12.7"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f94a1c1d074fbe3ea443d6c6a476a80af6f16ea794fcb6be4bb1bdeddd7f3"
+checksum = "2227e547593b0c89be2c5711af8af0ec132397a4bdd2eb13033171e06ce4fba7"
 dependencies = [
  "async-stream",
  "chrono",
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.12.7"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f846f97468b73de4d70059c6c89adf5606dfdd3b08f7d98f2093e9b534d699c"
+checksum = "cdde286ff62b9d58b6e43ce414920c57b799641fcbadb8c633452f8e7687122c"
 dependencies = [
  "convert_case",
  "darling 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ obix-macros = { path = "obix-macros", version = "0.8.1-dev" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-es-entity = "0.12.7"
+es-entity = "0.12.9"
 anyhow = "1.0"
 tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }

--- a/src/out/persist_events_hook.rs
+++ b/src/out/persist_events_hook.rs
@@ -36,12 +36,22 @@ where
     /// this commit hook is constructed (i.e. at the operation's first
     /// publish). Merged publishes keep the first snapshot.
     post_persist_hooks: PostPersistHooks<P>,
-    /// Set on the force-execute path (no commit hooks): `post_commit` never
-    /// runs, so the persist statement must carry the in-tx NOTIFY. Also
-    /// suppresses own-failure compensation — on that path the caller's
-    /// bare transaction is still open when `pre_commit` returns and its
-    /// fate is unknowable (it may savepoint-recover and commit), so those
-    /// sequences are the proof-gated backstop's responsibility.
+    /// Set on the force-execute path: `post_commit` never runs, so the
+    /// persist statement must carry the in-tx NOTIFY. Also suppresses
+    /// own-failure compensation — on that path the caller's bare transaction
+    /// is still open when `pre_commit` returns and its fate is unknowable
+    /// (it may savepoint-recover and commit), so those sequences are the
+    /// proof-gated backstop's responsibility.
+    ///
+    /// Narrower scope than the name once implied: with es-entity's
+    /// re-entrant hook registration, this only fires for an operation that
+    /// genuinely has no commit pass to join (a bare `sqlx::Transaction`).
+    /// A repost from inside another outbox's [`PostPersistHook`] no longer
+    /// takes this path — `add_commit_hook` now succeeds there, so the
+    /// repost joins the enclosing commit pass and gets the full
+    /// `post_commit`/`on_rollback` lifecycle instead.
+    ///
+    /// [`PostPersistHook`]: crate::out::PostPersistHook
     notify_in_tx: bool,
     _phantom: PhantomData<Tables>,
 }
@@ -72,7 +82,9 @@ where
         }
     }
 
-    /// Use the in-transaction NOTIFY persist variant (force-execute path).
+    /// Use the in-transaction NOTIFY persist variant — for the force-execute
+    /// path only (see the `notify_in_tx` field doc above for its narrowed
+    /// scope: genuinely hookless operations, not reposts).
     pub(crate) fn with_in_tx_notify(mut self) -> Self {
         self.notify_in_tx = true;
         self

--- a/src/out/post_persist_hook.rs
+++ b/src/out/post_persist_hook.rs
@@ -28,16 +28,28 @@ pub(crate) type PostPersistHooks<P> = Arc<[Arc<dyn PostPersistHook<P>>]>;
 ///   see [`MailboxConfig::persist_events_batch_size`](crate::MailboxConfig)).
 ///   Implementations must not assume they see an operation's events in one
 ///   call.
-/// - The [`HookOperation`] cannot register commit hooks, so a hook cannot
-///   schedule further commit hooks. It CAN publish to another outbox — that
-///   takes the immediate-insert path (same transaction) and invokes that
-///   outbox's own post-persist hooks. Chains (A→B→C) compose; it is the
-///   implementor's responsibility not to register hooks that form a cycle
-///   (A→B→A), which would recurse until the stack overflows.
+/// - A hook CAN publish to another outbox — `on_persisted` runs from inside
+///   a real commit pass, so the [`HookOperation`] it is handed supports
+///   registering further commit hooks: the repost's own `PersistEvents` hook
+///   joins the **tail of this same pass** rather than executing immediately.
+///   The destination outbox therefore gets its full lifecycle — its own
+///   `pre_commit`, `post_commit` (in-process broadcast, debounced `NOTIFY`)
+///   and `on_rollback` (reactive gap-fill) — atomically, in the same
+///   transaction. `Outbox::publish_all_persisted` needs no special-casing
+///   for this: it always tries to register a commit hook first, only
+///   falling back to an immediate in-transaction write (which skips
+///   `post_commit`/`on_rollback`) when the underlying operation genuinely
+///   has no commit pass to join (e.g. a bare `sqlx::Transaction` at the root
+///   of the chain). Chains (A→B→C) compose; a cycle (A→B→A) is bounded by
+///   es-entity's [`MAX_HOOK_GENERATIONS`](es_entity::hooks::MAX_HOOK_GENERATIONS)
+///   (8) and fails the commit loudly instead of recursing unboundedly —
+///   still the implementor's responsibility to avoid, just a safely-caught
+///   mistake now rather than a stack overflow. See [`es_entity::hooks`] for
+///   the full re-entrant registration contract.
 /// - Fires on every persist path, including publishes on operations without
-///   commit-hook support (e.g. a bare `sqlx::Transaction`), where events are
-///   inserted immediately — the hook then fires during the publish call
-///   itself rather than at commit time.
+///   commit-hook support at all (e.g. a bare `sqlx::Transaction`), where
+///   events are inserted immediately — the hook then fires during the
+///   publish call itself rather than at commit time.
 /// - Registration is snapshot-at-publish: registering a hook affects only
 ///   subsequently-constructed commit hooks (in practice: subsequent
 ///   operations). Register at startup before serving traffic; this is not a

--- a/tests/post_persist_hook.rs
+++ b/tests/post_persist_hook.rs
@@ -493,19 +493,41 @@ async fn repost_on_rollback_reaches_destination_reactively() -> anyhow::Result<(
     // `PersistEvents` hook's `pre_commit` had already succeeded (staged
     // earlier in the same pass, its own persist done) by the time hop's
     // veto surfaced deeper in the queue — so es-entity fires its
-    // `on_rollback`, not its own-failure branch. Bound well under the 2s
-    // gap-fill grace so a regression back to the pre-#200 force-execute
-    // path (no `on_rollback` at all) fails this test rather than just
-    // running slow.
-    let gap_event =
-        tokio::time::timeout(std::time::Duration::from_millis(1500), dest_listener.next())
+    // `on_rollback`, not its own-failure branch.
+    //
+    // `dest_listener` sees every row on the shared physical table (comment
+    // at the top of this file), including source's and hop's own
+    // compensation — and each of source/dest/hop has its *own* `GapFiller`
+    // task (one per `Outbox::init`), so the three placeholders can land in
+    // any order. We must therefore identify dest's placeholder by its
+    // sequence, not just take the first payload-less event we see.
+    //
+    // Sequences are deterministic here: this test's fresh table (truncated
+    // + identity-restarted by the `init_outbox::<SourceEvent>` call above)
+    // sees exactly one publish, so source's own persist is sequence 1 and
+    // dest's repost — persisted next in the same pass, before hop's — is
+    // sequence 2, regardless of which GapFiller physically writes first.
+    const DEST_SEQUENCE: u64 = 2;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(1500);
+    let dest_gap_event = loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            anyhow::bail!("dest's compensation placeholder did not arrive reactively");
+        }
+        let event = tokio::time::timeout(remaining, dest_listener.next())
             .await
             .map_err(|_| {
                 anyhow::anyhow!("dest's compensation placeholder did not arrive reactively")
             })?
             .expect("stream open")?;
+        if u64::from(event.sequence) == DEST_SEQUENCE {
+            break event;
+        }
+        // Not dest's row (source's or hop's own compensation, arrived
+        // first from their own independent GapFiller) — keep waiting.
+    };
     assert!(
-        gap_event.payload.is_none(),
+        dest_gap_event.payload.is_none(),
         "dest's abandoned sequence must resolve as a placeholder, not a real Mapped event"
     );
 

--- a/tests/post_persist_hook.rs
+++ b/tests/post_persist_hook.rs
@@ -147,7 +147,12 @@ impl PostPersistHook<SourceEvent> for FailingHook {
 
 /// The repost consumer from the design doc: map source events into the
 /// destination outbox's payload type and publish them from inside the hook —
-/// same transaction, immediate-insert path.
+/// same transaction. `dest`'s own commit hook joins the tail of the *same*
+/// commit pass (es-entity's re-entrant hook registration) rather than
+/// inserting inline here: its persist and its own post-persist hooks run
+/// later, when the enclosing `execute_pre` loop reaches it — still before
+/// the single `COMMIT`, and still ordered ahead of anything registered
+/// after `source`'s hook.
 struct RepostHook {
     dest: Outbox<DestEvent, TestTables>,
 }
@@ -395,8 +400,11 @@ async fn repost_rolls_back_atomically() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// A hook publishing into outbox B runs B's own post-persist hooks (force
-/// path) — chains compose.
+/// A hook publishing into outbox B runs B's own post-persist hooks — B's
+/// repost into C joins the tail of the same pass in turn, so a linear chain
+/// (A→B→C) still lands its hops in causal insertion order even though the
+/// enclosing `execute_pre` loop processes them breadth-first (by
+/// generation), not by recursing inline through each `on_persisted` call.
 #[tokio::test]
 #[file_serial]
 async fn chained_reposts_compose() -> anyhow::Result<()> {
@@ -423,6 +431,84 @@ async fn chained_reposts_compose() -> anyhow::Result<()> {
         ],
         "A→B→C: each hop persisted in the same tx, in causal order"
     );
+    Ok(())
+}
+
+/// The `on_rollback` tier reaches a repost that already joined the pass.
+/// `hop` — three hops deep — vetoes from its own post-persist hook, *after*
+/// `hop`'s own persist has already allocated its sequence: the whole
+/// transaction rolls back, including `source`'s and `dest`'s already-
+/// succeeded hooks earlier in the pass.
+///
+/// Before es-entity's re-entrant commit-hook registration
+/// (GaloyMoney/es-entity#200), `dest`'s repost always force-executed — a
+/// repost's `HookOperation` could never register further hooks, so
+/// `dest`'s hook never entered the `CommitHooks` bookkeeping at all.
+/// Neither `post_commit` nor `on_rollback` ever ran for it, and its burned
+/// sequence depended entirely on the slow, grace-gated backstop (2s
+/// default). Now that the repost joins the same commit pass as `source`,
+/// `dest`'s `PersistEvents` hook is tracked exactly like a directly-
+/// registered hook: its `on_rollback` fires once the deeper failure
+/// surfaces, and `dest`'s abandoned sequence is placeholder-filled
+/// reactively — in milliseconds, not seconds.
+#[tokio::test]
+#[file_serial]
+async fn repost_on_rollback_reaches_destination_reactively() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    let source = init_outbox::<SourceEvent>(&pool, default_config()).await?;
+    let dest = Outbox::<DestEvent, TestTables>::init(&pool, default_config()).await?;
+    let hop = Outbox::<HopEvent, TestTables>::init(&pool, default_config()).await?;
+
+    source.add_post_persist_hook(RepostHook { dest: dest.clone() });
+    dest.add_post_persist_hook(HopHook { next: hop.clone() });
+
+    /// Vetoes after `hop`'s own persist already ran — the failure that must
+    /// unwind the whole chain, including the hops that already succeeded
+    /// earlier in the same pass.
+    struct VetoHopHook;
+
+    impl PostPersistHook<HopEvent> for VetoHopHook {
+        fn on_persisted<'a>(
+            &'a self,
+            _op: &'a mut HookOperation<'_>,
+            _events: &'a [PersistentOutboxEvent<HopEvent>],
+        ) -> BoxFuture<'a, Result<(), sqlx::Error>> {
+            Box::pin(async { Err(sqlx::Error::Protocol("hop veto".into())) })
+        }
+    }
+    hop.add_post_persist_hook(VetoHopHook);
+
+    let mut dest_listener = dest.listen_persisted(None);
+
+    let mut op = source.begin_op().await?;
+    source
+        .publish_persisted_in_op(&mut op, SourceEvent::Source(11))
+        .await?;
+    assert!(
+        op.commit().await.is_err(),
+        "hop's veto, three hops deep, must fail the whole commit"
+    );
+
+    // Reactive compensation must reach `dest` specifically: its
+    // `PersistEvents` hook's `pre_commit` had already succeeded (staged
+    // earlier in the same pass, its own persist done) by the time hop's
+    // veto surfaced deeper in the queue — so es-entity fires its
+    // `on_rollback`, not its own-failure branch. Bound well under the 2s
+    // gap-fill grace so a regression back to the pre-#200 force-execute
+    // path (no `on_rollback` at all) fails this test rather than just
+    // running slow.
+    let gap_event =
+        tokio::time::timeout(std::time::Duration::from_millis(1500), dest_listener.next())
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!("dest's compensation placeholder did not arrive reactively")
+            })?
+            .expect("stream open")?;
+    assert!(
+        gap_event.payload.is_none(),
+        "dest's abandoned sequence must resolve as a placeholder, not a real Mapped event"
+    );
+
     Ok(())
 }
 
@@ -523,10 +609,21 @@ async fn late_registration_affects_only_subsequent_ops() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// With es-entity ≥ 0.11.7 commit hooks run in registration order, so the
-/// relative order of destination-native vs reposted events follows the order
-/// of each outbox's first publish in the op — deterministically, in both
-/// directions.
+/// Commit hooks run in registration order (es-entity ≥ 0.11.7) — but a
+/// repost's destination hook shares its `TypeId` with any hook the
+/// destination's own direct publishes already registered on the same op,
+/// so es-entity's ordinary same-op merge rule applies: the merge keeps the
+/// **earliest still-pending** registration's queue position and appends
+/// later contributions to its event list in the order they fold in. When
+/// `dest` published nothing of its own before the repost lands, the
+/// repost's hook is fresh — it runs at its own (later) position, after
+/// `source`. But when `dest` already published directly on the same op
+/// *before* `source`'s hook ran, the repost merges INTO that still-pending
+/// hook (es-entity's re-entrant registration folds into the tail of the
+/// pass — see [`PostPersistHook`]'s contract docs) — so the merged hook
+/// still runs at `dest`'s earlier position, and physically inserts `dest`'s
+/// own events before the freshly-appended reposted ones, regardless of
+/// which outbox's `publish_*_in_op` call came first in program order.
 #[tokio::test]
 #[file_serial]
 async fn ordering_follows_first_publish_order() -> anyhow::Result<()> {
@@ -536,7 +633,9 @@ async fn ordering_follows_first_publish_order() -> anyhow::Result<()> {
 
     source.add_post_persist_hook(RepostHook { dest: dest.clone() });
 
-    // Dest-native publish first → its commit hook registers (and runs) first.
+    // Dest-native publish first → dest's hook is already-executed by the
+    // time the repost is staged, so the repost gets a fresh (later)
+    // instance instead of merging — its position follows program order.
     let mut op = source.begin_op().await?;
     dest.publish_persisted_in_op(&mut op, DestEvent::Native(1))
         .await?;
@@ -555,7 +654,11 @@ async fn ordering_follows_first_publish_order() -> anyhow::Result<()> {
         "dest-native published first ⇒ dest-native sequences < reposted"
     );
 
-    // Inverted: source publish first → reposted events precede dest-native.
+    // Inverted: source publish first → `dest`'s direct publish is still
+    // PENDING (not yet executed) when `source`'s hook stages the repost, so
+    // the repost merges into it and inherits dest's earlier queue position.
+    // The merged batch still inserts dest's own event before the appended
+    // repost — Native precedes Mapped despite `source` publishing first.
     let mut op = source.begin_op().await?;
     source
         .publish_persisted_in_op(&mut op, SourceEvent::Source(4))
@@ -568,17 +671,18 @@ async fn ordering_follows_first_publish_order() -> anyhow::Result<()> {
         payloads_by_sequence(&pool).await?[3..],
         [
             serde_json::json!({"Source": 4}),
-            serde_json::json!({"Mapped": 4}),
             serde_json::json!({"Native": 5}),
+            serde_json::json!({"Mapped": 4}),
         ],
-        "source published first ⇒ reposted sequences < dest-native"
+        "source published first, but dest's still-pending direct publish \
+         absorbs the repost at dest's own queue position"
     );
     Ok(())
 }
 
-/// The immediate-insert path drops the destination's in-process broadcast
-/// hook, so delivery to destination listeners is healed by pg NOTIFY (fires
-/// at commit) and the poller/gap-fill — reposted events must still arrive.
+/// A repost's destination hook now joins the same commit pass as the
+/// source, so its own `post_commit` runs — feeding the in-process broadcast
+/// directly, not just healing via pg NOTIFY and the poller/gap-fill.
 #[tokio::test]
 #[file_serial]
 async fn reposted_events_reach_destination_listener() -> anyhow::Result<()> {
@@ -596,7 +700,14 @@ async fn reposted_events_reach_destination_listener() -> anyhow::Result<()> {
         .await?;
     op.commit().await?;
 
-    let deadline = std::time::Duration::from_secs(5);
+    // `dest`'s repost joins the same commit pass as `source` (the op
+    // supports commit hooks), so `dest`'s own `PersistEvents::post_commit`
+    // now runs — feeding its in-process broadcast directly, not just the
+    // debounced NOTIFY fallback. A tight bound (well under the crate's 2s
+    // gap-fill grace) is a meaningful regression signal: before es-entity's
+    // re-entrant hook registration, `dest`'s hook always force-executed and
+    // never fed the broadcast at all.
+    let deadline = std::time::Duration::from_secs(2);
     let received = tokio::time::timeout(deadline, async {
         while let Some(Ok(event)) = listener.next().await {
             if event.payload == Some(DestEvent::Mapped(9)) {
@@ -609,8 +720,7 @@ async fn reposted_events_reach_destination_listener() -> anyhow::Result<()> {
     .unwrap_or(false);
     assert!(
         received,
-        "reposted event must reach a destination listener via NOTIFY/gap-fill \
-         despite the dropped in-process broadcast"
+        "reposted event must reach a destination listener via in-process forwarding"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Bumps `es-entity` `0.12.7` → `0.12.9` to pick up [GaloyMoney/es-entity#200](https://github.com/GaloyMoney/es-entity/pull/200) ("re-entrant commit-hook registration in `HookOperation`"), and updates `PostPersistHook` docs + tests to match the resulting behavior change.

**Correction to an earlier assumption:** #200 landed as **0.12.9**, not 0.12.8 — 0.12.8 shipped #199 (savepoint-scoped ops) first.

## What changed upstream

Before #200, `HookOperation::add_commit_hook` always returned `Err`. That meant every cross-outbox repost from inside `PostPersistHook::on_persisted` — `Outbox::publish_all_persisted`'s `op.add_commit_hook(hook)` — unconditionally took the immediate-execute fallback (`force_execute_pre_commit` + `with_in_tx_notify`), which silently drops the destination hook's `post_commit` (in-process broadcast, debounced `NOTIFY`) and `on_rollback` (reactive gap-fill).

With 0.12.9, `add_commit_hook` succeeds when called from inside a real commit pass (which `on_persisted` always is) — the destination's hook joins the **tail of the same pass** instead, getting its full lifecycle atomically in the same transaction. **No change to obix's publish path was needed** — the improvement is automatic on upgrade.

## obix changes

**Docs** (`PostPersistHook` contract, `persist_events_hook.rs`):
- Removed the now-false claim that a hook "cannot register commit hooks" and that a cycle "would recurse until the stack overflows" — cycles are now bounded by `es_entity::hooks::MAX_HOOK_GENERATIONS` (8), failing the commit loudly instead.
- `notify_in_tx` / `with_in_tx_notify` docs now note their narrowed scope: this force-execute variant only fires for genuinely hookless ops now, not for every repost like before.

**Tests** (`tests/post_persist_hook.rs`):
- Tightened + reworded `reposted_events_reach_destination_listener` — reposts now reach listeners via in-process forwarding, not by "healing via NOTIFY/gap-fill despite the dropped broadcast".
- **New regression test** `repost_on_rollback_reaches_destination_reactively`: a failure three hops into a repost chain (`source → dest → hop`, where `hop`'s own post-persist hook vetoes *after* `hop`'s own persist already ran) now reactively placeholder-fills `dest`'s abandoned sequence via `on_rollback`, in milliseconds — previously impossible, since a repost's hook never entered the `CommitHooks` bookkeeping at all.
- **Fixed a real (not just doc-stale) test failure** in `ordering_follows_first_publish_order`, surfaced by the bump: when a destination outbox has a direct publish still pending on the same op when a repost targeting it gets staged, the repost now *merges* into that still-pending hook (same `TypeId` → es-entity's ordinary same-op merge rule) and inherits its earlier queue position — so the destination's own event physically precedes the appended repost, regardless of which outbox's publish call came first in program order. Rewrote the test's doc comment and second-scenario assertion with the merge mechanics spelled out.

## Testing

- `nix flake check` (fmt, clippy `-D warnings`, deny) ✅
- `cargo test --doc --workspace` ✅, `cargo doc --no-deps --workspace` clean (only 3 pre-existing, unrelated `private_intra_doc_links` warnings)
- Full workspace `cargo nextest run --workspace`: **93/93 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior of cross-outbox reposts, commit-hook ordering, rollback compensation, and listener delivery changes with the dependency bump, though publish-path code is unchanged and tests cover the new contract.
> 
> **Overview**
> Bumps **`es-entity`** from **0.12.7** to **0.12.9** (re-entrant commit-hook registration from upstream #200). Cross-outbox reposts from **`PostPersistHook::on_persisted`** can now register the destination’s **`PersistEvents`** hook on the **same commit pass** instead of always falling back to immediate in-tx persist.
> 
> **Docs** in **`PostPersistHook`**, **`persist_events_hook`**, and **`notify_in_tx`** are updated: reposts get full **`post_commit`** / **`on_rollback`**; **`with_in_tx_notify`** is described as the genuinely hookless path only; hook cycles are bounded by **`MAX_HOOK_GENERATIONS`** instead of unbounded recursion.
> 
> **Tests** tighten expectations for repost delivery and ordering (merge into a still-pending destination hook), add **`repost_on_rollback_reaches_destination_reactively`**, and fix **`ordering_follows_first_publish_order`** for merged-hook queue behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 403ffa362622883ca3c5065bb31dee978804996a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->