### PR TITLE
fix(build): sqlx-prepare drops dependency and test query caches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,14 @@ check-code:
 	nix flake check
 
 sqlx-prepare:
-	cargo sqlx prepare --workspace -- --all-targets
+	# --all (before --)   : also captures dependency-side queries (e.g. job's
+	#                       own queries, vendored into obix's .sqlx) -- without
+	#                       it those entries get silently dropped.
+	# -- --all-targets     : also captures test-only queries (queries that only
+	#                       appear under tests/) -- without it those entries
+	#                       get silently dropped too.
+	# Do not "simplify" either flag away -- both have bitten us before.
+	cargo sqlx prepare --workspace --all -- --all-targets
 
 # Coverage-guided fuzzing via the shared vendored script
 # (ci/vendor/tasks/fuzz.sh, from galoy-concourse-shared), also used by


### PR DESCRIPTION
## The bug

`make sqlx-prepare` ran:

```
cargo sqlx prepare --workspace -- --all-targets
```

This omits `--all`, so `cargo sqlx prepare` only records queries reachable from
obix's own workspace crates. Query metadata for `sqlx::query!` call sites that
live in *dependency* crates (e.g. `job`'s own internal queries, which get
vendored into obix's `.sqlx` so `SQLX_OFFLINE` builds work without a live DB)
is silently dropped whenever `.sqlx` is regenerated from a clean slate.

This has bitten twice:
1. Memory `019ff8f8` — omitting `-- --all-targets` deleted ~7 test-only cache
   entries (queries that only appear under `tests/`).
2. obix PR #130 — the engineer hit the dependency-side variant despite the
   memory existing, because a memory that has to be remembered at the right
   moment isn't a fix for the tooling itself.

## The fix

```
cargo sqlx prepare --workspace --all -- --all-targets
```

Both flags are now documented inline in the Makefile so neither gets
"simplified" away by a future edit:
- `--all` (before `--`) keeps dependency-side query caches.
- `-- --all-targets` keeps test-only queries.

No other sqlx-related targets exist in the repo (`grep -rn "sqlx prepare"`
turns up only this one invocation).

## Verification

**Clean-slate entry-count delta (job 0.11.0, pre-rebase state on this branch's
parent commit):**
- Old invocation (`--workspace -- --all-targets`) from a clean `.sqlx`: **26 entries**
- Fixed invocation (`--workspace --all -- --all-targets`) from a clean `.sqlx`: **55 entries**, byte-identical filename set to what's committed on `main`
- The 29 entries the old form drops are genuinely dependency-side: their SQL
  (e.g. `INSERT/UPDATE/DELETE ... job_executions ... poller_instance_id ...`)
  does not appear anywhere in obix's own `.rs` sources — they only exist inside
  the `job` crate itself.

**From-scratch offline check** (`cargo clean` + `SQLX_OFFLINE=true cargo check
--all-targets`, no `DATABASE_URL`) passes cleanly with the fixed/complete
cache — **zero missing-query errors**.

**After rebasing onto `main`** (which in the meantime merged #130, bumping
`job` to 0.12.0), I re-ran the same clean-slate comparison: on this exact repo
snapshot both the old and fixed invocations produced the identical, complete
59-entry set matching `main`'s committed `.sqlx`. I'm flagging this honestly
rather than only reporting the run that reproduces the failure — `cargo sqlx
prepare`'s exact conditions for capturing out-of-workspace query metadata
appear to depend on incidental build-graph state, which is itself the
argument for this fix: relying on a memory to "remember --all at the right
moment" is fragile precisely because the failure doesn't reproduce
deterministically. `--all` and `--all-targets` are still the documented,
correct, defensive flags (`--all`: "Prepare query macros in dependencies that
exist outside the current crate or workspace") regardless of whether a given
snapshot happens to reproduce the drop on demand.

**`.sqlx` diff:** unchanged by this PR — 0 files touched. The cache committed
on `main` was already complete (PR #130's engineer regenerated it correctly).

**Checks (fresh, not cached — re-ran after the job 0.12.0 rebase):**
- `nix flake check --option eval-cache false` → all checks passed (fmt, clippy -D warnings, audit, deny)
- `nix run .#nextest` → 102 tests run: 102 passed, 0 skipped

## cala / lana-bank — same bug, not fixed here

Per task scope, these are **not** touched in this PR — findings only, for
follow-up PRs in their own repos:

- **cala** (`Makefile`):
  ```
  sqlx-prepare:
  	cd cala-ledger && cargo sqlx prepare -- --all-features
  ```
  Missing `--workspace`, missing `--all` (dependency-side), and uses
  `--all-features` instead of `-- --all-targets` (test-only queries) — a
  different flag entirely, so test-only queries are likely also dropped.
  There's also a standing memory (`019ffefd`) noting this target fails to
  discover ~28 pre-existing query! call sites even from a clean build.

- **lana-bank** (`Makefile`):
  ```
  sqlx-prepare:
  	cargo sqlx prepare --workspace
  ```
  Missing both `--all` and `-- --all-targets` — the same bug in its most
  complete form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only change to a dev/build helper; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Fixes `make sqlx-prepare` so offline SQLx metadata is not silently incomplete.**
> 
> The `sqlx-prepare` target now runs `cargo sqlx prepare --workspace --all -- --all-targets` instead of omitting `--all`. Without `--all`, dependency-crate `query!` sites (e.g. in `job`, vendored into obix’s `.sqlx`) can be dropped when `.sqlx` is regenerated; without `-- --all-targets`, test-only queries can be dropped too.
> 
> Inline Makefile comments document both flags and warn not to remove either. **No `.sqlx` files change in this PR** — the committed cache on `main` was already complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f8d31789f26d6942f6270037c045d45d7615734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->