### PR TITLE
feat(out): persist_after cross-outbox persist ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,9 +480,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.12.9"
+version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2227e547593b0c89be2c5711af8af0ec132397a4bdd2eb13033171e06ce4fba7"
+checksum = "1b46ec6f5ea842d48519daa7a59060667e5df7a8018390d9aefb9928f4241883"
 dependencies = [
  "async-stream",
  "chrono",
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.12.9"
+version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdde286ff62b9d58b6e43ce414920c57b799641fcbadb8c633452f8e7687122c"
+checksum = "c80cfaeb802cdfc853aaba00a123b2f8b4593f970ad5e1de7c9c77a503e7c260"
 dependencies = [
  "convert_case",
  "darling 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ obix-macros = { path = "obix-macros", version = "0.8.3-dev" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-es-entity = "0.12.9"
+es-entity = "0.12.10"
 anyhow = "1.0"
 tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }

--- a/src/out/mod.rs
+++ b/src/out/mod.rs
@@ -17,6 +17,7 @@ mod registered_handler;
 use es_entity::clock::ClockHandle;
 use serde::{Serialize, de::DeserializeOwned};
 
+use std::any::TypeId;
 use std::sync::Arc;
 
 pub use self::ctx::{BatchOp, EventCtx, FlushError, FlushOp, Handled, IsolatedOp};
@@ -60,6 +61,11 @@ where
     /// registration swaps in a rebuilt slice, publishes snapshot it with a
     /// single `Arc` clone.
     post_persist_hooks: Arc<std::sync::RwLock<post_persist_hook::PostPersistHooks<P>>>,
+    /// TypeIds of upstream outboxes' `PersistEvents` hooks that this
+    /// outbox's persist hook must run after within a shared commit pass.
+    /// Copy-on-write; snapshotted into each constructed hook at publish,
+    /// like `post_persist_hooks`.
+    persist_after: Arc<std::sync::RwLock<Arc<[TypeId]>>>,
 }
 
 impl<P, Tables> std::fmt::Debug for Outbox<P, Tables>
@@ -93,6 +99,7 @@ where
             gap_filler: self.gap_filler.clone(),
             clock: self.clock.clone(),
             post_persist_hooks: self.post_persist_hooks.clone(),
+            persist_after: self.persist_after.clone(),
         }
     }
 }
@@ -155,6 +162,7 @@ where
             gap_filler,
             clock: config.clock.clone(),
             post_persist_hooks: Arc::new(std::sync::RwLock::new(Vec::new().into())),
+            persist_after: Arc::new(std::sync::RwLock::new(Vec::new().into())),
         })
     }
 
@@ -175,6 +183,43 @@ where
         let mut rebuilt: Vec<Arc<dyn PostPersistHook<P>>> = hooks.iter().cloned().collect();
         rebuilt.push(Arc::new(hook));
         *hooks = rebuilt.into();
+    }
+
+    /// Declare that this outbox's persist commit hook must run after
+    /// `upstream`'s whenever both are registered on the same operation.
+    ///
+    /// Use when a [`PostPersistHook`] on `upstream` republishes into this
+    /// outbox: with the ordering declared, the repost merges into this
+    /// outbox's still-pending commit hook — one INSERT batch, one notify —
+    /// instead of appending a fresh re-entrant generation whenever this
+    /// outbox happened to publish earlier in the operation. Without a
+    /// shared operation, or when `upstream` never publishes in it, this
+    /// declaration has no effect.
+    ///
+    /// `upstream` is used only to name its concrete hook type; nothing is
+    /// stored from it. Call at startup next to the hook registration —
+    /// snapshot-at-publish semantics, same as
+    /// [`add_post_persist_hook`](Self::add_post_persist_hook). Idempotent.
+    ///
+    /// Declaring a cycle (A after B and B after A, directly or
+    /// transitively) is an error caught at commit time: a pass containing
+    /// the cycle fails loudly with a protocol error and rolls back.
+    pub fn persist_after<P2, Tables2>(&self, _upstream: &Outbox<P2, Tables2>)
+    where
+        P2: Serialize + DeserializeOwned + Send + Sync + 'static + Unpin,
+        Tables2: MailboxTables,
+    {
+        let dep = TypeId::of::<persist_events_hook::PersistEvents<P2, Tables2>>();
+        let mut deps = self
+            .persist_after
+            .write()
+            .expect("persist_after lock poisoned");
+        if deps.contains(&dep) {
+            return;
+        }
+        let mut rebuilt: Vec<TypeId> = deps.iter().copied().collect();
+        rebuilt.push(dep);
+        *deps = rebuilt.into();
     }
 
     pub async fn begin_op(&self) -> Result<es_entity::DbOp<'static>, sqlx::Error> {
@@ -199,6 +244,11 @@ where
             .read()
             .expect("post_persist_hooks lock poisoned")
             .clone();
+        let persist_after = self
+            .persist_after
+            .read()
+            .expect("persist_after lock poisoned")
+            .clone();
         let hook = persist_events_hook::PersistEvents::<P, Tables>::new(
             self.persistent_cache.cache_fill_sender(),
             self.notifier.report_sender(),
@@ -206,6 +256,7 @@ where
             events,
             self.persist_events_batch_size,
             post_persist_hooks,
+            persist_after,
         );
         if let Err(hook) = op.add_commit_hook(hook) {
             use es_entity::hooks::CommitHook;

--- a/src/out/persist_events_hook.rs
+++ b/src/out/persist_events_hook.rs
@@ -1,4 +1,6 @@
+use std::any::TypeId;
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 use es_entity::hooks::{CommitHook, HookOperation, PreCommitRet};
 use serde::{Serialize, de::DeserializeOwned};
@@ -51,6 +53,11 @@ where
     ///
     /// [`PostPersistHook`]: crate::out::PostPersistHook
     notify_in_tx: bool,
+    /// Snapshot of the outbox's declared upstream hook types
+    /// (`Outbox::persist_after`) at construction. Merged publishes keep the
+    /// first snapshot — identical by construction, since all instances of
+    /// this concrete type come from the same outbox.
+    runs_after: Arc<[TypeId]>,
     _phantom: PhantomData<Tables>,
 }
 
@@ -66,6 +73,7 @@ where
         events: impl IntoIterator<Item = impl Into<P>>,
         batch_size: usize,
         post_persist_hooks: PostPersistHooks<P>,
+        runs_after: Arc<[TypeId]>,
     ) -> Self {
         Self {
             sender,
@@ -76,6 +84,7 @@ where
             batch_size,
             post_persist_hooks,
             notify_in_tx: false,
+            runs_after,
             _phantom: PhantomData,
         }
     }
@@ -217,5 +226,9 @@ where
     fn merge(&mut self, other: &mut Self) -> bool {
         self.pre_commit_events.append(&mut other.pre_commit_events);
         true
+    }
+
+    fn runs_after(&self) -> &[TypeId] {
+        &self.runs_after
     }
 }

--- a/src/out/post_persist_hook.rs
+++ b/src/out/post_persist_hook.rs
@@ -37,6 +37,14 @@ pub(crate) type PostPersistHooks<P> = Arc<[Arc<dyn PostPersistHook<P>>]>;
 ///   es-entity's [`MAX_HOOK_GENERATIONS`](es_entity::hooks::MAX_HOOK_GENERATIONS)
 ///   (8) and fails the commit loudly — still the implementor's job to avoid.
 ///   See [`es_entity::hooks`] for the re-entrant registration contract.
+///   Whether the repost merges into the destination's still-pending commit
+///   hook or appends a fresh generation depends on registration order,
+///   which is otherwise an accident of application call order — declare
+///   [`Outbox::persist_after`](super::Outbox::persist_after) on the
+///   destination to pin it: the destination's persist hook then always
+///   defers behind the source's while the source is still pending, so the
+///   repost merges into one INSERT batch, one notify, one broadcast,
+///   regardless of which outbox published first in program order.
 /// - Fires on every persist path, including publishes on operations without
 ///   commit-hook support at all (e.g. a bare `sqlx::Transaction`), where
 ///   events are inserted immediately — the hook then fires during the

--- a/tests/post_persist_hook.rs
+++ b/tests/post_persist_hook.rs
@@ -690,6 +690,166 @@ async fn ordering_follows_first_publish_order() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Records each invocation's persisted payloads for `DestEvent` — used to
+/// prove `Outbox::persist_after` merges a deferred repost into a single
+/// dest batch instead of the two-invocation behavior
+/// `ordering_follows_first_publish_order` documents without the ordering
+/// declared.
+struct DestRecordingHook {
+    invocations: Arc<Mutex<Vec<Vec<DestEvent>>>>,
+}
+
+impl PostPersistHook<DestEvent> for DestRecordingHook {
+    fn on_persisted<'a>(
+        &'a self,
+        _op: &'a mut HookOperation<'_>,
+        events: &'a [PersistentOutboxEvent<DestEvent>],
+    ) -> BoxFuture<'a, Result<(), sqlx::Error>> {
+        Box::pin(async move {
+            self.invocations.lock().unwrap().push(
+                events
+                    .iter()
+                    .map(|e| e.payload.clone().expect("payload present"))
+                    .collect(),
+            );
+            Ok(())
+        })
+    }
+}
+
+/// `Outbox::persist_after` fixes the *cost* (not the correctness) of the
+/// unlucky registration order `ordering_follows_first_publish_order`
+/// documents: with `dest.persist_after(&source)` declared, `dest`'s persist
+/// hook defers behind `source`'s while `source` is still pending, so it is
+/// never already-executed by the time the repost stages — the repost always
+/// merges into `dest`'s single still-pending hook, regardless of which
+/// outbox published first in program order.
+#[tokio::test]
+#[file_serial]
+async fn persist_after_merges_repost_into_single_dest_batch() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    let source = init_outbox::<SourceEvent>(&pool, default_config()).await?;
+    let dest = Outbox::<DestEvent, TestTables>::init(&pool, default_config()).await?;
+
+    dest.persist_after(&source);
+    source.add_post_persist_hook(RepostHook { dest: dest.clone() });
+
+    let invocations = Arc::new(Mutex::new(Vec::new()));
+    dest.add_post_persist_hook(DestRecordingHook {
+        invocations: invocations.clone(),
+    });
+
+    let mut listener = dest.listen_persisted(None);
+
+    // Dest-native publish FIRST — the unlucky order that, without
+    // `persist_after`, leaves dest's hook already-executed by the time the
+    // repost stages (see `ordering_follows_first_publish_order`).
+    let mut op = source.begin_op().await?;
+    dest.publish_persisted_in_op(&mut op, DestEvent::Native(1))
+        .await?;
+    source
+        .publish_persisted_in_op(&mut op, SourceEvent::Source(7))
+        .await?;
+    op.commit().await?;
+
+    {
+        let invocations = invocations.lock().unwrap();
+        assert_eq!(
+            invocations.len(),
+            1,
+            "dest's hook deferred behind source, so the repost merges into \
+             the same still-pending instance instead of appending a fresh \
+             generation"
+        );
+        assert_eq!(
+            invocations[0],
+            [DestEvent::Native(1), DestEvent::Mapped(7)],
+            "dest's own event precedes the merged repost"
+        );
+    }
+
+    // Still joins the same commit pass — reaches a destination listener via
+    // in-process forwarding, not just the debounced NOTIFY fallback.
+    let deadline = std::time::Duration::from_secs(2);
+    let received = tokio::time::timeout(deadline, async {
+        while let Some(Ok(event)) = listener.next().await {
+            if event.payload == Some(DestEvent::Mapped(7)) {
+                return true;
+            }
+        }
+        false
+    })
+    .await
+    .unwrap_or(false);
+    assert!(
+        received,
+        "merged repost still reaches a destination listener"
+    );
+
+    Ok(())
+}
+
+/// Declaring `persist_after` an upstream that never publishes on the op is
+/// vacuous — `dest` commits normally, single invocation, event delivered.
+#[tokio::test]
+#[file_serial]
+async fn persist_after_vacuous_when_upstream_never_publishes() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    let source = init_outbox::<SourceEvent>(&pool, default_config()).await?;
+    let dest = Outbox::<DestEvent, TestTables>::init(&pool, default_config()).await?;
+
+    dest.persist_after(&source);
+
+    let invocations = Arc::new(Mutex::new(Vec::new()));
+    dest.add_post_persist_hook(DestRecordingHook {
+        invocations: invocations.clone(),
+    });
+
+    let mut op = dest.begin_op().await?;
+    dest.publish_persisted_in_op(&mut op, DestEvent::Native(1))
+        .await?;
+    op.commit().await?;
+
+    let invocations = invocations.lock().unwrap();
+    assert_eq!(invocations.len(), 1, "no upstream publish ⇒ no deferral");
+    assert_eq!(invocations[0], [DestEvent::Native(1)]);
+    assert_eq!(outbox_row_count(&pool).await?, 1);
+    Ok(())
+}
+
+/// A declared cycle (A after B and B after A) can never make progress —
+/// es-entity fails the commit loudly with a protocol error instead of
+/// hanging inside an open transaction, and the whole operation rolls back.
+#[tokio::test]
+#[file_serial]
+async fn persist_after_cycle_fails_commit_loudly() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    let source = init_outbox::<SourceEvent>(&pool, default_config()).await?;
+    let dest = Outbox::<DestEvent, TestTables>::init(&pool, default_config()).await?;
+
+    source.persist_after(&dest);
+    dest.persist_after(&source);
+
+    let mut op = source.begin_op().await?;
+    source
+        .publish_persisted_in_op(&mut op, SourceEvent::Source(1))
+        .await?;
+    dest.publish_persisted_in_op(&mut op, DestEvent::Native(2))
+        .await?;
+
+    let result = op.commit().await;
+    assert!(
+        matches!(result, Err(sqlx::Error::Protocol(_))),
+        "a runs_after cycle must fail the commit with a protocol error, got {result:?}"
+    );
+    assert_eq!(
+        outbox_row_count(&pool).await?,
+        0,
+        "the cycle is caught before any hook's pre_commit runs — nothing persists"
+    );
+    Ok(())
+}
+
 /// A repost's destination hook now joins the same commit pass as the
 /// source, so its own `post_commit` runs — feeding the in-process broadcast
 /// directly, not just healing via pg NOTIFY and the poller/gap-fill.


### PR DESCRIPTION
## What

Adds `Outbox::persist_after(&upstream)`: declares that this outbox's persist commit hook must run **after** `upstream`'s whenever both are registered on the same operation. Built on **es-entity 0.12.10**'s new `CommitHook::runs_after` primitive — a hook can declare dependency types it must defer behind; the commit pass's `execute_pre` loop retries a deferred hook while any still-pending instance of a declared type exists.

## Why

Since es-entity 0.12.9's re-entrant commit-hook registration, a `PostPersistHook` repost from outbox A into outbox B is always **correct** regardless of registration order — but its *cost* isn't. If B's persist hook already executed by the time A's repost stages onto it (an accident of application call order — see the concrete lana-bank `LedgerEventMirror` case in the handoff), the repost can't merge into an already-executed hook, so es-entity appends a fresh re-entrant generation: an extra INSERT round trip, an extra `post_commit` (broadcast + debounced-notifier range), and one of `MAX_HOOK_GENERATIONS` (8) burned.

`dest.persist_after(&source)` pins the ordering edge once, at wiring time, so the repost always merges into `dest`'s single still-pending hook — one INSERT batch, one notify, one broadcast — no matter which outbox happened to publish first in program order.

## Implementation

- `Outbox` gains a `persist_after: Arc<RwLock<Arc<[TypeId]>>>` field — copy-on-write, mirroring the existing `post_persist_hooks` field exactly. `persist_after<P2, Tables2>(&self, upstream: &Outbox<P2, Tables2>)` is idempotent and records `TypeId::of::<PersistEvents<P2, Tables2>>()`.
- Snapshotted into `PersistEvents` at publish time (`publish_all_persisted`), same snapshot-at-publish semantics as post-persist hooks.
- `PersistEvents` implements `CommitHook::runs_after` from that snapshot.
- `merge` is untouched — the surviving (target) instance's snapshot applies, which is correct by construction (all instances of one concrete `PersistEvents<P, Tables>` type come from the same outbox).
- Declaring a cycle (`A.persist_after(&B)` and `B.persist_after(&A)`, directly or transitively) fails the commit loudly with `sqlx::Error::Protocol` and rolls back — no hang inside an open transaction, no silent misorder. This is es-entity's guarantee; obix adds no cycle detection of its own.
- `PersistEphemeralEvents` and the force-execute path (`publish_*` on a bare `sqlx::Transaction` with no commit-pass support) are untouched by design — there's no commit pass for ordering to apply to.
- Amended the `PostPersistHook` contract doc (`src/out/post_persist_hook.rs`) to document the merge behavior once `persist_after` is declared.

**Deferred to a follow-up PR:** the optional `republish_into` sugar (bundling `persist_after` + a mapping repost hook into one call). The handoff itself calls this out as separable, and keeping this PR to just the ordering-correctness primitive keeps the diff and the test story clean.

## Semantics

Hard ordering, not best-effort: a deferred hook is still *pending*, so it remains a valid merge target — this is what makes the merge work. Composes for free with `on_rollback` (0.12.4, PR #116 Tier-1 gap-fill compensation) and savepoint hook-staging (0.12.8): es-entity's deferral is orthogonal to both by construction (see the es-entity handoff's "what does NOT change" section — generations, `absorb_staged`, `commit_hook()` reads, and the force path are all untouched). No interaction with PR #128's read-path/`OpCursor` fixes — `persist_after` is purely commit-hook-ordering on the publish side; `OpCursor` reads `pending()`, which this doesn't touch.

## Dependency bump

`es-entity` `0.12.9` → `0.12.10` (workspace dep). Verified against the actual released crate (not just the handoff's proposal) — `CommitHook::runs_after` shipped byte-for-byte as spec'd: defaulted `&[]`, deferral loop in `execute_pre`, cycle → `sqlx::Error::Protocol`. `job` 0.9.1 has no narrower pin of its own; `cargo tree` confirms a clean unify on 0.12.10.

## Tests (`tests/post_persist_hook.rs`, live PG via `nix run .#nextest`)

- **`persist_after_merges_repost_into_single_dest_batch`** — the regression test. Publishes `DestEvent::Native` on `dest` *first*, then `SourceEvent::Source` on `source` (the unlucky order `ordering_follows_first_publish_order` documents as yielding **two** dest-hook invocations without `persist_after`). With `dest.persist_after(&source)` declared, asserts exactly **one** invocation with `[Native, Mapped]`, and that the merged repost still reaches a destination listener.
- **`persist_after_vacuous_when_upstream_never_publishes`** — declaring the edge when the upstream never publishes on the op has no effect; single invocation, normal commit.
- **`persist_after_cycle_fails_commit_loudly`** — a mutual `persist_after` cycle fails `commit()` with `sqlx::Error::Protocol`; nothing persists.
- Full existing suite stays green: all `PostPersistHook`/repost tests (chained reposts, on_rollback reactive compensation, force-path, listener delivery), tx-scoping/`EventCtx` DSL, partition Stage-1, trust-boundary/pg_notify, two-tier gap-fill, checkpoint read-back — **96/96 passed**.

## Verification

- `nix flake check` (fmt / clippy `-D warnings` / audit / deny) — fresh, not cached — passed.
- `nix run .#nextest` (hermetic live-PG suite) — 96/96 passed, including doc-tests and `cargo doc`.

## Downstream ripple (not in this PR)

lana-bank's `CoreAccounting::new` (`core/accounting/src/lib.rs`) would add one line once this releases:

```rust
outbox.persist_after(cala.outbox());
cala.outbox().add_post_persist_hook(LedgerEventMirror::new(outbox));
```

This fixes the unlucky-order case in `ManualTransactions::execute` and similar service methods that create the lana entity before posting to cala. Not touched here — separate follow-up per task scope.

## References

- Handoff (this repo): `obix-dev/handoff-outbox-persist-after-ordering.md`
- Handoff (mechanism, consumed): `es-entity-dev/handoff-commit-hook-runs-after-ordering.md`
- Consumes: `es-entity` 0.12.10 (`CommitHook::runs_after`)
- Composes with: PR #86 (tx-scoping/EventCtx DSL), #96 (PostPersistHook + OpCursor), #101/#114 (NOTIFY path), #106 (partitioning), #107 (pg_notify trust boundary), #116 (two-tier gap-fill), #127 (es-entity 0.12.9 re-entrant registration bump), #128 (read-path fix — merged, unrelated surface)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-outbox commit-hook ordering and depends on es-entity 0.12.10 deferral semantics; incorrect wiring could still affect batching and notify behavior, though cycles are detected at commit.
> 
> **Overview**
> Adds **`Outbox::persist_after(&upstream)`** so this outbox’s `PersistEvents` commit hook declares it must run after the upstream outbox’s hook when both share one operation. Wiring stores upstream `PersistEvents` `TypeIds` (copy-on-write, snapshot-at-publish like post-persist hooks) and passes them into **`PersistEvents` via `CommitHook::runs_after`**, using **es-entity 0.12.10**.
> 
> The goal is cheaper cross-outbox reposts: when a `PostPersistHook` on the source republishes into the destination, **`dest.persist_after(&source)`** keeps the destination hook pending until the source runs, so reposted events **merge into one INSERT / notify / broadcast** even if the destination published first in program order. **Mutual `persist_after` cycles fail commit with `sqlx::Error::Protocol`** and roll back.
> 
> **`PostPersistHook` docs** now describe this ordering vs accidental registration order. **Tests** cover single-batch merge, vacuous upstream, and cycle failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 995abce30da497981c90bc1f1a6f6a94e11cb0af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->